### PR TITLE
sdk-core readme fixes + cleanup

### DIFF
--- a/packages/sdk-core/README.md
+++ b/packages/sdk-core/README.md
@@ -31,6 +31,9 @@ To get the package up and running you'll need to install the necessary dependenc
 yarn install && yarn build
 ```
 
+# Tutorial
+
+For the best and most immersive experience of learning how to use the main sdk-core features, I would highly recommend heading over to our [interactive tutorials](https://docs.superfluid.finance/superfluid/protocol-tutorials/interactive-tutorials).
 # Usage
 
 ## Framework Initialization
@@ -117,6 +120,11 @@ const mmSf = await Framework.create({
 });
 
 // web3modal
+import Web3Modal from "web3modal";
+const web3Modal = new Web3Modal({
+  cacheProvider: false,
+  providerOptions: {}
+});
 const web3ModalRawProvider = await web3Modal.connect();
 const web3ModalProvider = new ethers.providers.Web3Provider(web3ModalRawProvider);
 const web3ModalSf = await Framework.create({
@@ -143,7 +151,7 @@ await onboard.walletSelect();
 
 > Note: You specify your project type in `package.json` - `"type": "module"` or `"type": "commonjs"`.
 
-This is the absolute minimum you need to provide the constructor (`chainId` or `networkName` and a `provider` object) if all you want to do are read operations. It is also important to note that the provider does not need to be an InfuraProvider - it just needs to satisfy the `ethers.Provider` interface.
+The absolute minimum you need to provide the constructor is `chainId` or `networkName` and a `provider` object if all you want to do are read operations. It is also important to note that the provider does not need to be an InfuraProvider - it just needs to satisfy the `SupportedProvider` interface: `ethers.providers.Provider | (typeof ethers & HardhatEthersHelpers) | Web3`.
 
 ## Helper Classes
 
@@ -173,8 +181,6 @@ const sf = await Framework.create({
 type Paging = { take: number, skip?: number, lastId?: string };
 
 const pageResult = await sf.query.
-  listAllResults(paging: Paging);
-  
   // The different queries can take different order by properties 
   // given the properties that exist on the entity itself.
   listAllSuperTokens({ isListed?: boolean },
@@ -359,10 +365,10 @@ const sf = await Framework.create({
 const signer = sf.createSigner({ privateKey: "<TEST_ACCOUNT_PRIVATE_KEY>", provider });
 
 // load the usdcx SuperToken via the Framework
-const usdcx = sf.loadToken("0xCAa7349CEA390F89641fe306D93591f87595dc1F");
+const usdcx = sf.loadSuperToken("0xCAa7349CEA390F89641fe306D93591f87595dc1F");
 
 // create an approve operation
-const approveOperation = usdcx.approve("0xab...", ethers.utils.parseUnits("100"));
+const approveOperation = usdcx.approve({ receiver: "0xab...", amount: ethers.utils.parseUnits("100").toString() });
 
 // execute the approve operation, passing in a signer
 const txn = await approveOperation.exec(signer);
@@ -371,7 +377,7 @@ const txn = await approveOperation.exec(signer);
 const receipt = await txn.wait();
 
 // or you can create and execute the transaction in a single line
-const approveTxn = await usdcx.approve("0xab...", ethers.utils.parseUnits("100")).exec(signer);
+const approveTxn = await usdcx.approve({ receiver: "0xab...", amount: ethers.utils.parseUnits("100").toString() }).exec(signer);
 const approveTxnReceipt = await approveTxn.wait();
 ```
 
@@ -386,7 +392,6 @@ import { ConstantFlowAgreementV1 } from "@superfluid-finance/sdk-core";
 
 const config = {
   hostAddress: "0x3E14dC1b13c488a8d5D310918780c983bD5982E7",
-  superTokenFactoryAddress: "0x2C90719f25B10Fc5646c82DA3240C76Fa5BcCF34",
   cfaV1Address: "0x6EeE6060f715257b970700bc2656De21dEdF074C",
   idaV1Address: "0xB0aABBA4B2783A72C52956CDEF62d438ecA2d7a1"
 };
