### PR TITLE
Emit TypeScript definition files

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -6,6 +6,7 @@
     "repository": "github:superfluid-finance/protocol-monorepo",
     "license": "MIT",
     "main": "src/index.js",
+    "types": "./dist/index.js",
     "files": [
         "src/**/*.json",
         "src/**/*.js"
@@ -51,6 +52,7 @@
         "@truffle/contract": "^4.3.9",
         "chai-as-promised": "^7.1.1",
         "truffle": "5.1.49",
+        "typescript": "^4.3.5",
         "web3": "^1.3.4",
         "webpack": "^5.24.4",
         "webpack-bundle-analyzer": "^4.4.0",

--- a/packages/js-sdk/src/getConfig.js
+++ b/packages/js-sdk/src/getConfig.js
@@ -1,8 +1,11 @@
 // eslint-disable-next-line no-global-assign
 if (typeof module === "undefined") module = {};
 
-// eslint-disable-next-line no-undef
-Superfluid_getConfig = module.exports = function getConfig(chainId) {
+/**
+ * @param {number} chainId - The id of the chain.
+ * @return {object} config - Configuration for the chain.
+ */
+module.exports = function getConfig(chainId) {
     const DEFAULT_CONFIGS = {
         //
         // ETHEREUM

--- a/packages/js-sdk/tsconfig.json
+++ b/packages/js-sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17096,6 +17096,11 @@ typescript@^3.9.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
 
+typescript@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
 ua-parser-js@^0.7.18:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"


### PR DESCRIPTION
Resolves https://github.com/superfluid-finance/protocol-monorepo/issues/360

## Description
- Set up TypeScript to generate `.d.ts` files. This change emits `.d.ts` files to `dist` by following the instructions in
  https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html

## Future work
- Add `tsc` to Webpack config so that `.d.ts` files are auto generated on `yarn build`
- Add JSDoc comments to more of the codebase

## Testing
- In `js-sdk`:
  ```bash
  yarn build
  tsc
  yarn link
  ```
- In `examples/continuous-auction`
  ```
  yarn build
  yarn link "@superfluid-finance/js-sdk"
  ```

Before | After
--- | ---
<img width="691" alt="before-ts-definitions" src="https://user-images.githubusercontent.com/3699047/127259881-35517423-cc6e-4e50-9fda-82e1dd5907e1.png"> | <img width="718" alt="after-ts-definitions" src="https://user-images.githubusercontent.com/3699047/127259891-a1b79416-7b0e-4953-88e0-59ebf63cf607.png">

