### PR TITLE
sdk-core/sdk-redux patch release

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -4,12 +4,19 @@ All notable changes to the SDK-core will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.1] - 2022-02-16
+
 ### Added
-- Added `indexValueCurrent` to `IndexSubscription` query to optimize calculating "total amount distributed" in consuming applications
-- Added `indexTotalUnits` to `IndexSubscription` query to optimize calculating "pool percentage" in consuming applications
+- Added `indexValueCurrent` to `IndexSubscription` query to optimize calculating "total amount distributed" in consuming applications ([#629])
+- Added `indexTotalUnits` to `IndexSubscription` query to optimize calculating "pool percentage" in consuming applications ([#630])
+
+### Fixed
+- Typo for `networkName: "arbitrum-rinkeby"` fixed (was expecting `"arbitrium-rinkeby"`) in `Framework.create` ([#637])
 
 ### Breaking
-- Using `"xdai"` as the `networkName` will no longer work. Updated to `"gnosis"`.
+- Using `"xdai"` as the `networkName` will no longer work. Updated to `"gnosis"` 
+  - Migration: change `networkName` from `"xdai"` to `"gnosis"`
 
 ## [0.3.0] - 2022-02-02
 ### Added
@@ -66,7 +73,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - New `SuperToken` class with `SuperToken` CRUD functionality and an underlying `Token` class with basic `ERC20` functionality
   - New `BatchCall` class for creating and executing batch calls with supported `Operation's`
 
-[Unreleased]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.3.0...HEAD
+[Unreleased]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.3.1...HEAD
+[0.3.1]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.3.0...sdk-core%40v0.3.1
 [0.3.0]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.2.1...sdk-core%40v0.3.0
 [0.2.1]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.2.0...sdk-core%40v0.2.1
 [0.2.0]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.1.0...sdk-core%40v0.2.0
@@ -88,3 +96,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [#550]: https://github.com/superfluid-finance/protocol-monorepo/pull/550
 [#556]: https://github.com/superfluid-finance/protocol-monorepo/pull/556
 [#588]: https://github.com/superfluid-finance/protocol-monorepo/pull/588
+[#629]: https://github.com/superfluid-finance/protocol-monorepo/pull/629
+[#630]: https://github.com/superfluid-finance/protocol-monorepo/pull/630
+[#630]: https://github.com/superfluid-finance/protocol-monorepo/pull/630
+[#637]: https://github.com/superfluid-finance/protocol-monorepo/pull/637

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-core",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "SDK Core for building with Superfluid Protocol",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/sdk-core#readme",
     "repository": "github:superfluid-finance/protocol-monorepo",

--- a/packages/sdk-redux/CHANGELOG.md
+++ b/packages/sdk-redux/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the SDK-redux will be documented in this file.
 
+## [0.2.1] - 2022-02-16
+### Added
+- Using SDK-Core@v0.3.1, SDK-core bug fix propagated to SDK-redux
 ## [0.2.0] - 2022-02-01
 ### Added
 - Introduce new Redux slice `sfSubgraph` ([#571])
@@ -21,6 +24,7 @@ All notable changes to the SDK-redux will be documented in this file.
     - Handle errors and offer user opportunity to retry
 
 
+[0.2.1]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-redux%40v0.2.0...sdk-redux%40v0.2.1
 [0.2.0]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-redux%40v0.1.0...sdk-redux%40v0.2.0
 [0.1.0]: https://github.com/superfluid-finance/protocol-monorepo/releases/tag/sdk-redux%40v0.1.0
 

--- a/packages/sdk-redux/package.json
+++ b/packages/sdk-redux/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-redux",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "SDK Redux for streamlined front-end application development with Superfluid Protocol",
     "homepage": "https://docs.superfluid.finance/",
     "repository": {
@@ -53,7 +53,7 @@
     },
     "peerDependencies": {
         "@reduxjs/toolkit": "^1.6.0 || ^1.7.0",
-        "@superfluid-finance/sdk-core": "0.3.0"
+        "@superfluid-finance/sdk-core": "0.3.1"
     },
     "files": [
         "dist/main",


### PR DESCRIPTION
- sdk-core typo fix release
- sdk-redux consumes sdk-core, so we want a new release for sdk-redux as well