### PR TITLE
[js-sdk] Remove `ethereum-contracts` dep for load contracts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
         es2020: true
     },
     plugins: ["prettier"],
+    globals: {
+        artifacts: "writable"
+    },
     rules: {
         "max-len": ["error", 120, { code: 80, ignoreUrls: true }],
         indent: ["error", 4],

--- a/packages/ethereum-contracts/scripts/loadContracts.js
+++ b/packages/ethereum-contracts/scripts/loadContracts.js
@@ -56,8 +56,7 @@ const loadContracts = ({ isTruffle, useMocks, web3Provider, from }) => {
                         name + ".json"
                     ));
                     const c = (contracts[name] = TruffleContract(
-                        builtContract,
-                        name
+                        builtContract
                     ));
                     c.setProvider(web3Provider);
                     from && c.defaults({ from });

--- a/packages/js-sdk/src/Framework.js
+++ b/packages/js-sdk/src/Framework.js
@@ -1,6 +1,6 @@
 const Web3 = require("web3");
 
-const loadContracts = require("@superfluid-finance/ethereum-contracts/scripts/loadContracts");
+const loadContracts = require("./utils/loadContracts");
 
 const getConfig = require("./getConfig");
 const { getErrorResponse } = require("./utils/error");

--- a/packages/js-sdk/src/README.md
+++ b/packages/js-sdk/src/README.md
@@ -7,7 +7,7 @@
 ## Overview
 
 ```js
-const SuperfluidSDK = require("@superfluid-finance/ethereum-contracts");
+const SuperfluidSDK = require("@superfluid-finance/js-sdk");
 const sf = new SuperfluidSDK.Framework({
     version: "v1", // Protocol release version
     web3Provider: web3.currentProvider, // your web3 provider
@@ -16,7 +16,7 @@ const sf = new SuperfluidSDK.Framework({
 
 await sf.initialize();
 
-const bob = sf.user({ address: "0xabc...", token: sf.tokens.fDAI.address });
+const bob = sf.user({ address: "0xabc...", token: sf.tokens.fDAIx.address });
 
 // Constant Flow Agreement
 await bob.flow({
@@ -67,7 +67,7 @@ During initialization, the resolver will be used to fetch the correct set of con
 Example:
 
 ```js
