### PR TITLE
Create codecov.yml

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -134,7 +134,7 @@ jobs:
             packages/sdk-core/coverage/
             packages/sdk-core/coverage/coverage-final.json
 
-      - name: Codecov
+      - name: Upload SDK-Core Coverage Results to codecov
         uses: codecov/codecov-action@v2
         with:
           files: packages/sdk-core/coverage/lcov.info

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "90...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no
+
+flags:
+  ethereum-contracts:
+    paths: packages/ethereum-contracts
+    carryforward: true
+  sdk-core:
+    paths: packages/sdk-core
+    carryforward: true


### PR DESCRIPTION
add a basic `codecov.yml` which tests out the carryforward flag feature to see if it solves the issue of 0% coverage ethereum-contracts when sdk-core information is uploaded to codecov first.