### PR TITLE
Subgraph 1.3.2 patch

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/subgraph",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Subgraph for the Superfluid Ethereum contracts.",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/subgraph",
     "repository": {

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -440,7 +440,7 @@ export function updateAccountUpdatedAt(
     accountAddress: Address,
     block: ethereum.Block
 ): void {
-    if (accountAddress.equals(ZERO_ADDRESS)) return;
+    // if (accountAddress.equals(ZERO_ADDRESS)) return;
     let account = getOrInitAccount(accountAddress, block);
     account.updatedAtTimestamp = block.timestamp;
     account.updatedAtBlockNumber = block.number;

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -440,7 +440,7 @@ export function updateAccountUpdatedAt(
     accountAddress: Address,
     block: ethereum.Block
 ): void {
-    // if (accountAddress.equals(ZERO_ADDRESS)) return;
+    if (accountAddress.equals(ZERO_ADDRESS)) return;
     let account = getOrInitAccount(accountAddress, block);
     account.updatedAtTimestamp = block.timestamp;
     account.updatedAtBlockNumber = block.number;
@@ -704,13 +704,13 @@ export function updateAggregateEntitiesTransferData(
     value: BigInt,
     block: ethereum.Block
 ): void {
-    let fromAccountTokenSnapshot = getOrInitAccountTokenSnapshot(
-        fromAddress,
-        tokenAddress,
-        block
-    );
-
     if (fromAddress.notEqual(ZERO_ADDRESS)) {
+        let fromAccountTokenSnapshot = getOrInitAccountTokenSnapshot(
+            fromAddress,
+            tokenAddress,
+            block
+        );
+
         // NOTE: fromAccountTokenSnapshot won't exist if address is ZERO_ADDRESS
         fromAccountTokenSnapshot.totalAmountTransferredUntilUpdatedAt =
             fromAccountTokenSnapshot.totalAmountTransferredUntilUpdatedAt.plus(

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -440,7 +440,6 @@ export function updateAccountUpdatedAt(
     accountAddress: Address,
     block: ethereum.Block
 ): void {
-    if (accountAddress.equals(ZERO_ADDRESS)) return;
     let account = getOrInitAccount(accountAddress, block);
     account.updatedAtTimestamp = block.timestamp;
     account.updatedAtBlockNumber = block.number;
@@ -465,9 +464,6 @@ export function updateAggregateIDASubscriptionsData(
     isApproving: boolean,
     block: ethereum.Block
 ): void {
-    // NOTE: we ignore if address is ZERO_ADDRESS
-    if (accountAddress.equals(ZERO_ADDRESS)) return;
-
     let tokenStatistic = getOrInitTokenStatistic(tokenAddress, block);
     let totalSubscriptionWithUnitsDelta =
         isDeletingSubscription && subscriptionWithUnitsExists
@@ -548,9 +544,6 @@ export function updateATSStreamedAndBalanceUntilUpdatedAt(
     tokenAddress: Address,
     block: ethereum.Block
 ): void {
-    // NOTE: we ignore if address is ZERO_ADDRESS
-    if (accountAddress.equals(ZERO_ADDRESS)) return;
-
     let accountTokenSnapshot = getOrInitAccountTokenSnapshot(
         accountAddress,
         tokenAddress,
@@ -704,22 +697,20 @@ export function updateAggregateEntitiesTransferData(
     value: BigInt,
     block: ethereum.Block
 ): void {
-    if (fromAddress.notEqual(ZERO_ADDRESS)) {
-        let fromAccountTokenSnapshot = getOrInitAccountTokenSnapshot(
-            fromAddress,
-            tokenAddress,
-            block
-        );
+    let fromAccountTokenSnapshot = getOrInitAccountTokenSnapshot(
+        fromAddress,
+        tokenAddress,
+        block
+    );
 
-        // NOTE: fromAccountTokenSnapshot won't exist if address is ZERO_ADDRESS
-        fromAccountTokenSnapshot.totalAmountTransferredUntilUpdatedAt =
-            fromAccountTokenSnapshot.totalAmountTransferredUntilUpdatedAt.plus(
-                value
-            );
-        fromAccountTokenSnapshot.updatedAtTimestamp = block.timestamp;
-        fromAccountTokenSnapshot.updatedAtBlockNumber = block.number;
-        fromAccountTokenSnapshot.save();
-    }
+    // NOTE: fromAccountTokenSnapshot won't exist if address is ZERO_ADDRESS
+    fromAccountTokenSnapshot.totalAmountTransferredUntilUpdatedAt =
+        fromAccountTokenSnapshot.totalAmountTransferredUntilUpdatedAt.plus(
+            value
+        );
+    fromAccountTokenSnapshot.updatedAtTimestamp = block.timestamp;
+    fromAccountTokenSnapshot.updatedAtBlockNumber = block.number;
+    fromAccountTokenSnapshot.save();
 
     let tokenStatistic = getOrInitTokenStatistic(tokenAddress, block);
     tokenStatistic.totalAmountTransferredUntilUpdatedAt =

--- a/packages/subgraph/src/utils.ts
+++ b/packages/subgraph/src/utils.ts
@@ -93,8 +93,7 @@ export function updateTotalSupplyForNativeSuperToken(
     tokenAddress: Address
 ): TokenStatistic {
     if (
-        token.underlyingAddress.toHex() ==
-            "0x0000000000000000000000000000000000000000" &&
+        Address.fromBytes(token.underlyingAddress).equals(ZERO_ADDRESS) &&
         tokenStatistic.totalSupply.equals(BIG_INT_ZERO)
     ) {
         let tokenContract = SuperToken.bind(tokenAddress);

--- a/packages/subgraph/test/helpers/helpers.ts
+++ b/packages/subgraph/test/helpers/helpers.ts
@@ -9,9 +9,8 @@ import {
     ITestModifyFlowData,
 } from "../interfaces";
 import { FlowActionType } from "./constants";
-import IResolverABI from "../../abis/IResolver.json";
 import TestTokenABI from "../../abis/TestToken.json";
-import { Resolver, TestToken } from "../../typechain";
+import { TestToken } from "../../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BigNumber } from "ethers";
 

--- a/packages/subgraph/test/queries/aggregateQueries.ts
+++ b/packages/subgraph/test/queries/aggregateQueries.ts
@@ -29,6 +29,14 @@ export const getAccountTokenSnapshot = gql`
     }
 `;
 
+export const getAccountTokenSnapshotIds = gql`
+    query getAccountTokenSnapshot($id: ID!) {
+        response: accountTokenSnapshot(where { account: $id }) {
+            id
+        }
+    }
+`;
+
 export const getTokenStatistic = gql`
     query getTokenStatistic($id: ID!) {
         response: tokenStatistic(id: $id) {

--- a/packages/subgraph/test/queries/aggregateQueries.ts
+++ b/packages/subgraph/test/queries/aggregateQueries.ts
@@ -31,7 +31,7 @@ export const getAccountTokenSnapshot = gql`
 
 export const getAccountTokenSnapshotIds = gql`
     query getAccountTokenSnapshot($id: ID!) {
-        response: accountTokenSnapshot(where: { account: $id }) {
+        response: accountTokenSnapshots(where: { account: $id }) {
             id
         }
     }

--- a/packages/subgraph/test/queries/aggregateQueries.ts
+++ b/packages/subgraph/test/queries/aggregateQueries.ts
@@ -31,7 +31,7 @@ export const getAccountTokenSnapshot = gql`
 
 export const getAccountTokenSnapshotIds = gql`
     query getAccountTokenSnapshot($id: ID!) {
-        response: accountTokenSnapshot(where { account: $id }) {
+        response: accountTokenSnapshot(where: { account: $id }) {
             id
         }
     }

--- a/packages/subgraph/test/queries/holQueries.ts
+++ b/packages/subgraph/test/queries/holQueries.ts
@@ -21,6 +21,14 @@ export const getAccount = gql`
     }
 `;
 
+export const getAccountIds = gql`
+    query getAccounts($id: ID!) {
+        response: account(where: { id: $id }) {
+            id
+        }
+    }
+`;
+
 export const getToken = gql`
     query getToken($id: ID!) {
         response: token(id: $id) {

--- a/packages/subgraph/test/queries/holQueries.ts
+++ b/packages/subgraph/test/queries/holQueries.ts
@@ -23,7 +23,7 @@ export const getAccount = gql`
 
 export const getAccountIds = gql`
     query getAccounts($id: ID!) {
-        response: account(where: { id: $id }) {
+        response: accounts(where: { id: $id }) {
             id
         }
     }

--- a/packages/subgraph/test/subgraph.test.ts
+++ b/packages/subgraph/test/subgraph.test.ts
@@ -1085,10 +1085,6 @@ describe("Subgraph Tests", () => {
     });
 
     describe("Global Check", () => {
-        // NOTE: this will be true for the current and all subsequent subgraphs deployed
-        // HOWEVER, it was possible to assign the zero address as the subscriber so this
-        // means that it is still possible Account or AccountTokenSnapshots can be created
-        // via one of the IDA events
         it("There should be no Account or AccountTokenSnapshot entities with the zero address", async () => {
             const accountTokenSnapshotIds = await fetchEntityAndEnsureExistence<
                 ILightEntity[]
@@ -1101,15 +1097,15 @@ describe("Subgraph Tests", () => {
                 ILightEntity[]
             >(getAccountIds, ethers.constants.AddressZero, "Account");
 
-            if (accountTokenSnapshotIds.length !== 0) {
+            if (accountTokenSnapshotIds.length === 0) {
                 throw new Error(
-                    "Invariant broken, nonzero zero address account snapshot"
+                    "Invariant broken, no nonzero zero address AccountTokenSnapshot's"
                 );
             }
 
-            if (accounts.length !== 0) {
+            if (accounts.length === 0) {
                 throw new Error(
-                    "Invariant broken, nonzero zero address accounts"
+                    "Invariant broken, no nonzero zero address Account's"
                 );
             }
         });

--- a/packages/subgraph/test/subgraph.test.ts
+++ b/packages/subgraph/test/subgraph.test.ts
@@ -1085,7 +1085,7 @@ describe("Subgraph Tests", () => {
     });
 
     describe("Global Check", () => {
-        it("There should be no Account or AccountTokenSnapshot entities with the zero address", async () => {
+        it("There should be at least one Account or AccountTokenSnapshot entities with the zero address", async () => {
             const accountTokenSnapshotIds = await fetchEntityAndEnsureExistence<
                 ILightEntity[]
             >(

--- a/packages/subgraph/test/subgraph.test.ts
+++ b/packages/subgraph/test/subgraph.test.ts
@@ -1085,6 +1085,10 @@ describe("Subgraph Tests", () => {
     });
 
     describe("Global Check", () => {
+        // NOTE: this will be true for the current and all subsequent subgraphs deployed
+        // HOWEVER, it was possible to assign the zero address as the subscriber so this
+        // means that it is still possible Account or AccountTokenSnapshots can be created
+        // via one of the IDA events
         it("There should be no Account or AccountTokenSnapshot entities with the zero address", async () => {
             const accountTokenSnapshotIds = await fetchEntityAndEnsureExistence<
                 ILightEntity[]


### PR DESCRIPTION
* Subgraph 1.3.1 was incorrectly handling ATS creation in a specific case leading to ATS with null addresses. This was because ATS was being created even though the fromAddress was the zero address
* This lets us know that no zero address account entities are being added (expected behavior) - **ACTUALLY THIS ISN'T TRUE ON POLYGON** - this is because there are events where the subscriber was the zero address and we are creating `IndexSubscription` and therefore `Account` entities for zero address subscribers