-const SuperfluidSDK = require("@superfluid-finance/ethereum-contracts");
+const SuperfluidSDK = require("@superfluid-finance/js-sdk");
 const sf = new SuperfluidSDK.Framework({
     version: "v1", // Protocol release version
     web3Provider: web3.currentProvider, // your web3 provider

--- a/packages/js-sdk/src/utils/error.js
+++ b/packages/js-sdk/src/utils/error.js
@@ -2,7 +2,7 @@ const getErrorResponse = (error, className, functionName) => {
     const errorText = typeof error === "string" ? error : error.message;
     let helperText = ` ${className}`;
     if (functionName) helperText = helperText.concat(`.${functionName}() `);
-    return `Error @superfluid-finance/ethereum-contracts${helperText}: ${errorText}`;
+    return `Error @superfluid-finance/js-sdk${helperText}: ${errorText}`;
 };
 
 module.exports = { getErrorResponse };

--- a/packages/js-sdk/src/utils/loadContracts.js
+++ b/packages/js-sdk/src/utils/loadContracts.js
@@ -19,12 +19,13 @@ const loadContracts = ({ isTruffle, useMocks, web3Provider, from }) => {
         if (!isTruffle) {
             try {
                 console.debug(
-                    "Using Superfluid scripts in an external or non-truffle environment"
+                    "Using SDK in an external or non-truffle environment"
                 );
                 if (!web3Provider) throw new Error("web3Provider is required");
                 // load contracts from ABI
                 allContractNames.forEach(name => {
                     const c = (contracts[name] = TruffleContract({
+                        contractName: name,
                         abi: abis[name]
                     }));
                     c.setProvider(web3Provider);
@@ -37,9 +38,7 @@ const loadContracts = ({ isTruffle, useMocks, web3Provider, from }) => {
             }
         } else {
             try {
-                console.debug(
-                    "Using Superfluid scripts within the truffle environment"
-                );
+                console.debug("Using SDK within the truffle environment");
                 // load contracts from truffle artifacts
                 allContractNames.forEach(name => {
                     contracts[name] = artifacts.require(name);

--- a/packages/js-sdk/src/utils/loadContracts.js
+++ b/packages/js-sdk/src/utils/loadContracts.js
@@ -1,0 +1,57 @@
+const TruffleContract = require("@truffle/contract");
+
+const contractNames = require("../contracts.json");
+const abis = require("../abi");
+
+const mockContractNames = [
+    "SuperfluidMock",
+    "SuperTokenMockFactory",
+    "SuperTokenFactoryMock"
+];
+
+const loadContracts = ({ isTruffle, useMocks, web3Provider, from }) => {
+    const allContractNames = [
+        ...contractNames,
+        ...(useMocks ? mockContractNames : [])
+    ];
+    try {
+        let contracts = {};
+        if (!isTruffle) {
+            try {
+                console.debug(
+                    "Using Superfluid scripts in an external or non-truffle environment"
+                );
+                if (!web3Provider) throw new Error("web3Provider is required");
+                // load contracts from ABI
+                allContractNames.forEach(name => {
+                    const c = (contracts[name] = TruffleContract({
+                        abi: abis[name]
+                    }));
+                    c.setProvider(web3Provider);
+                    from && c.defaults({ from });
+                });
+            } catch (e) {
+                throw Error(
+                    `could not load non-truffle environment contracts. ${e}`
+                );
+            }
+        } else {
+            try {
+                console.debug(
+                    "Using Superfluid scripts within the truffle environment"
+                );
+                // load contracts from truffle artifacts
+                allContractNames.forEach(name => {
+                    contracts[name] = artifacts.require(name);
+                });
+            } catch (e) {
+                throw Error(`could not load truffle artifacts. ${e}`);
+            }
+        }
+        return contracts;
+    } catch (e) {
+        throw Error(`@superfluid-finance/js-sdk loadContracts(): ${e}`);
+    }
+};
+
+module.exports = loadContracts;

--- a/packages/js-sdk/truffle-config.js
+++ b/packages/js-sdk/truffle-config.js
@@ -1,12 +1,17 @@
 /**
- * More information about configuration can be found at:
+ * This truffle-config is only used for testing the js-sdk.
  *
- * truffleframework.com/docs/advanced/configuration
+ * See the @superfluid-finance/ethereum-contracts package for a good example.
  **/
 const path = require("path");
 module.exports = {
     contracts_build_directory: path.join(
         __dirname,
         "../ethereum-contracts/build/contracts"
-    )
+    ),
+    compilers: {
+        solc: {
+            version: "0.7.6"
+        }
+    }
 };

--- a/packages/js-sdk/truffle-config.js
+++ b/packages/js-sdk/truffle-config.js
@@ -11,7 +11,15 @@ module.exports = {
     ),
     compilers: {
         solc: {
-            version: "0.7.6"
+            version: "0.7.6", // Fetch exact version from solc-bin (default: truffle's version)
+            settings: {
+                // See the solidity docs for advice about optimization and evmVersion
+                optimizer: {
+                    enabled: true,
+                    runs: 200
+                }
+                // evmVersion: "petersburg" use default
+            }
         }
     }
 };

--- a/tasks/npm-publish.sh
+++ b/tasks/npm-publish.sh
@@ -2,10 +2,14 @@
 
 D="$(dirname "$0")"
 
-echo "Publishing $1 @$2 to NPMJS registry"
-$D/npmrc-use-npmjs.sh > .npmrc
-npm publish --tag $2 $1
+PACKAGE_DIR="$1"
+TAG="$2"
+shift 2
 
-echo "Publishing $1 @$2 to Github Packages"
+echo "Publishing ${PACKAGE_DIR} @${TAG} to NPMJS registry"
+$D/npmrc-use-npmjs.sh > .npmrc
+npm publish --tag ${TAG} ${PACKAGE_DIR} "$@"
+
+echo "Publishing ${PACKAGE_DIR} @${TAG} to Github Packages"
 $D/npmrc-use-github.sh > .npmrc
-npm publish --tag $2 $1
+npm publish --tag ${TAG} ${PACKAGE_DIR} "$@"


### PR DESCRIPTION
Currently, using `new Framework()` requires that the `ethereum-contracts` package also be installed. This should not be the case, and is due to the `loadContracts.js` script that we missed during the monorepo migration.

### TODO

- [x]  Copy `loadContracts.js` into the sdk
- [x] Remove devDependency for `ethereum-contracts` 
- [x] Test for both truffle/non truffle environments

Marking as "Ready" only to access the published packages.