### PR TITLE
fix query syntax

### DIFF
--- a/packages/subgraph/test/queries/globalQueries.ts
+++ b/packages/subgraph/test/queries/globalQueries.ts
@@ -223,7 +223,7 @@ const getIndexesLightEntities = gql`
             subscriptions(first: 1) {
                 id
             }
-            indexCreatedEvent(first: 1) {
+            indexCreatedEvent {
                 id
             }
             indexDistributionClaimedEvents(first: 1) {


### PR DESCRIPTION
* this query actually worked as it was previously which is why the tests passed, but this syntax makes more sense