@@ -491,7 +496,6 @@ import { InstantDistributionAgreementV1 } from "@superfluid-finance/sdk-core";
 
 const config = {
   hostAddress: "0x3E14dC1b13c488a8d5D310918780c983bD5982E7",
-  superTokenFactoryAddress: "0x2C90719f25B10Fc5646c82DA3240C76Fa5BcCF34",
   cfaV1Address: "0x6EeE6060f715257b970700bc2656De21dEdF074C",
   idaV1Address: "0xB0aABBA4B2783A72C52956CDEF62d438ecA2d7a1"
 };
@@ -627,7 +631,7 @@ const sf = await Framework.create({
   provider
 });
 
-const usdcx = sf.loadToken("0xCAa7349CEA390F89641fe306D93591f87595dc1F");
+const usdcx = sf.loadSuperToken("0xCAa7349CEA390F89641fe306D93591f87595dc1F");
 ```
 
 #### Direct Initialization
@@ -643,7 +647,6 @@ const provider = new ethers.providers.InfuraProvider(
 
 const config = {
   hostAddress: "0x3E14dC1b13c488a8d5D310918780c983bD5982E7",
-  superTokenFactoryAddress: "0x2C90719f25B10Fc5646c82DA3240C76Fa5BcCF34",
   cfaV1Address: "0x6EeE6060f715257b970700bc2656De21dEdF074C",
   idaV1Address: "0xB0aABBA4B2783A72C52956CDEF62d438ecA2d7a1"
 };
@@ -651,7 +654,7 @@ const config = {
 const usdcx = await SuperToken.create({
   address: "0xCAa7349CEA390F89641fe306D93591f87595dc1F",
   config,
-  networkName: "matic",
+  networkName: "matic", // you can also pass in chainId instead (e.g. chainId: 137)
   provider
 });
 ```
