### PR TITLE
update to 0.8.13

### DIFF
--- a/examples/budget-nft/contracts/BudgetNFT.sol
+++ b/examples/budget-nft/contracts/BudgetNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/examples/budget-nft/truffle-config.js
+++ b/examples/budget-nft/truffle-config.js
@@ -82,7 +82,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.12"       // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.13"       // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {

--- a/examples/continuous-auction/contracts/Auction.sol
+++ b/examples/continuous-auction/contracts/Auction.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/examples/continuous-auction/truffle-config.js
+++ b/examples/continuous-auction/truffle-config.js
@@ -33,7 +33,7 @@ module.exports = {
     // Configure your compilers
     compilers: {
         solc: {
-            version: "0.8.12" // Fetch exact version from solc-bin (default: truffle's version)
+            version: "0.8.13" // Fetch exact version from solc-bin (default: truffle's version)
             // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
             // settings: {          // See the solidity docs for advice about optimization and evmVersion
             //  optimizer: {

--- a/examples/flowlottery/solidity-contracts/contracts/LotterySuperApp.sol
+++ b/examples/flowlottery/solidity-contracts/contracts/LotterySuperApp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/examples/flowlottery/solidity-contracts/truffle-config.js
+++ b/examples/flowlottery/solidity-contracts/truffle-config.js
@@ -25,7 +25,7 @@ module.exports = {
     },
     compilers: {
         solc: {
-            version: "0.8.12" // Fetch exact version from solc-bin (default: truffle's version)
+            version: "0.8.13" // Fetch exact version from solc-bin (default: truffle's version)
         }
     },
     mocha: {

--- a/examples/nftbillboard-userdata/packages/hardhat/contracts/RedirectAll.sol
+++ b/examples/nftbillboard-userdata/packages/hardhat/contracts/RedirectAll.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import "hardhat/console.sol";
 

--- a/examples/nftbillboard-userdata/packages/hardhat/contracts/TradeableCashflow.sol
+++ b/examples/nftbillboard-userdata/packages/hardhat/contracts/TradeableCashflow.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {RedirectAll, ISuperToken, IConstantFlowAgreementV1, ISuperfluid} from "./RedirectAll.sol";
 

--- a/examples/nftbillboard-userdata/packages/hardhat/hardhat.config.js
+++ b/examples/nftbillboard-userdata/packages/hardhat/hardhat.config.js
@@ -25,7 +25,7 @@ module.exports = {
   defaultNetwork,
 
   solidity: {
-    version: "0.8.12",
+    version: "0.8.13",
     settings: {
       optimizer: {
         enabled: true

--- a/examples/rewards-distribution-token/contracts/DividendRightsToken.sol
+++ b/examples/rewards-distribution-token/contracts/DividendRightsToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/examples/rewards-distribution-token/truffle-config.js
+++ b/examples/rewards-distribution-token/truffle-config.js
@@ -116,7 +116,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.8.12",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.8.13",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {

--- a/examples/streaming-call-option/contracts/RedirectAllCallOption.sol
+++ b/examples/streaming-call-option/contracts/RedirectAllCallOption.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 

--- a/examples/streaming-call-option/contracts/TradeableCashflowOption.sol
+++ b/examples/streaming-call-option/contracts/TradeableCashflowOption.sol
@@ -1,5 +1,5 @@
  //SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {RedirectAllCallOption, ISuperToken, IConstantFlowAgreementV1, ISuperfluid} from "./RedirectAllCallOption.sol";
 

--- a/examples/streaming-call-option/contracts/test/MockV3Aggregator.sol
+++ b/examples/streaming-call-option/contracts/test/MockV3Aggregator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 

--- a/examples/streaming-call-option/hardhat.config.js
+++ b/examples/streaming-call-option/hardhat.config.js
@@ -25,7 +25,7 @@ module.exports = {
   // defaultNetwork,
 
   solidity: {
-    version: "0.8.12",
+    version: "0.8.13",
     settings: {
       optimizer: {
         enabled: true

--- a/examples/tradeable-cashflow-hardhat/contracts/RedirectAll.sol
+++ b/examples/tradeable-cashflow-hardhat/contracts/RedirectAll.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {ISuperfluid, ISuperToken, ISuperApp, ISuperAgreement, SuperAppDefinitions} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol"; //"@superfluid-finance/ethereum-monorepo/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
 

--- a/examples/tradeable-cashflow-hardhat/contracts/TradeableCashflow.sol
+++ b/examples/tradeable-cashflow-hardhat/contracts/TradeableCashflow.sol
@@ -1,5 +1,5 @@
-//SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
 
 import {RedirectAll, ISuperToken, IConstantFlowAgreementV1, ISuperfluid} from "./RedirectAll.sol";
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/examples/tradeable-cashflow-hardhat/hardhat.config.js
+++ b/examples/tradeable-cashflow-hardhat/hardhat.config.js
@@ -27,7 +27,7 @@ require('hardhat-deploy');
     // },
  
      solidity: {
-      version: "0.8.12",
+      version: "0.8.13",
       settings: {
         optimizer: {
           enabled: true

--- a/examples/tradeable-cashflow-truffle/contracts/RedirectAll.sol
+++ b/examples/tradeable-cashflow-truffle/contracts/RedirectAll.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {ISuperfluid, ISuperToken, ISuperApp, ISuperAgreement, SuperAppDefinitions} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol"; //"@superfluid-finance/ethereum-monorepo/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
 

--- a/examples/tradeable-cashflow-truffle/contracts/TradeableCashflow.sol
+++ b/examples/tradeable-cashflow-truffle/contracts/TradeableCashflow.sol
@@ -1,5 +1,5 @@
-//SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
 
 import {RedirectAll, ISuperToken, IConstantFlowAgreementV1, ISuperfluid} from "./RedirectAll.sol";
 import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/examples/tradeable-cashflow-truffle/truffle-config.js
+++ b/examples/tradeable-cashflow-truffle/truffle-config.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     compilers: {
         solc: {
-            version: "0.8.12" // Fetch exact version from solc-bin (default: truffle's version)
+            version: "0.8.13" // Fetch exact version from solc-bin (default: truffle's version)
         }
     }
 };

--- a/packages/ethereum-contracts/contracts/agreements/AgreementBase.sol
+++ b/packages/ethereum-contracts/contracts/agreements/AgreementBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { UUPSProxiable } from "../upgradability/UUPSProxiable.sol";
 import { ISuperAgreement } from "../interfaces/superfluid/ISuperAgreement.sol";

--- a/packages/ethereum-contracts/contracts/agreements/AgreementLibrary.sol
+++ b/packages/ethereum-contracts/contracts/agreements/AgreementLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluidGovernance,

--- a/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     IConstantFlowAgreementV1,

--- a/packages/ethereum-contracts/contracts/agreements/InstantDistributionAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/InstantDistributionAgreementV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     IInstantDistributionAgreementV1,

--- a/packages/ethereum-contracts/contracts/agreements/SlotsBitmapLibrary.sol
+++ b/packages/ethereum-contracts/contracts/agreements/SlotsBitmapLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluidToken

--- a/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceBase.sol
+++ b/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceII.sol
+++ b/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceII.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { UUPSProxy } from "../upgradability/UUPSProxy.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/ethereum-contracts/contracts/libs/CallUtils.sol
+++ b/packages/ethereum-contracts/contracts/libs/CallUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 /**
  * @title Call utilities library that is absent from the OpenZeppelin

--- a/packages/ethereum-contracts/contracts/libs/ERC777Helper.sol
+++ b/packages/ethereum-contracts/contracts/libs/ERC777Helper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { IERC1820Registry } from "@openzeppelin/contracts/utils/introspection/IERC1820Registry.sol";
 

--- a/packages/ethereum-contracts/contracts/libs/FixedSizeData.sol
+++ b/packages/ethereum-contracts/contracts/libs/FixedSizeData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 /**
  * @title Utilities for fixed size data in storage

--- a/packages/ethereum-contracts/contracts/libs/Int96SafeMath.sol
+++ b/packages/ethereum-contracts/contracts/libs/Int96SafeMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 /**
  * @title Int96SafeMath

--- a/packages/ethereum-contracts/contracts/libs/UInt128SafeMath.sol
+++ b/packages/ethereum-contracts/contracts/libs/UInt128SafeMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 
 /**

--- a/packages/ethereum-contracts/contracts/mocks/AgreementMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/AgreementMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/CFAAppMocks.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFAAppMocks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/CFALibraryMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFALibraryMock.sol
@@ -1,5 +1,5 @@
-//SPDX-License-Identifier: MIT
-pragma solidity 0.8.12;
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
 
 import {ISuperfluid, ISuperfluidToken, ISuperToken} from "../interfaces/superfluid/ISuperfluid.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/CallUtilsMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CallUtilsMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { CallUtils } from "../libs/CallUtils.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/CustomSuperTokenMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CustomSuperTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     CustomSuperTokenBase,

--- a/packages/ethereum-contracts/contracts/mocks/ERC777SenderRecipientMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/ERC777SenderRecipientMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/packages/ethereum-contracts/contracts/mocks/FakeSuperfluidMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/FakeSuperfluidMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { CallUtils } from "../libs/CallUtils.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/ForwarderMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/ForwarderMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { CallUtils } from "../libs/CallUtils.sol";
 import { IRelayRecipient } from "../interfaces/ux/IRelayRecipient.sol";

--- a/packages/ethereum-contracts/contracts/mocks/IDASuperAppTester.sol
+++ b/packages/ethereum-contracts/contracts/mocks/IDASuperAppTester.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/IDAv1LibraryMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/IDAv1LibraryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 pragma experimental ABIEncoderV2;
 
 import {ISuperfluid, ISuperfluidToken, ISuperToken} from "../interfaces/superfluid/ISuperfluid.sol";

--- a/packages/ethereum-contracts/contracts/mocks/MockSmartWallet.sol
+++ b/packages/ethereum-contracts/contracts/mocks/MockSmartWallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { ISuperToken, IERC20 } from "../superfluid/Superfluid.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/SuperTokenFactoryMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperTokenFactoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { SuperTokenMock } from "./SuperTokenMock.sol";
 import {

--- a/packages/ethereum-contracts/contracts/mocks/SuperTokenMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/SuperfluidDestructorMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperfluidDestructorMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPLv3
 // solhint-disable
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 contract SuperfluidDestructorMock {
 

--- a/packages/ethereum-contracts/contracts/mocks/SuperfluidGovernanceIIMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperfluidGovernanceIIMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { ISuperfluid } from "../interfaces/superfluid/ISuperfluid.sol";
 import { SuperfluidGovernanceII } from "../gov/SuperfluidGovernanceII.sol";

--- a/packages/ethereum-contracts/contracts/mocks/SuperfluidMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperfluidMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     Superfluid,

--- a/packages/ethereum-contracts/contracts/mocks/UUPSProxiableMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/UUPSProxiableMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { UUPSProxiable } from "../upgradability/UUPSProxiable.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/UtilsTester.sol
+++ b/packages/ethereum-contracts/contracts/mocks/UtilsTester.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { Int96SafeMath } from "../libs/Int96SafeMath.sol";
 import { UInt128SafeMath } from "../libs/UInt128SafeMath.sol";

--- a/packages/ethereum-contracts/contracts/superfluid/SuperToken.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { UUPSProxiable } from "../upgradability/UUPSProxiable.sol";
 

--- a/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperTokenFactory,

--- a/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { UUPSProxiable } from "../upgradability/UUPSProxiable.sol";
 import { UUPSProxy } from "../upgradability/UUPSProxy.sol";

--- a/packages/ethereum-contracts/contracts/superfluid/SuperfluidToken.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperfluidToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { ISuperfluid } from "../interfaces/superfluid/ISuperfluid.sol";
 import { ISuperAgreement } from "../interfaces/superfluid/ISuperAgreement.sol";

--- a/packages/ethereum-contracts/contracts/test/MultiFlowApp.sol
+++ b/packages/ethereum-contracts/contracts/test/MultiFlowApp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/test/TestGovernance.sol
+++ b/packages/ethereum-contracts/contracts/test/TestGovernance.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/test/TestToken.sol
+++ b/packages/ethereum-contracts/contracts/test/TestToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/ethereum-contracts/contracts/tokens/FullUpgradableSuperTokenProxy.sol
+++ b/packages/ethereum-contracts/contracts/tokens/FullUpgradableSuperTokenProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { ISuperTokenFactory } from "../interfaces/superfluid/ISuperTokenFactory.sol";
 import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";

--- a/packages/ethereum-contracts/contracts/tokens/MaticBridgedNativeSuperToken.sol
+++ b/packages/ethereum-contracts/contracts/tokens/MaticBridgedNativeSuperToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperToken,

--- a/packages/ethereum-contracts/contracts/tokens/NativeSuperToken.sol
+++ b/packages/ethereum-contracts/contracts/tokens/NativeSuperToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperToken,

--- a/packages/ethereum-contracts/contracts/tokens/SETH.sol
+++ b/packages/ethereum-contracts/contracts/tokens/SETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import {
     ISuperToken,

--- a/packages/ethereum-contracts/contracts/upgradability/UUPSProxiable.sol
+++ b/packages/ethereum-contracts/contracts/upgradability/UUPSProxiable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { UUPSUtils } from "./UUPSUtils.sol";
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/ethereum-contracts/contracts/upgradability/UUPSProxy.sol
+++ b/packages/ethereum-contracts/contracts/upgradability/UUPSProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { UUPSUtils } from "./UUPSUtils.sol";
 import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";

--- a/packages/ethereum-contracts/contracts/upgradability/UUPSUtils.sol
+++ b/packages/ethereum-contracts/contracts/upgradability/UUPSUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 /**
  * @title UUPS (Universal Upgradeable Proxy Standard) Shared Library

--- a/packages/ethereum-contracts/contracts/utils/BatchLiquidator.sol
+++ b/packages/ethereum-contracts/contracts/utils/BatchLiquidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { ISuperfluid, ISuperAgreement } from "../interfaces/superfluid/ISuperfluid.sol";
 import { IConstantFlowAgreementV1 } from "../interfaces/agreements/IConstantFlowAgreementV1.sol";

--- a/packages/ethereum-contracts/contracts/utils/TOGA.sol
+++ b/packages/ethereum-contracts/contracts/utils/TOGA.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/packages/ethereum-contracts/contracts/utils/TokenCustodian.sol
+++ b/packages/ethereum-contracts/contracts/utils/TokenCustodian.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { IERC777 } from "@openzeppelin/contracts/token/ERC777/IERC777.sol";
 import { IERC1820Registry } from "@openzeppelin/contracts/utils/introspection/IERC1820Registry.sol";

--- a/packages/ethereum-contracts/contracts/ux/BaseRelayRecipient.sol
+++ b/packages/ethereum-contracts/contracts/ux/BaseRelayRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import "../interfaces/ux/IRelayRecipient.sol";
 

--- a/packages/ethereum-contracts/contracts/ux/Resolver.sol
+++ b/packages/ethereum-contracts/contracts/ux/Resolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { AccessControlEnumerable } from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import { IResolver } from "../interfaces/ux/IResolver.sol";

--- a/packages/ethereum-contracts/contracts/ux/SuperUpgrader.sol
+++ b/packages/ethereum-contracts/contracts/ux/SuperUpgrader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/ethereum-contracts/contracts/ux/SuperfluidLoader.sol
+++ b/packages/ethereum-contracts/contracts/ux/SuperfluidLoader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.12;
+pragma solidity 0.8.13;
 
 import { IResolver } from "../interfaces/ux/IResolver.sol";
 import {

--- a/packages/ethereum-contracts/truffle-config.js
+++ b/packages/ethereum-contracts/truffle-config.js
@@ -337,7 +337,7 @@ const E = (module.exports = {
     // Configure your compilers
     compilers: {
         solc: {
-            version: "0.8.12", // Fetch exact version from solc-bin (default: truffle's version)
+            version: "0.8.13", // Fetch exact version from solc-bin (default: truffle's version)
             settings: {
                 // See the solidity docs for advice about optimization and evmVersion
                 optimizer: {


### PR DESCRIPTION
Release announcement: https://blog.soliditylang.org/2022/03/16/solidity-0.8.13-release-announcement/

Looks like the main fix of the release was a bug related to `abi.encodeCall`: https://blog.soliditylang.org/2022/03/16/encodecall-bug/