### PR TITLE
Fix compile warning in tradeable-cashflow example

### DIFF
--- a/examples/tradeable-cashflow-hardhat/contracts/RedirectAll.sol
+++ b/examples/tradeable-cashflow-hardhat/contracts/RedirectAll.sol
@@ -177,7 +177,7 @@ contract RedirectAll is SuperAppBase {
         ISuperToken _superToken,
         address _agreementClass,
         bytes32, //_agreementId,
-        bytes calldata agreementData,
+        bytes calldata, //agreementData,
         bytes calldata, //_cbdata,
         bytes calldata _ctx
     )

--- a/examples/tradeable-cashflow-truffle/contracts/RedirectAll.sol
+++ b/examples/tradeable-cashflow-truffle/contracts/RedirectAll.sol
@@ -181,7 +181,7 @@ contract RedirectAll is SuperAppBase {
         ISuperToken _superToken,
         address _agreementClass,
         bytes32, //_agreementId,
-        bytes calldata agreementData,
+        bytes calldata, //agreementData,
         bytes calldata, //_cbdata,
         bytes calldata _ctx
     )


### PR DESCRIPTION
This removes the following warning one gets when compiling the contracts in tradable-cashflow example

```
Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
   --> contracts/RedirectAll.sol:180:9:
    |
180 |         bytes calldata agreementData,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```