@@ -659,7 +662,7 @@ const usdcx = await SuperToken.create({
 #### SuperToken Functions
 
 ```ts
-const usdcx = sf.loadToken("0xCAa7349CEA390F89641fe306D93591f87595dc1F");
+const usdcx = sf.loadSuperToken("0xCAa7349CEA390F89641fe306D93591f87595dc1F");
 
 // ERC20 `Token`
 // Read functions
@@ -744,7 +747,7 @@ const sf = await Framework.create({
   provider
 });
 
-const usdcx = sf.loadToken("0xCAa7349CEA390F89641fe306D93591f87595dc1F");
+const usdcx = sf.loadSuperToken("0xCAa7349CEA390F89641fe306D93591f87595dc1F");
 
 // Read example
 const name = await usdcx.name();
@@ -809,15 +812,8 @@ const batchCall = sf.batchCall([<OPERATION_A>, <OPERATION_B>, ...]);
 ```ts
 import { SuperToken } from "@superfluid-finance/sdk-core";
 
-const config = {
-  hostAddress: "0x3E14dC1b13c488a8d5D310918780c983bD5982E7",
-  superTokenFactoryAddress: "0x2C90719f25B10Fc5646c82DA3240C76Fa5BcCF34",
-  cfaV1Address: "0x6EeE6060f715257b970700bc2656De21dEdF074C",
-  idaV1Address: "0xB0aABBA4B2783A72C52956CDEF62d438ecA2d7a1"
-};
-
 const batchCall = new BatchCall({
-  config,
+  hostAddress: "0x3E14dC1b13c488a8d5D310918780c983bD5982E7",
   operations: [<OPERATION_A>, <OPERATION_B>, ...],
 });
 ```

--- a/packages/sdk-core/src/BatchCall.ts
+++ b/packages/sdk-core/src/BatchCall.ts
@@ -4,11 +4,10 @@ import Host from "./Host";
 import Operation, { OperationType } from "./Operation";
 import SFError from "./SFError";
 import SuperfluidABI from "./abi/Superfluid.json";
-import { IConfig } from "./interfaces";
 import { getTransactionDescription, removeSigHashFromCallData } from "./utils";
 
 interface IBatchCallOptions {
-    config: IConfig;
+    hostAddress: string;
     operations: ReadonlyArray<Operation>;
 }
 
@@ -37,7 +36,7 @@ export default class BatchCall {
 
     constructor(options: IBatchCallOptions) {
         this.options = options;
-        this.host = new Host(options.config.hostAddress);
+        this.host = new Host(options.hostAddress);
     }
 
     /**

--- a/packages/sdk-core/src/Framework.ts
+++ b/packages/sdk-core/src/Framework.ts
@@ -174,7 +174,6 @@ export default class Framework {
                 networkName,
                 config: {
                     hostAddress: framework.superfluid,
-                    superTokenFactoryAddress: framework.superTokenFactory,
                     cfaV1Address: framework.agreementCFAv1,
                     idaV1Address: framework.agreementIDAv1,
                 },
@@ -243,7 +242,10 @@ export default class Framework {
      * @returns `BatchCall` class
      */
     batchCall = (operations: Operation[]) => {
-        return new BatchCall({ operations, config: this.settings.config });
+        return new BatchCall({
+            operations,
+            hostAddress: this.settings.config.hostAddress,
+        });
     };
 
     /**

--- a/packages/sdk-core/src/interfaces.ts
+++ b/packages/sdk-core/src/interfaces.ts
@@ -371,7 +371,6 @@ export interface ISignerConstructorOptions {
 
 export interface IConfig {
     readonly hostAddress: string;
-    readonly superTokenFactoryAddress: string;
     readonly cfaV1Address: string;
     readonly idaV1Address: string;
 }

--- a/packages/sdk-core/test/3_supertoken.test.ts
+++ b/packages/sdk-core/test/3_supertoken.test.ts
@@ -66,7 +66,6 @@ describe("SuperToken Tests", () => {
                         hostAddress: "",
                         cfaV1Address: "",
                         idaV1Address: "",
-                        superTokenFactoryAddress: "",
                     },
                 });
             } catch (err: any) {
@@ -84,7 +83,6 @@ describe("SuperToken Tests", () => {
                         hostAddress: "",
                         cfaV1Address: "",
                         idaV1Address: "",
-                        superTokenFactoryAddress: "",
                     },
                 });
             } catch (err: any) {
@@ -561,7 +559,9 @@ describe("SuperToken Tests", () => {
                 daix
                     .updateIndexValue({
                         indexId: "0",
-                        indexValue: ethers.utils.parseUnits("0.000000002").toString(),
+                        indexValue: ethers.utils
+                            .parseUnits("0.000000002")
+                            .toString(),
                     })
                     .exec(alpha)
             )
@@ -619,7 +619,9 @@ describe("SuperToken Tests", () => {
                 daix
                     .updateIndexValue({
                         indexId: "0",
-                        indexValue: ethers.utils.parseUnits("0.000000003").toString(),
+                        indexValue: ethers.utils
+                            .parseUnits("0.000000003")
+                            .toString(),
                     })
                     .exec(alpha)
             )

--- a/packages/subgraph/cache/solidity-files-cache.json
+++ b/packages/subgraph/cache/solidity-files-cache.json
@@ -1,0 +1,4 @@
+{
+  "_format": "hh-sol-cache-2",
+  "files": {}
+}

--- a/packages/subgraph/cache/solidity-files-cache.json
+++ b/packages/subgraph/cache/solidity-files-cache.json
@@ -1,4 +1,0 @@
-{
-  "_format": "hh-sol-cache-2",
-  "files": {}
-}


### PR DESCRIPTION
- point users towards the new interactive tutorials
- web3Modal example fix
- some more descriptive comments
- remove listAllResults (example is quite complicated)
- API inconsistency fixed for `approve` and `loadToken`
- Updated batchCall constructor and IConfig object
- removed `superTokenFactoryAddress` from IConfig