### PR TITLE
change solidity pragma in cfa lib to support versions 0.8 & later

### DIFF
--- a/packages/ethereum-contracts/contracts/apps/CFAv1Library.sol
+++ b/packages/ethereum-contracts/contracts/apps/CFAv1Library.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: AGPLv3
-pragma solidity ^0.7.0;
+pragma solidity >=0.7.0;
 pragma experimental ABIEncoderV2;
 
 import {


### PR DESCRIPTION
@hellwolf this is fix for the CFA Lib prior to the weekend's hackathon. Just changing the pragma statement from ^0.7.0 to > 0.7.0 as I believe using the '^' won't allow for support with 0.8.0 and above.

