### PR TITLE
[sdk-redux] Store SuperfluidContext in a global

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 coverage
 coverage.json
 build
-/packages/sdk-redux/src/typings/global.d.ts

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 coverage
 coverage.json
 build
+/packages/sdk-redux/src/typings/global.d.ts

--- a/.github/workflows/handler.publish-pr-packages.yml
+++ b/.github/workflows/handler.publish-pr-packages.yml
@@ -1,6 +1,4 @@
 name: Publish PR Packages
-env:
-  GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
 
 on:
   workflow_run:
@@ -15,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/handler.publish-pr-packages.yml
+++ b/.github/workflows/handler.publish-pr-packages.yml
@@ -1,4 +1,6 @@
 name: Publish PR Packages
+env:
+  GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
 
 on:
   workflow_run:
@@ -13,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v2
@@ -59,6 +58,8 @@ jobs:
           for f in `ls` ; do
             npm --userconfig .npmrc publish $f --tag "PR$pr_number"
           done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryLocalVariableJS" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="m_ignoreImmediatelyReturnedVariables" value="false" />

--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EslintConfiguration">
+    <work-dir-patterns value="$PROJECT_DIR$/" />
+    <custom-configuration-file used="true" path="$PROJECT_DIR$/.eslintrc.js" />
     <option name="fix-on-save" value="true" />
   </component>
 </project>

--- a/packages/sdk-redux/.eslintignore
+++ b/packages/sdk-redux/.eslintignore
@@ -1,0 +1,3 @@
+dist
+build
+src/typings/global.d.ts

--- a/packages/sdk-redux/.eslintrc.json
+++ b/packages/sdk-redux/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "root": true,
+  "root": false,
   "parser": "@typescript-eslint/parser",
   "parserOptions": { "project": "./tsconfig.json" },
   "env": { "es6": true },

--- a/packages/sdk-redux/src/createSdkReduxParts.ts
+++ b/packages/sdk-redux/src/createSdkReduxParts.ts
@@ -11,7 +11,8 @@ import {
     transactionSlice,
 } from './redux-slices/transactions/transactionSlice';
 
