### PR TITLE
Minimal native SuperToken with deploy script

### DIFF
--- a/packages/ethereum-contracts/contracts/tokens/NativeSuperToken.sol
+++ b/packages/ethereum-contracts/contracts/tokens/NativeSuperToken.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity 0.7.6;
+
+import {
+    ISuperToken,
+    CustomSuperTokenProxyBase
+}
+from "../interfaces/superfluid/CustomSuperTokenProxyBase.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { UUPSProxy } from "../upgradability/UUPSProxy.sol";
+
+/**
+ * @dev Native SuperToken custom token functions
+ *
+ * @author Superfluid
+ */
+interface INativeSuperTokenCustom {
+    function initialize(string calldata name, string calldata symbol, uint256 initialSupply) external;
+}
+
+/**
+ * @dev Native SuperToken full interface
+ *
+ * @author Superfluid
+ */
+interface INativeSuperToken is INativeSuperTokenCustom, ISuperToken {
+    function initialize(string calldata name, string calldata symbol, uint256 initialSupply) external override;
+}
+
+/**
+ * @dev Native SuperToken custom super token implementation
+ *
+ * @author Superfluid
+ */
+contract NativeSuperTokenProxy is INativeSuperTokenCustom, CustomSuperTokenProxyBase {
+    function initialize(string calldata name, string calldata symbol, uint256 initialSupply)
+        external override
+    {
+        ISuperToken(address(this)).initialize(
+            IERC20(0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF), // 0xFF... for "no underlying token"
+            18, // not sure if this has any effect in our case
+            name,
+            symbol
+        );
+        ISuperToken(address(this)).selfMint(msg.sender, initialSupply, new bytes(0));
+    }
+}

