### PR TITLE
Add `IndexValueCurrent` to IndexSubscription query

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the SDK-core will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `indexValueCurrent` to `IndexSubscription` query to optimize calculating "total amount distributed" in consuming applications
 
 ## [0.3.0] - 2022-02-02
 ### Added

--- a/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscription.ts
+++ b/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscription.ts
@@ -29,6 +29,7 @@ export interface IndexSubscription {
     updatedAtBlockNumber: BlockNumber;
     approved: boolean;
     indexValueUntilUpdatedAt: BigNumber;
+    indexValueCurrent: BigNumber;
     totalAmountReceivedUntilUpdatedAt: BigNumber;
     units: BigNumber;
     index: SubgraphId;
@@ -74,6 +75,7 @@ export class IndexSubscriptionQueryHandler extends SubgraphQueryHandler<
             updatedAtTimestamp: Number(x.updatedAtTimestamp),
             updatedAtBlockNumber: Number(x.updatedAtBlockNumber),
             index: x.index.id,
+            indexValueCurrent: x.index.indexValue,
             token: x.index.token.id,
             publisher: x.index.publisher.id,
         }));

--- a/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscriptions.graphql
+++ b/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscriptions.graphql
@@ -12,6 +12,7 @@ query indexSubscriptions($first: Int = 10, $orderBy: IndexSubscription_orderBy =
         id
         index {
             id
+            indexValue
             token {
                 id
             }


### PR DESCRIPTION
Why?
To optimize showing `total amount distributed` in consuming applications. Right now, if we show a list of index subscriptions and want to show the total amount distributed then we would have to do _select N + 1_ queries.

Anything else?
In another pull request, I would add `tokenSymbol` to all the entities as well because consuming applications want to display the token almost everywhere but currently only the bare token ID is available which I doubt anyone wants to display. 