### PR TITLE
missing emits

### DIFF
--- a/packages/ethereum-contracts/contracts/mocks/WETH9Mock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/WETH9Mock.sol
@@ -37,13 +37,13 @@ contract WETH9Mock {
     }
     function deposit() public payable {
         balanceOf[msg.sender] += msg.value;
-        Deposit(msg.sender, msg.value);
+        emit Deposit(msg.sender, msg.value);
     }
     function withdraw(uint wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
         msg.sender.transfer(wad);
-        Withdrawal(msg.sender, wad);
+        emit Withdrawal(msg.sender, wad);
     }
 
     function totalSupply() public view returns (uint) {
@@ -52,7 +52,7 @@ contract WETH9Mock {
 
     function approve(address guy, uint wad) public returns (bool) {
         allowance[msg.sender][guy] = wad;
-        Approval(msg.sender, guy, wad);
+        emit Approval(msg.sender, guy, wad);
         return true;
     }
 
@@ -74,7 +74,7 @@ contract WETH9Mock {
         balanceOf[src] -= wad;
         balanceOf[dst] += wad;
 
-        Transfer(src, dst, wad);
+        emit Transfer(src, dst, wad);
 
         return true;
     }


### PR DESCRIPTION
whenever I try to compile the contracts using hardhat, I get this error: `TypeError: Event invocations have to be prefixed by "emit".