### PR TITLE
A separated ISuperAppRegistry and a  SuperAppRegistryDelegate

### DIFF
--- a/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperAppRegistry.sol
+++ b/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperAppRegistry.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity >= 0.8.0;
+import { ISuperApp } from "./ISuperApp.sol";
+
+
+/**
+ * @title Super App Registry
+ * @author Superfluid
+ *
+ * NOTE:
+ * The superfluid host implements the Super App Registry interface, but it might have a white-list.
+ * To register as an app for such host contract, a delegate may be trusted by the host, and implements this registry
+ * inteface instead.
+ *
+ */
+interface ISuperAppRegistry {
+
+    /**
+    * @dev Message sender declares it as a super app
+    * @param configWord The super app manifest configuration, flags are defined in
+    * `SuperAppDefinitions`
+    */
+    function registerApp(uint256 configWord) external;
+
+    /**
+    * @dev App registered event
+    * @param app Address of jailed app
+    */
+    event AppRegistered(ISuperApp indexed app);
+
+    /**
+     * @dev Query if the app is registered
+     * @param app Super app address
+     */
+    function isApp(ISuperApp app) external view returns(bool);
+
+    /**
+     * @dev Query app level
+     * @param app Super app address
+     */
+    function getAppLevel(ISuperApp app) external view returns(uint8 appLevel);
+
+    /**
+     * @dev Get the manifest of the super app
+     * @param app Super app address
+     */
+    function getAppManifest(
+        ISuperApp app
+    )
+        external view
+        returns (
+            bool isSuperApp,
+            bool isJailed,
+            uint256 noopMask
+        );
+
+    /**
+     * @dev Query if the app has been jailed
+     * @param app Super app address
+     */
+    function isAppJailed(ISuperApp app) external view returns (bool isJail);
+
+    /**
+     * @dev Whitelist the target app for app composition for the source app (msg.sender)
+     * @param targetApp The target super app address
+     */
+    function allowCompositeApp(ISuperApp targetApp) external;
+
+    /**
+     * @dev Query if source app is allowed to call the target app as downstream app
+     * @param app Super app address
+     * @param targetApp The target super app address
+     */
+    function isCompositeAppAllowed(
+        ISuperApp app,
+        ISuperApp targetApp
+    )
+        external view
+        returns (bool isAppAllowed);
+
+}

--- a/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol
+++ b/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol
@@ -6,6 +6,7 @@ import { ISuperfluidToken } from "./ISuperfluidToken.sol";
 import { ISuperToken } from "./ISuperToken.sol";
 import { ISuperTokenFactory } from "./ISuperTokenFactory.sol";
 import { ISuperAgreement } from "./ISuperAgreement.sol";
+import { ISuperAppRegistry } from "./ISuperAppRegistry.sol";
 import { ISuperApp } from "./ISuperApp.sol";
 import {
     BatchOperation,
@@ -19,8 +20,9 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC777 } from "@openzeppelin/contracts/token/ERC777/IERC777.sol";
 
 /**
- * @title Host interface
+ * @title Superfluid host interface
  * @author Superfluid
+ *
  * NOTE:
  * This is the central contract of the system where super agreement, super app
  * and super token features are connected.
@@ -29,7 +31,7 @@ import { IERC777 } from "@openzeppelin/contracts/token/ERC777/IERC777.sol";
  * where batch call and meta transaction are provided for UX improvements.
  *
  */
-interface ISuperfluid {
+interface ISuperfluid is ISuperAppRegistry {
 
     /**************************************************************************
      * Time
@@ -180,20 +182,8 @@ interface ISuperfluid {
     event SuperTokenLogicUpdated(ISuperToken indexed token, address code);
 
     /**************************************************************************
-     * App Registry
+     * App White-listing Facilities
      *************************************************************************/
-
-    /**
-     * @dev Message sender declares it as a super app
-     * @param configWord The super app manifest configuration, flags are defined in
-     * `SuperAppDefinitions`
-     */
-    function registerApp(uint256 configWord) external;
-    /**
-     * @dev App registered event
-     * @param app Address of jailed app
-     */
-    event AppRegistered(ISuperApp indexed app);
 
     /**
      * @dev Message sender declares it as a super app, using a registration key
@@ -210,56 +200,6 @@ interface ISuperfluid {
      * NOTE: only factory contracts authorized by governance can register super apps
      */
     function registerAppByFactory(ISuperApp app, uint256 configWord) external;
-
-    /**
-     * @dev Query if the app is registered
-     * @param app Super app address
-     */
-    function isApp(ISuperApp app) external view returns(bool);
-
-    /**
-     * @dev Query app level
-     * @param app Super app address
-     */
-    function getAppLevel(ISuperApp app) external view returns(uint8 appLevel);
-
-    /**
-     * @dev Get the manifest of the super app
-     * @param app Super app address
-     */
-    function getAppManifest(
-        ISuperApp app
-    )
-        external view
-        returns (
-            bool isSuperApp,
-            bool isJailed,
-            uint256 noopMask
-        );
-
-    /**
-     * @dev Query if the app has been jailed
-     * @param app Super app address
-     */
-    function isAppJailed(ISuperApp app) external view returns (bool isJail);
-
-    /**
-     * @dev Whitelist the target app for app composition for the source app (msg.sender)
-     * @param targetApp The target super app address
-     */
-    function allowCompositeApp(ISuperApp targetApp) external;
-
-    /**
-     * @dev Query if source app is allowed to call the target app as downstream app
-     * @param app Super app address
-     * @param targetApp The target super app address
-     */
-    function isCompositeAppAllowed(
-        ISuperApp app,
-        ISuperApp targetApp
-    )
-        external view
-        returns (bool isAppAllowed);
 
     /**************************************************************************
      * Agreement Framework


### PR DESCRIPTION
To have a smoother transition from white-listed Super App framework to no whitelisted ones, this can be a solution to unify the super app deployment workflow:

On testnets:

- Superfluid implements ISuperAppRegistry, and the apps can continue to use it directly,
- But they are also going to be asked to add new code to select the app registry during its constructor. For reason that will be evident below.

On mainnets:

- A SuperAppRegistryDelegate is created for each host contract,
- Such contract may white-list deployer with an expiration date,
- And Super App register their app via this delegate instead.