-export let initializedSuperfluidContext: SuperfluidContext = null!;
+export const getSfContext: () => SuperfluidContext = () =>
+    globalThis.superfluidContext;
 
 /**
  * First initialization point of SDK-Redux.
@@ -34,18 +35,14 @@ export const createSdkReduxParts = (
      */
     transactionSlice: SuperfluidTransactionReduxSlice;
 } => {
-    if (initializedSuperfluidContext) {
-        throw Error("You shouldn't create the slice multiple times.");
-    }
-
     if (superfluidContext) {
-        initializedSuperfluidContext = superfluidContext;
+        globalThis.superfluidContext = superfluidContext;
     } else {
-        initializedSuperfluidContext = preinitializedSuperfluidContext;
+        globalThis.superfluidContext = preinitializedSuperfluidContext;
     }
 
     return {
-        superfluidContext: initializedSuperfluidContext,
+        superfluidContext: getSfContext(),
         apiSlice: rtkQuerySlice,
         transactionSlice: transactionSlice,
     };

--- a/packages/sdk-redux/src/redux-slices/rtk-query/cacheTags/monitorAddressForNextEventToInvalidateCache.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/cacheTags/monitorAddressForNextEventToInvalidateCache.ts
@@ -1,7 +1,7 @@
 import {AnyAction} from '@reduxjs/toolkit';
 import {ThunkDispatch} from '@reduxjs/toolkit';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {MillisecondTimes} from '../../../utils';
 import {TransactionInfo} from '../../argTypes';
 
@@ -18,7 +18,7 @@ export const monitorAddressForNextEventToInvalidateCache = async (
     transactionInfo: TransactionInfo,
     dispatch: ThunkDispatch<any, any, AnyAction>
 ) => {
-    const framework = await initializedSuperfluidContext.getFramework(
+    const framework = await getSfContext().getFramework(
         transactionInfo.chainId
     );
     framework.query.on(

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/approveIndexSubscription.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/approveIndexSubscription.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {
     NothingString,
@@ -30,9 +30,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         >({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/claimFromIndexSubscription.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/claimFromIndexSubscription.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {
     NothingString,
@@ -32,9 +32,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         >({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/createFlow.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/createFlow.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {SuperTokenMutationArg, TransactionInfo} from '../../argTypes';
 import {registerNewTransaction} from '../../transactions/registerNewTransaction';
@@ -25,9 +25,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         createFlow: builder.mutation<TransactionInfo, CreateFlowArg>({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/createIndex.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/createIndex.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {SuperTokenMutationArg, TransactionInfo} from '../../argTypes';
 import {registerNewTransaction} from '../../transactions/registerNewTransaction';
@@ -24,9 +24,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
              */
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const [superToken, signerAddress] = await Promise.all([
                     framework.loadSuperToken(arg.superTokenAddress),

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/deleteFlow.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/deleteFlow.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {SuperTokenMutationArg, TransactionInfo} from '../../argTypes';
 import {registerNewTransaction} from '../../transactions/registerNewTransaction';
@@ -23,9 +23,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         deleteFlow: builder.mutation<TransactionInfo, DeleteFlowArg>({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress
                 );

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/deleteIndexSubscription.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/deleteIndexSubscription.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {
     NothingString,
@@ -32,9 +32,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         >({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/distributeToIndex.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/distributeToIndex.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {
     NothingString,
@@ -30,9 +30,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         >({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const [superToken, signerAddress] = await Promise.all([
                     framework.loadSuperToken(arg.superTokenAddress),

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/downgradeFromSuperToken.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/downgradeFromSuperToken.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {SuperTokenMutationArg, TransactionInfo} from '../../argTypes';
 import {registerNewTransaction} from '../../transactions/registerNewTransaction';
@@ -22,9 +22,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         >({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const [superToken, signerAddress] = await Promise.all([
                     framework.loadSuperToken(arg.superTokenAddress),

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/monitorForEventsToInvalidateCache.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/monitorForEventsToInvalidateCache.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {MillisecondTimes} from '../../../utils';
 import {NothingString} from '../../argTypes';
 import {invalidateCacheTagsForEvents} from '../cacheTags/invalidateCacheTagsForEvents';
@@ -32,10 +32,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
             ) => {
                 // TODO(KK): Consider how changing of networks inside the application can affect this.
 
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
 
                 await cacheDataLoaded;
 

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/revokeIndexSubscription.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/revokeIndexSubscription.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {
     NothingString,
@@ -30,9 +30,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         >({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/transferSuperToken.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/transferSuperToken.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {SuperTokenMutationArg, TransactionInfo} from '../../argTypes';
 import {registerNewTransaction} from '../../transactions/registerNewTransaction';
@@ -24,9 +24,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         >({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const [superToken, signerAddress] = await Promise.all([
                     framework.loadSuperToken(arg.superTokenAddress),

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/updateFlow.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/updateFlow.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {SuperTokenMutationArg, TransactionInfo} from '../../argTypes';
 import {registerNewTransaction} from '../../transactions/registerNewTransaction';
@@ -25,9 +25,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         updateFlow: builder.mutation<TransactionInfo, UpdateFlowArg>({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress
                 );

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/updateIndexSubscriptionUnits.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/updateIndexSubscriptionUnits.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {
     NothingString,
@@ -32,9 +32,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         >({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress

--- a/packages/sdk-redux/src/redux-slices/rtk-query/mutations/upgradeToSuperToken.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/mutations/upgradeToSuperToken.ts
@@ -1,6 +1,6 @@
 import {ethers} from 'ethers';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {SuperTokenMutationArg, TransactionInfo} from '../../argTypes';
 import {registerNewTransaction} from '../../transactions/registerNewTransaction';
@@ -25,9 +25,7 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
         >({
             queryFn: async (arg, queryApi) => {
                 const [framework, signer] =
-                    await initializedSuperfluidContext.getFrameworkAndSigner(
-                        arg.chainId
-                    );
+                    await getSfContext().getFrameworkAndSigner(arg.chainId);
 
                 const [superToken, signerAddress] = await Promise.all([
                     framework.loadSuperToken(arg.superTokenAddress),

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/getAllowanceForUpgradeToSuperToken.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/getAllowanceForUpgradeToSuperToken.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {QueryArg} from '../../argTypes';
 import {getMostSpecificTokenTag} from '../cacheTags/tokenTags';
 import {rtkQuerySlice} from '../rtkQuerySlice';
@@ -27,10 +27,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
 
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/getIndex.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/getIndex.ts
@@ -1,6 +1,6 @@
 import {IWeb3Index} from '@superfluid-finance/sdk-core';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {QueryArg} from '../../argTypes';
 import {getMostSpecificIndexTag} from '../cacheTags/indexTags';
 import {rtkQuerySlice} from '../rtkQuerySlice';
@@ -25,10 +25,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress
                 );

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/getIndexSubscription.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/getIndexSubscription.ts
@@ -1,6 +1,6 @@
 import {IWeb3Subscription} from '@superfluid-finance/sdk-core';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {QueryArg} from '../../argTypes';
 import {getMostSpecificIndexTag} from '../cacheTags/indexTags';
 import {rtkQuerySlice} from '../rtkQuerySlice';
@@ -28,10 +28,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress
                 );

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/getRealtimeBalance.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/getRealtimeBalance.ts
@@ -1,4 +1,4 @@
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {typeGuard} from '../../../utils';
 import {NothingNumber, QueryArg} from '../../argTypes';
 import {getMostSpecificIndexTag} from '../cacheTags/indexTags';
@@ -52,10 +52,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
                 const superToken = await framework.loadSuperToken(
                     arg.superTokenAddress
                 );

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/listEvents.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/listEvents.ts
@@ -4,7 +4,7 @@ import {
     PagedResult,
 } from '@superfluid-finance/sdk-core';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {insertIf} from '../../../utils';
 import {NothingNumber, NothingString, PaginatedQueryArg} from '../../argTypes';
 import {createEventTag} from '../cacheTags/eventTags';
@@ -44,10 +44,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
                 const pagedResult = await framework.query.listEvents(
                     {
                         account: arg.accountAddress,

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/listIndexSubscriptions.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/listIndexSubscriptions.ts
@@ -4,7 +4,7 @@ import {
     PagedResult,
 } from '@superfluid-finance/sdk-core';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {NothingBoolean, NothingString, PaginatedQueryArg} from '../../argTypes';
 import {getMostSpecificIndexTag} from '../cacheTags/indexTags';
 import {rtkQuerySlice} from '../rtkQuerySlice';
@@ -31,10 +31,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
 
                 return {
                     data: await framework.query.listIndexSubscriptions(

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/listIndexes.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/listIndexes.ts
@@ -4,7 +4,7 @@ import {
     PagedResult,
 } from '@superfluid-finance/sdk-core';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {NothingString, PaginatedQueryArg} from '../../argTypes';
 import {getMostSpecificIndexTag} from '../cacheTags/indexTags';
 import {rtkQuerySlice} from '../rtkQuerySlice';
@@ -28,10 +28,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
 
                 return {
                     data: await framework.query.listIndexes(

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/listStreams.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/listStreams.ts
@@ -4,7 +4,7 @@ import {
     PagedResult,
 } from '@superfluid-finance/sdk-core';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {NothingString, PaginatedQueryArg} from '../../argTypes';
 import {getMostSpecificStreamTag} from '../cacheTags/streamTags';
 import {rtkQuerySlice} from '../rtkQuerySlice';
@@ -27,10 +27,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
 
                 return {
                     data: await framework.query.listStreams(

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/listSuperTokens.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/listSuperTokens.ts
@@ -4,7 +4,7 @@ import {
     PagedResult,
 } from '@superfluid-finance/sdk-core';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {NothingBoolean, PaginatedQueryArg} from '../../argTypes';
 import {getMostSpecificTokenTag} from '../cacheTags/tokenTags';
 import {rtkQuerySlice} from '../rtkQuerySlice';
@@ -28,10 +28,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
 
                 return {
                     data: await framework.query.listAllSuperTokens(

--- a/packages/sdk-redux/src/redux-slices/rtk-query/queries/listUserInteractedSuperTokens.ts
+++ b/packages/sdk-redux/src/redux-slices/rtk-query/queries/listUserInteractedSuperTokens.ts
@@ -4,7 +4,7 @@ import {
     PagedResult,
 } from '@superfluid-finance/sdk-core';
 
-import {initializedSuperfluidContext} from '../../../createSdkReduxParts';
+import {getSfContext} from '../../../createSdkReduxParts';
 import {NothingString, PaginatedQueryArg} from '../../argTypes';
 import {getMostSpecificIndexTag} from '../cacheTags/indexTags';
 import {getMostSpecificStreamTag} from '../cacheTags/streamTags';
@@ -44,10 +44,9 @@ const apiSlice = rtkQuerySlice.injectEndpoints({
                 }),
             ],
             queryFn: async (arg) => {
-                const framework =
-                    await initializedSuperfluidContext.getFramework(
-                        arg.chainId
-                    );
+                const framework = await getSfContext().getFramework(
+                    arg.chainId
+                );
                 const pagedResult =
                     await framework.query.listUserInteractedSuperTokens(
                         {

--- a/packages/sdk-redux/src/redux-slices/transactions/registerNewTransaction.ts
+++ b/packages/sdk-redux/src/redux-slices/transactions/registerNewTransaction.ts
@@ -1,6 +1,6 @@
 import {ThunkDispatch} from '@reduxjs/toolkit';
 
-import {initializedSuperfluidContext} from '../../createSdkReduxParts';
+import {getSfContext} from '../../createSdkReduxParts';
 
 import {trackTransaction, waitForOneConfirmation} from './trackTransaction';
 
@@ -23,7 +23,7 @@ export const registerNewTransaction = async (
      */
     dispatch: ThunkDispatch<any, any, any>
 ) => {
-    const framework = await initializedSuperfluidContext.getFramework(chainId);
+    const framework = await getSfContext().getFramework(chainId);
 
     dispatch(
         trackTransaction({

--- a/packages/sdk-redux/src/redux-slices/transactions/trackTransaction.ts
+++ b/packages/sdk-redux/src/redux-slices/transactions/trackTransaction.ts
@@ -2,7 +2,7 @@
 import {createAsyncThunk, Dispatch} from '@reduxjs/toolkit';
 import {ethers} from 'ethers';
 
-import {preinitializedSuperfluidContext} from '../../SuperfluidContext';
+import {getSfContext} from '../../createSdkReduxParts';
 import {MillisecondTimes} from '../../utils';
 import {TransactionInfo} from '../argTypes';
 import {rtkQuerySlice} from '../rtk-query/rtkQuerySlice';
@@ -47,9 +47,7 @@ export const trackTransaction = createAsyncThunk<void, TransactionInfo>(
             })
         );
 
-        const framework = await preinitializedSuperfluidContext.getFramework(
-            arg.chainId
-        );
+        const framework = await getSfContext().getFramework(arg.chainId);
 
         waitForOneConfirmation(framework.settings.provider, arg.hash)
             .then(

--- a/packages/sdk-redux/src/typings/global.d.ts
+++ b/packages/sdk-redux/src/typings/global.d.ts
@@ -1,0 +1,6 @@
+import {SuperfluidContext} from '../SuperfluidContext';
+
+// Solution inspired by: https://stackoverflow.com/a/69429093
+declare global {
+    var superfluidContext: SuperfluidContext;
+}


### PR DESCRIPTION
Why?
`SuperfluidContext` is a _service locator_ used in the Redux reducers. Current implementation of storing it seems to have an issue with HMR runtimes like the one CodeSandbox & Next.js have.

Solution?
Use `globalThis` syntax to store `SuperfluidContext` in a global object (e.g. `window`).