### PR TITLE
Fix SDK browser support + add hardhat network

### DIFF
--- a/packages/ethereum-contracts/test/TestEnvironment.js
+++ b/packages/ethereum-contracts/test/TestEnvironment.js
@@ -62,7 +62,7 @@ module.exports = class TestEnvironment {
      *************************************************************************/
 
     /// reset the system
-    async reset(deployOpts = {}) {
+    async reset(deployOpts = {}, frameworkOpts = {}) {
         console.log("Aliases", this.aliases);
 
         // deploy framework
@@ -80,6 +80,7 @@ module.exports = class TestEnvironment {
             gasReportType: this.gasReportType,
             isTruffle: this.isTruffle,
             version: process.env.RELEASE_VERSION || "test",
+            ...frameworkOpts,
         });
         await this.sf.initialize();
 

--- a/packages/js-sdk/src/Framework.js
+++ b/packages/js-sdk/src/Framework.js
@@ -104,6 +104,7 @@ module.exports = class Framework {
             networkId: networkId,
         });
 
+        /** @dev resolverAddress cannot be undefined after this point. */
         const resolverAddress =
             this._options.resolverAddress || this.config.resolverAddress;
         console.debug("Resolver at", resolverAddress);

--- a/packages/js-sdk/src/getConfig.js
+++ b/packages/js-sdk/src/getConfig.js
@@ -7,8 +7,12 @@ Superfluid_getConfig = module.exports = function getConfig(chainId) {
         //
         // ETHEREUM
         //
-        4447: {
-            // for local testing (truffle internal ganache)
+        31337: {
+            // for local testing hardhat
+            nativeTokenSymbol: "ETH",
+        },
+        1337: {
+            // for local testing localhost
             nativeTokenSymbol: "ETH",
         },
         5777: {

--- a/packages/js-sdk/src/getConfig.js
+++ b/packages/js-sdk/src/getConfig.js
@@ -8,11 +8,11 @@ Superfluid_getConfig = module.exports = function getConfig(chainId) {
         // ETHEREUM
         //
         31337: {
-            // for local testing hardhat
+            // for testing hardhat
             nativeTokenSymbol: "ETH",
         },
         1337: {
-            // for local testing localhost
+            // for testing localhost
             nativeTokenSymbol: "ETH",
         },
         5777: {
@@ -79,9 +79,5 @@ Superfluid_getConfig = module.exports = function getConfig(chainId) {
         },
     };
 
-    const configs = { ...DEFAULT_CONFIGS[chainId] };
-    // overriding environment variables
-    configs.resolverAddress =
-        process.env.TEST_RESOLVER_ADDRESS || configs.resolverAddress;
-    return configs;
+    return DEFAULT_CONFIGS[chainId] ? DEFAULT_CONFIGS[chainId] : {};
 };

--- a/packages/js-sdk/test/ConstantFlowAgreementV1Helper.test.js
+++ b/packages/js-sdk/test/ConstantFlowAgreementV1Helper.test.js
@@ -10,7 +10,10 @@ contract("ConstantFlowAgreementV1 helper class", (accounts) => {
     let superToken;
 
     before(async () => {
-        await t.reset();
+        await t.reset(
+            {},
+            { resolverAddress: process.env.TEST_RESOLVER_ADDRESS }
+        );
         sf = t.sf;
     });
 

--- a/packages/js-sdk/test/Framework.test.js
+++ b/packages/js-sdk/test/Framework.test.js
@@ -13,7 +13,10 @@ contract("Framework class", (accounts) => {
     const { admin } = t.aliases;
 
     before(async () => {
-        await t.reset();
+        await t.reset(
+            {},
+            { resolverAddress: process.env.TEST_RESOLVER_ADDRESS }
+        );
         await deployTestToken(t.errorHandler, [":", "fDAI"], {
             isTruffle: true,
         });

--- a/packages/js-sdk/test/InstantDistributionAgreementV1Helper.test.js
+++ b/packages/js-sdk/test/InstantDistributionAgreementV1Helper.test.js
@@ -9,7 +9,10 @@ contract("InstantDistributionAgreementV1Helper helper class", (accounts) => {
     let superToken;
 
     before(async () => {
-        await t.reset();
+        await t.reset(
+            {},
+            { resolverAddress: process.env.TEST_RESOLVER_ADDRESS }
+        );
         sf = t.sf;
     });
 

--- a/packages/js-sdk/test/User.test.js
+++ b/packages/js-sdk/test/User.test.js
@@ -28,7 +28,10 @@ contract("User helper class", (accounts) => {
     let carol;
 
     before(async () => {
-        await t.reset();
+        await t.reset(
+            {},
+            { resolverAddress: process.env.TEST_RESOLVER_ADDRESS }
+        );
         sf = t.sf;
     });
 

--- a/packages/js-sdk/test/batchCall.test.js
+++ b/packages/js-sdk/test/batchCall.test.js
@@ -17,7 +17,10 @@ contract("batchCall helper class", (accounts) => {
     let testToken;
 
     before(async () => {
-        await t.reset();
+        await t.reset(
+            {},
+            { resolverAddress: process.env.TEST_RESOLVER_ADDRESS }
+        );
         sf = t.sf;
         sf.batchCall = (calls) => {
             console.log(batchCall({ agreements: sf.agreements, calls: calls }));

--- a/packages/js-sdk/test/ethers.test.js
+++ b/packages/js-sdk/test/ethers.test.js
@@ -36,7 +36,10 @@ contract("User helper class", (accounts) => {
     let carol;
 
     before(async () => {
-        await t.reset();
+        await t.reset(
+            {},
+            { resolverAddress: process.env.TEST_RESOLVER_ADDRESS }
+        );
         sf = new SuperfluidSDK.Framework({
             ethers: new Web3Provider(web3.currentProvider),
             version: "test",

--- a/packages/js-sdk/test/getConfig.test.js
+++ b/packages/js-sdk/test/getConfig.test.js
@@ -10,10 +10,5 @@ contract("SuperfluidSDK JS SDK", () => {
         // defaultConfig
         const defaultConfig = SuperfluidSDK.getConfig(8888);
         assert.isUndefined(defaultConfig.resolverAddress);
-        // test environment
-        process.env.TEST_RESOLVER_ADDRESS = "0x42";
-        const testConfig = SuperfluidSDK.getConfig(5555);
-        assert.equal(testConfig.resolverAddress, "0x42");
-        delete process.env.TEST_RESOLVER_ADDRESS;
     });
 });


### PR DESCRIPTION
Closes #388 

Simply adds support for hardhat and localhost chainIds in `getConfig.js`.

NOTE making the SDK browser compatible should not be too hard:
* Their is only a single reference to `process.env` in the js-sdk, which is found in `getConfig.js`.
* There is an additional reference to `process` in `js-sdk/src/utils/gasMetering.js`.

Approach:
1. In order to separate concerns the resolver address for the test networks will not be set in `getConfig.js`. 
This file exports a getter function and should not be used to set state - even for tests.
Instead test shall specify `resolverAdress` as an option `SuperfluidSDK.Frameworkd({....})` . 

In order to facilitate this another argument has been added to `reset()` in `TestEnvironment.js`. 
```
    async reset(deployOpts = {}, frameworkOpts = {}) {
        console.log("Aliases", this.aliases);
       .....

        // load the SDK
        this.sf = new SuperfluidSDK.Framework({
            gasReportType: this.gasReportType,
            isTruffle: this.isTruffle,
            version: process.env.RELEASE_VERSION || "test",
            ...frameworkOpts,
        });
```

2. We can safely delete the test part in `getConfig.test.js`:
```
        process.env.TEST_RESOLVER_ADDRESS = "0x42";
        const testConfig = SuperfluidSDK.getConfig(5555);
        assert.equal(testConfig.resolverAddress, "0x42");
        delete process.env.TEST_RESOLVER_ADDRESS;
```

This test is already failing as there is no entry for chainId `5555`.


TODO:
1. Resolve `getConfig.js` issue and update tests.

2. Resolve `gasMetering.js`
