### PR TITLE
added externals to webpack

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -10,7 +10,8 @@
         "src/**/*.md",
         "src/**/*.d.ts",
         "src/**/*.json",
-        "src/**/*.js"
+        "src/**/*.js",
+        "dist/index.js"
     ],
     "browser": {
         "fs": false,

--- a/packages/js-sdk/webpack.config.js
+++ b/packages/js-sdk/webpack.config.js
@@ -26,4 +26,8 @@ module.exports = {
             crypto: false,
         },
     },
+    externals: {
+        "@ethersproject/contracts": "@ethersproject/contracts",
+        "@truffle/contract": "@truffle/contract",
+    },
 };


### PR DESCRIPTION
This PR adds peer dependencies to externals in webpack. 
This reduces the bundle size by 10x, also solving some webpack errors:

Old bundle:
```
asset index.js 13.3 MiB [emitted] (name: main)
orphan modules 1.71 KiB [orphan] 7 modules
runtime modules 1.28 KiB 7 modules
modules by path ../../node_modules/ 10.5 MiB
  javascript modules 10.1 MiB 2694 modules
  json modules 486 KiB 55 modules
modules by path ./src/ 200 KiB
  modules by path ./src/*.js 190 KiB 10 modules
  modules by path ./src/utils/ 9.92 KiB
    modules by path ./src/utils/gasMetering/*.js 8.31 KiB 3 modules
    modules by path ./src/utils/*.js 1.61 KiB
      ./src/utils/error.js 760 bytes [built] [code generated]
      ./src/utils/general.js 886 bytes [built] [code generated]
  ./src/contracts.json 272 bytes [built] [code generated]
optional modules 150 bytes [optional] 10 modules
37 modules
```

New bundle:
```
$ tasks/build-abi-js.sh && webpack
asset index.js 536 KiB [emitted] (name: main)
orphan modules 45.1 KiB [orphan] 14 modules
runtime modules 1.25 KiB 6 modules
cacheable modules 438 KiB
  modules by path ../../node_modules/ 238 KiB
    modules by path ../../node_modules/@ethersproject/ 152 KiB 34 modules
    2 modules
  modules by path ./src/ 200 KiB
    modules by path ./src/*.js 190 KiB 10 modules
    modules by path ./src/utils/ 9.92 KiB 5 modules
    ./src/contracts.json 272 bytes [built] [code generated]
  fs (ignored) 15 bytes [built] [code generated]
  path (ignored) 15 bytes [built] [code generated]
  buffer (ignored) 15 bytes [optional] [built] [code generated]
external "@ethersproject/contracts" 42 bytes [built] [code generated]
external "@truffle/contract" 42 bytes [optional] [built] [code generated]
webpack 5.49.0 compiled successfully in 573 ms
✨  Done in 1.86s.
```