### PR TITLE
Added gas griefing prevention

### DIFF
--- a/packages/ethereum-contracts/contracts/utils/TOGA.sol
+++ b/packages/ethereum-contracts/contracts/utils/TOGA.sol
@@ -104,6 +104,8 @@ contract TOGA is ITOGAv1, IERC777Recipient {
     uint256 public immutable minBondDuration;
     IERC1820Registry constant internal _ERC1820_REGISTRY =
         IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
+    // solhint-disable-next-line var-name-mixedcase
+    uint64 immutable public ERC777_SEND_GAS_LIMIT = 3000000;
 
     constructor(ISuperfluid host_, uint256 minBondDuration_) {
         _host = ISuperfluid(host_);
@@ -237,11 +239,10 @@ contract TOGA is ITOGAv1, IERC777Recipient {
         }
 
         // send remaining bond to current PIC
-        // send() allows the PIC to automatically re-bid
         // If the current PIC causes the send() to fail (iff contract with failing hook), we're sorry for them.
         // In this case the new PIC will "inherit" the remainder of their bond.
         // solhint-disable-next-line check-send-result
-        try token.send(currentPICAddr, currentPICBond, "0x")
+        try token.send{gas: ERC777_SEND_GAS_LIMIT}(currentPICAddr, currentPICBond, "0x")
         // solhint-disable-next-line no-empty-blocks
         {} catch {}
 

--- a/packages/ethereum-contracts/test/contracts/utils/TOGA.test.js
+++ b/packages/ethereum-contracts/test/contracts/utils/TOGA.test.js
@@ -4,6 +4,10 @@ const TestEnvironment = require("../../TestEnvironment");
 const traveler = require("ganache-time-traveler");
 
 const TOGA = artifacts.require("TOGA");
+const ERC777RecipientReverting = artifacts.require("ERC777RecipientReverting");
+const ERC777RecipientDrainingGas = artifacts.require(
+    "ERC777RecipientDrainingGas"
+);
 
 describe("TOGA", function () {
     this.timeout(300e3);
@@ -55,13 +59,20 @@ describe("TOGA", function () {
     }
 
     // returns a promise
-    function sendPICBid(sender, token, bondAmount, exitRate) {
+    function sendPICBid(
+        sender,
+        token,
+        bondAmount,
+        exitRate,
+        gasLimit = 3000000
+    ) {
         const exitRateEncoded =
             exitRate !== undefined
                 ? web3.eth.abi.encodeParameter("int96", exitRate)
                 : "0x";
         return token.send(toga.address, bondAmount, exitRateEncoded, {
             from: sender,
+            gas: gasLimit,
         });
     }
 
@@ -143,8 +154,7 @@ describe("TOGA", function () {
             exitRate: EXIT_RATE_1.toString(),
         });
 
-        const curPIC = await toga.getCurrentPIC(superToken.address);
-        assert.equal(curPIC, alice);
+        assert.equal(await toga.getCurrentPIC(superToken.address), alice);
 
         const { pic, bond: bond } = await toga.getCurrentPICInfo(
             superToken.address
@@ -160,8 +170,7 @@ describe("TOGA", function () {
 
         await sendPICBid(alice, superToken, BOND_AMOUNT_1E12, 0);
 
-        let curPIC = await toga.getCurrentPIC(superToken.address);
-        assert.equal(curPIC, alice);
+        assert.equal(await toga.getCurrentPIC(superToken.address), alice);
 
         const bond = (await toga.getCurrentPICInfo(superToken.address)).bond;
         //console.log(`remaining bond: ${bond}`);
@@ -188,8 +197,7 @@ describe("TOGA", function () {
             EXIT_RATE_1
         );
 
-        curPIC = await toga.getCurrentPIC(superToken.address);
-        assert.equal(curPIC, bob);
+        assert.equal(await toga.getCurrentPIC(superToken.address), bob);
         assert.equal(
             (await toga.getCurrentPICInfo(superToken.address)).bond,
             BOND_AMOUNT_1E12 + 1
@@ -573,5 +581,56 @@ describe("TOGA", function () {
             (await superToken.balanceOf(alice)).toString(),
             alicePreBal.sub(toBN(BOND_AMOUNT_2E12)).toString()
         );
+    });
+
+    it("#17 reverting send() hook can't prevent a successful bid", async () => {
+        await t.upgradeBalance("bob", t.configs.INIT_BALANCE);
+
+        const aliceRecipientHook = await ERC777RecipientReverting.new();
+        await erc1820.setInterfaceImplementer(
+            alice,
+            web3.utils.soliditySha3("ERC777TokensRecipient"),
+            aliceRecipientHook.address,
+            { from: alice }
+        );
+
+        await sendPICBid(bob, superToken, BOND_AMOUNT_1E12, EXIT_RATE_1E3);
+        assert.equal(await toga.getCurrentPIC(superToken.address), bob);
+    });
+
+    it("#18 previous PIC can't grief new bidder with gas draining send() hook", async () => {
+        await t.upgradeBalance("bob", t.configs.INIT_BALANCE);
+
+        // alice becomes malicious and tries to prevent others from outbidding her
+        const aliceRecipientHook = await ERC777RecipientDrainingGas.new();
+        await erc1820.setInterfaceImplementer(
+            alice,
+            web3.utils.soliditySha3("ERC777TokensRecipient"),
+            aliceRecipientHook.address,
+            { from: alice }
+        );
+
+        await sendPICBid(alice, superToken, BOND_AMOUNT_1E12, EXIT_RATE_1E3);
+
+        // send hook has higher allowance than gas limit, causes the tx to fail
+        await expectRevert.unspecified(
+            sendPICBid(bob, superToken, BOND_AMOUNT_2E12, EXIT_RATE_1E3)
+        );
+
+        // tx gets high enough gas limit for the send allowance not to make it fail
+        const r1 = await sendPICBid(
+            bob,
+            superToken,
+            BOND_AMOUNT_2E12,
+            EXIT_RATE_1E3,
+            4000000
+        );
+
+        await expectEvent.inTransaction(
+            r1.tx,
+            aliceRecipientHook.contract,
+            "DrainedGas"
+        );
+        console.log(`gas used by tx: ${r1.receipt.gasUsed}`);
     });
 });


### PR DESCRIPTION
With this changes, a malicious PIC can nomore prevent being outbid by installing an ERC777 send() hook which drains all enough gas for the calling TOGA contract to run out of gas.