### PR TITLE
[sdk-core] Prioritize Wrapper Super Token creation over Native Asset one

### DIFF
--- a/packages/sdk-core/src/SuperToken.ts
+++ b/packages/sdk-core/src/SuperToken.ts
@@ -129,9 +129,13 @@ export default abstract class SuperToken extends ERC20Token {
                 networkName,
             };
 
-            const tokenSymbol = await superToken
-                .connect(options.provider)
-                .symbol();
+            if (underlyingTokenAddress !== ethers.constants.AddressZero) {
+                return new WrapperSuperToken(options, {
+                    ...settings,
+                    underlyingTokenAddress,
+                });
+            }
+
             const resolverData = chainIdToResolverDataMap.get(chainId) || {
                 subgraphAPIEndpoint: "",
                 resolverAddress: "",
@@ -141,6 +145,9 @@ export default abstract class SuperToken extends ERC20Token {
             const nativeTokenSymbol = resolverData.nativeTokenSymbol || "ETH";
             const nativeSuperTokenSymbol = nativeTokenSymbol + "x";
 
+            const tokenSymbol = await superToken
+                .connect(options.provider)
+                .symbol();
             if (nativeSuperTokenSymbol === tokenSymbol) {
                 return new NativeAssetSuperToken(
                     options,
@@ -149,12 +156,6 @@ export default abstract class SuperToken extends ERC20Token {
                 );
             }
 
-            if (underlyingTokenAddress !== ethers.constants.AddressZero) {
-                return new WrapperSuperToken(options, {
-                    ...settings,
-                    underlyingTokenAddress,
-                });
-            }
             return new PureSuperToken(options, settings);
         } catch (err) {
             throw new SFError({


### PR DESCRIPTION
Why?
For "MATICx" & "xDAIx", `NativeAssetSuperToken` was being created when it's actually a `WrapperSuperToken`.

Solution?
The solution is to change the order of object creation in the `create` method. The first thing is to check whether the token has an underlying token and when it does that means it's a `WrapperSuperToken`.

Todo?
- [ ] Write a test for this case.