### PR TITLE
SDK-Core and Subgraph Release Cleanup

### DIFF
--- a/packages/sdk-core/src/SuperToken.ts
+++ b/packages/sdk-core/src/SuperToken.ts
@@ -62,11 +62,6 @@ export interface ITokenOptions {
     readonly networkName?: string;
 }
 
-type SuperTokenType =
-    | NativeAssetSuperToken
-    | WrapperSuperToken
-    | PureSuperToken;
-
 /**
  * SuperToken Helper Class
  * @description A helper class to create `SuperToken` objects which can interact with the `SuperToken` contract as well as the CFAV1 and IDAV1 contracts of the desired `SuperToken`.
@@ -104,7 +99,7 @@ export default abstract class SuperToken extends ERC20Token {
         ) as ISuperToken;
     }
 
-    static create = async (options: ITokenOptions): Promise<SuperTokenType> => {
+    static create = async (options: ITokenOptions): Promise<SuperToken> => {
         if (!options.chainId && !options.networkName) {
             throw new SFError({
                 type: "SUPERTOKEN_INITIALIZATION",

--- a/packages/sdk-core/test/1_supertoken.test.ts
+++ b/packages/sdk-core/test/1_supertoken.test.ts
@@ -67,13 +67,13 @@ describe("SuperToken Tests", () => {
         alpha = Alpha;
         bravo = Bravo;
         superToken = SuperToken;
-        daix = await framework.loadSuperToken(superToken.address);
+        daix = await framework.loadWrapperSuperToken(superToken.address);
         token = Token;
         charlie = Charlie;
         signerCount = SignerCount;
     });
 
-    describe("Pure Token Tests", () => {
+    describe("SuperToken Tests", () => {
         it("Should throw an error if SuperToken isn't initialized properly.", async () => {
             try {
                 await SuperToken.create({
@@ -347,20 +347,67 @@ describe("SuperToken Tests", () => {
         });
     });
 
-    describe("NativeSuperToken Tests", () => {
+    describe("SuperToken Initialization Tests", () => {
         let nativeAssetSuperToken: NativeAssetSuperToken;
-        it("Should be able to create a NativeSuperToken (SuperTokenWithoutUnderlying)", async () => {
-            // TODO: SCRIPTS ARE A BLOCKER - FIX LATER SO THAT WE DON'T NEED TO HARDCODE HERE
-            // 0x67d269191c92Caf3cD7723F116c85e6E9bf55933 is MR address
+        it("Should load SuperToken base class for any token type", async () => {
+            // load WrapperSuperToken
+            await framework.loadSuperToken(daix.address);
+
+            // load NativeAssetSuperToken
+            await framework.loadSuperToken("ETHx");
+
+            // load PureSuperToken
             await framework.loadSuperToken(
                 "0x67d269191c92Caf3cD7723F116c85e6E9bf55933"
             );
         });
 
+        it("Should be able to create a WrapperSuperToken", async () => {
+            await framework.loadWrapperSuperToken(daix.address);
+        });
+
+        it("Should throw if trying to load a non-WrapperSuperToken", async () => {
+            try {
+                await framework.loadWrapperSuperToken("ETHx");
+            } catch (err: any) {
+                expect(err.message).to.eql(
+                    "SuperToken Initialization Error - The token is not a wrapper supertoken."
+                );
+            }
+        });
+
         it("Should be able to create a NativeAssetSuperToken", async () => {
-            nativeAssetSuperToken = (await framework.loadSuperToken(
+            nativeAssetSuperToken = await framework.loadNativeAssetSuperToken(
                 "ETHx"
-            )) as NativeAssetSuperToken;
+            );
+        });
+
+        it("Should throw if trying to load a non-NativeAssetSuperToken", async () => {
+            try {
+                await framework.loadNativeAssetSuperToken(daix.address);
+            } catch (err: any) {
+                expect(err.message).to.eql(
+                    "SuperToken Initialization Error - The token is not a native asset supertoken."
+                );
+            }
+        });
+
+        it("Should be able to create a PureSuperToken", async () => {
+            // TODO: SCRIPTS ARE A BLOCKER - FIX LATER SO THAT WE DON'T NEED TO HARDCODE HERE
+            // 0x67d269191c92Caf3cD7723F116c85e6E9bf55933 is MR address
+            await framework.loadPureSuperToken(
+                "0x67d269191c92Caf3cD7723F116c85e6E9bf55933"
+            );
+        });
+
+        it("Should throw if trying to load a non-PureSuperToken", async () => {
+            try {
+                await framework.loadPureSuperToken(daix.address);
+            } catch (err: any) {
+                expect(err.message).to.eql(
+                    "SuperToken Initialization Error - The token is not a pure supertoken."
+                );
+            }
         });
 
         it("Should be able to upgrade native asset", async () => {

--- a/packages/sdk-core/test/4_governance.test.ts
+++ b/packages/sdk-core/test/4_governance.test.ts
@@ -26,7 +26,7 @@ describe("Governance Tests", () => {
         framework = frameworkClass;
         deployer = Deployer;
         superToken = SuperToken;
-        daix = await framework.loadSuperToken(superToken.address);
+        daix = await framework.loadWrapperSuperToken(superToken.address);
     });
 
     it("Should get default governance parameters", async () => {

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -86,7 +86,7 @@ type FlowUpdatedEvent implements Event @entity {
     stream: Stream!
 }
 
-type FlowOperatorUpdatedEvent implements Event @entity {
+type FlowOperatorUpdatedEvent implements Event @entity(immutable: true) {
     id: ID!
     transactionHash: Bytes!
     timestamp: BigInt!
@@ -1114,7 +1114,7 @@ interaction with a `token`.
 """
 type AccountTokenSnapshot @entity {
     """
-    ID composed of: accountID + keccak256("-") + tokenID (without the 0x)
+    ID composed of: accountID + keccak256("-") + tokenID
     """
     id: ID!
     updatedAtTimestamp: BigInt!

--- a/packages/subgraph/src/mappings/cfav1.ts
+++ b/packages/subgraph/src/mappings/cfav1.ts
@@ -360,8 +360,6 @@ export function handleFlowUpdatedExtension(event: FlowUpdatedExtension): void {
 }
 
 export function handleFlowOperatorUpdated(event: FlowOperatorUpdated): void {
-    createFlowOperatorUpdatedEventEntity(event);
-
     let flowOperator = getOrInitFlowOperator(
         event.block,
         event.params.flowOperator,
@@ -374,6 +372,8 @@ export function handleFlowOperatorUpdated(event: FlowOperatorUpdated): void {
     flowOperator.flowRateAllowanceRemaining = event.params.flowRateAllowance;
     flowOperator.flowOperator = event.params.flowOperator;
     flowOperator.save();
+
+    createFlowOperatorUpdatedEventEntity(event);
 }
 
 export function updateFlowOperatorForFlowUpdated(


### PR DESCRIPTION
# Subgraph Cleanup
* make `FlowOperatorUpdatedEvent` entity immutable
* fix a comment regarding the `AccountTokenSnapshot` entity ID

# SDK-Core Cleanup
* add new explicit initialization functions for different SuperToken class types
* add tests for new initialization functions including expected fail cases