--- a/packages/ethereum-contracts/contracts/tokens/NativeSuperToken.sol
+++ b/packages/ethereum-contracts/contracts/tokens/NativeSuperToken.sol
@@ -30,6 +30,9 @@ interface INativeSuperToken is INativeSuperTokenCustom, ISuperToken {
 /**
  * @dev Native SuperToken custom super token implementation
  *
+ * NOTE:
+ * - This is a simple implementation where the supply is pre-minted.
+ *
  * @author Superfluid
  */
 contract NativeSuperTokenProxy is INativeSuperTokenCustom, CustomSuperTokenProxyBase {

--- a/packages/ethereum-contracts/contracts/tokens/NativeSuperToken.sol
+++ b/packages/ethereum-contracts/contracts/tokens/NativeSuperToken.sol
@@ -37,8 +37,8 @@ contract NativeSuperTokenProxy is INativeSuperTokenCustom, CustomSuperTokenProxy
         external override
     {
         ISuperToken(address(this)).initialize(
-            IERC20(0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF), // 0xFF... for "no underlying token"
-            18, // not sure if this has any effect in our case
+            IERC20(0x0), // no underlying/wrapped token
+            18, // shouldn't matter if there's no wrapped token
             name,
             symbol
         );

--- a/packages/ethereum-contracts/scripts/deploy-native-supertoken.js
+++ b/packages/ethereum-contracts/scripts/deploy-native-supertoken.js
@@ -8,7 +8,7 @@ const {
 } = require("./utils");
 
 /**
- * @dev Deploy unlisted super token to the network.
+ * @dev Deploy unlisted native super token to the network.
  * @param {Array} argv Overriding command line arguments
  * @param {boolean} options.isTruffle Whether the script is used within native truffle framework
  * @param {Web3} options.web3  Injected web3 instance
@@ -19,7 +19,7 @@ const {
  */
 module.exports = async function (callback, argv, options = {}) {
     try {
-        console.log("======== Deploying unmanaged super token ========");
+        console.log("======== Deploying unlisted native super token ========");
 
         await eval(`(${detectTruffleAndConfigure.toString()})(options)`);
         let { protocolReleaseVersion } = options;
@@ -58,19 +58,19 @@ module.exports = async function (callback, argv, options = {}) {
         console.log("Deploying NativeSuperTokenProxy...");
         const proxy = await NativeSuperTokenProxy.new();
 
-        const logic = await INativeSuperToken.at(proxy.address);
+        const token = await INativeSuperToken.at(proxy.address);
 
         console.log("Invoking initializeCustomSuperToken...");
-        await superTokenFactory.initializeCustomSuperToken(logic.address);
+        await superTokenFactory.initializeCustomSuperToken(token.address);
 
         console.log("Invoking initialize...");
-        await logic.initialize(
+        await token.initialize(
             superTokenName,
             superTokenSymbol,
             web3.utils.toWei(String(initialSupply))
         );
 
-        console.log(`Native SuperToken deployed at ${logic.address}`);
+        console.log(`Native SuperToken deployed at ${token.address}`);
 
         callback();
     } catch (err) {

--- a/packages/ethereum-contracts/scripts/deploy-native-supertoken.js
+++ b/packages/ethereum-contracts/scripts/deploy-native-supertoken.js
@@ -1,0 +1,79 @@
+const SuperfluidSDK = require("@superfluid-finance/js-sdk");
+
+const {
+    parseColonArgs,
+    extractWeb3Options,
+    detectTruffleAndConfigure,
+    builtTruffleContractLoader,
+} = require("./utils");
+
+/**
+ * @dev Deploy unlisted super token to the network.
+ * @param {Array} argv Overriding command line arguments
+ * @param {boolean} options.isTruffle Whether the script is used within native truffle framework
+ * @param {Web3} options.web3  Injected web3 instance
+ * @param {Address} options.from Address to deploy contracts from
+ * @param {boolean} options.protocolReleaseVersion Specify the protocol release version to be used
+ *
+ * Usage: npx truffle exec scripts/deploy-native-super-token.js : {NAME} ${SYMBOL} ${INITIAL SUPPLY}
+ */
+module.exports = async function (callback, argv, options = {}) {
+    try {
+        console.log("======== Deploying unmanaged super token ========");
+
+        await eval(`(${detectTruffleAndConfigure.toString()})(options)`);
+        let { protocolReleaseVersion } = options;
+
+        const args = parseColonArgs(argv || process.argv);
+        if (args.length !== 3) {
+            throw new Error("Wrong number of arguments");
+        }
+        const initialSupply = args.pop();
+        const superTokenSymbol = args.pop();
+        const superTokenName = args.pop();
+        console.log("Super token name", superTokenName);
+        console.log("Super token symbol", superTokenSymbol);
+        console.log("Super token initial supply", initialSupply);
+
+        protocolReleaseVersion =
+            protocolReleaseVersion || process.env.RELEASE_VERSION || "test";
+        const chainId = await web3.eth.net.getId(); // MAYBE? use eth.getChainId;
+        console.log("chain ID: ", chainId);
+        console.log("protocol release version:", protocolReleaseVersion);
+
+        const sf = new SuperfluidSDK.Framework({
+            ...extractWeb3Options(options),
+            version: protocolReleaseVersion,
+            additionalContracts: ["NativeSuperTokenProxy", "INativeSuperToken"],
+            contractLoader: builtTruffleContractLoader,
+        });
+        await sf.initialize();
+
+        const { NativeSuperTokenProxy, INativeSuperToken } = sf.contracts;
+
+        const superTokenFactory = await sf.contracts.ISuperTokenFactory.at(
+            await sf.host.getSuperTokenFactory.call()
+        );
+
+        console.log("Deploying NativeSuperTokenProxy...");
+        const proxy = await NativeSuperTokenProxy.new();
+
+        const logic = await INativeSuperToken.at(proxy.address);
+
+        console.log("Invoking initializeCustomSuperToken...");
+        await superTokenFactory.initializeCustomSuperToken(logic.address);
+
+        console.log("Invoking initialize...");
+        await logic.initialize(
+            superTokenName,
+            superTokenSymbol,
+            web3.utils.toWei(String(initialSupply))
+        );
+
+        console.log(`Native SuperToken deployed at ${logic.address}`);
+
+        callback();
+    } catch (err) {
+        callback(err);
+    }
+};

--- a/packages/ethereum-contracts/test/contracts/tokens/NativeSuperTokenProxy.test.js
+++ b/packages/ethereum-contracts/test/contracts/tokens/NativeSuperTokenProxy.test.js
@@ -1,0 +1,40 @@
+const { expectRevert } = require("@openzeppelin/test-helpers");
+
+const ISuperTokenFactory = artifacts.require("ISuperTokenFactory");
+const TestEnvironment = require("../../TestEnvironment");
+const NativeSuperTokenProxy = artifacts.require("NativeSuperTokenProxy");
+
+const { web3tx, toWad } = require("@decentral.ee/web3-helpers");
+
+contract("NativeSuperTokenProxy Contract", (accounts) => {
+    const t = new TestEnvironment(accounts.slice(0, 3), {
+        isTruffle: true,
+        useMocks: true,
+    });
+
+    let superTokenFactory;
+
+    before(async () => {
+        await t.reset();
+        superTokenFactory = await ISuperTokenFactory.at(
+            await t.contracts.superfluid.getSuperTokenFactory()
+        );
+    });
+
+    it("#1 create token", async () => {
+        const tokenProxy = await NativeSuperTokenProxy.new();
+        await web3tx(
+            superTokenFactory.initializeCustomSuperToken,
+            "superTokenFactory.initializeCustomSuperToken"
+        )(tokenProxy.address);
+        await web3tx(tokenProxy.initialize, "tokenProxy.initialize")(
+            "Didi Token",
+            "DD",
+            toWad(42)
+        );
+        await expectRevert(
+            tokenProxy.initialize("Hacker", "HH", toWad(0)),
+            "Initializable: contract is already initialized"
+        );
+    });
+});

--- a/packages/ethereum-contracts/test/contracts/tokens/NativeSuperTokenProxy.test.js
+++ b/packages/ethereum-contracts/test/contracts/tokens/NativeSuperTokenProxy.test.js
@@ -7,11 +7,11 @@ const NativeSuperTokenProxy = artifacts.require("NativeSuperTokenProxy");
 const { web3tx, toWad } = require("@decentral.ee/web3-helpers");
 
 contract("NativeSuperTokenProxy Contract", (accounts) => {
-    const t = new TestEnvironment(accounts.slice(0, 3), {
+    const t = new TestEnvironment(accounts.slice(0, 1), {
         isTruffle: true,
         useMocks: true,
     });
-
+    const { admin } = t.aliases;
     let superTokenFactory;
 
     before(async () => {
@@ -31,6 +31,11 @@ contract("NativeSuperTokenProxy Contract", (accounts) => {
             "Didi Token",
             "DD",
             toWad(42)
+        );
+        const token = await t.sf.contracts.ISuperToken.at(tokenProxy.address);
+        assert.equal(
+            (await token.balanceOf.call(admin)).toString(),
+            toWad(42).toString()
         );
         await expectRevert(
             tokenProxy.initialize("Hacker", "HH", toWad(0)),


### PR DESCRIPTION
Implements a native SuperToken (no underlying ERC20), setting `underlyingToken` to `0x0`.  
Comes with a deploy script very similar to that for deploying a SuperToken wrapping an ERC20.