### PR TITLE
Add `indexTotalUnits` to IndexSubscription query

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Added
 - Added `indexValueCurrent` to `IndexSubscription` query to optimize calculating "total amount distributed" in consuming applications
+- Added `indexTotalUnits` to `IndexSubscription` query to optimize calculating "pool percentage" in consuming applications
 
 ## [0.3.0] - 2022-02-02
 ### Added

--- a/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscription.ts
+++ b/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscription.ts
@@ -32,6 +32,7 @@ export interface IndexSubscription {
     indexValueCurrent: BigNumber;
     totalAmountReceivedUntilUpdatedAt: BigNumber;
     units: BigNumber;
+    indexTotalUnits: BigNumber;
     index: SubgraphId;
     token: Address;
     subscriber: Address;
@@ -76,6 +77,7 @@ export class IndexSubscriptionQueryHandler extends SubgraphQueryHandler<
             updatedAtBlockNumber: Number(x.updatedAtBlockNumber),
             index: x.index.id,
             indexValueCurrent: x.index.indexValue,
+            indexTotalUnits: x.index.totalUnits,
             token: x.index.token.id,
             publisher: x.index.publisher.id,
         }));

--- a/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscriptions.graphql
+++ b/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscriptions.graphql
@@ -13,6 +13,7 @@ query indexSubscriptions($first: Int = 10, $orderBy: IndexSubscription_orderBy =
         index {
             id
             indexValue
+            totalUnits
             token {
                 id
             }


### PR DESCRIPTION
Why?
To optimize showing index subscription's pool percentage in consuming applications. Makes it easy to display a list of subscriptions with the % of the index. Having better overview of pool percentages was a feedback from one of the Ricochet developers.