### PR TITLE
Fix a hot fuzz temporary link in  the flowlottery contracts

### DIFF
--- a/examples/flowlottery/solidity-contracts/package.json
+++ b/examples/flowlottery/solidity-contracts/package.json
@@ -19,7 +19,7 @@
     "devDependencies": {
         "@decentral.ee/web3-helpers": "^0.5.3",
         "@openzeppelin/test-helpers": "^0.5.15",
-        "@superfluid-finance/hot-fuzz": "https://gitpkg.now.sh/api/pkg?url=superfluid-finance/protocol-monorepo/packages/hot-fuzz&commit=da8234b58cf614922936e15c1befe3944e008c12",
+        "@superfluid-finance/hot-fuzz": "https://gitpkg.now.sh/api/pkg?url=superfluid-finance/protocol-monorepo/packages/hot-fuzz&commit=90b879cb5dda258caa0883ca73d7befc4c5446f0",
         "@superfluid-finance/js-sdk": "^0.6.0",
         "@truffle/contract": "4.5.10",
         "@truffle/hdwallet-provider": "2.0.8",

--- a/examples/flowlottery/solidity-contracts/yarn.lock
+++ b/examples/flowlottery/solidity-contracts/yarn.lock
@@ -1116,9 +1116,9 @@
     hardhat "^2.9.3"
     stack-trace "0.0.10"
 
-"@superfluid-finance/hot-fuzz@https://gitpkg.now.sh/api/pkg?url=superfluid-finance/protocol-monorepo/packages/hot-fuzz&commit=da8234b58cf614922936e15c1befe3944e008c12":
+"@superfluid-finance/hot-fuzz@https://gitpkg.now.sh/api/pkg?url=superfluid-finance/protocol-monorepo/packages/hot-fuzz&commit=90b879cb5dda258caa0883ca73d7befc4c5446f0":
   version "0.1.0"
-  resolved "https://gitpkg.now.sh/api/pkg?url=superfluid-finance/protocol-monorepo/packages/hot-fuzz&commit=da8234b58cf614922936e15c1befe3944e008c12#a39dbf9d9e37580c826203dcc3d4cadfb25f84e9"
+  resolved "https://gitpkg.now.sh/api/pkg?url=superfluid-finance/protocol-monorepo/packages/hot-fuzz&commit=90b879cb5dda258caa0883ca73d7befc4c5446f0#00de1cfd7c58f0e84073fae3167f25020b50bfdc"
   dependencies:
     "@openzeppelin/contracts" "4.5.0"
 

--- a/packages/hot-fuzz/README.md
+++ b/packages/hot-fuzz/README.md
@@ -34,7 +34,7 @@ How To Use
 `hot-fuzz` does not have a package yet, you should install it through:
 
 ```
-yarn add https://gitpkg.now.sh/superfluid-finance/protocol-monorepo/packages/hot-fuzz?dev
+yarn add 'https://gitpkg.now.sh/api/pkg?url=superfluid-finance/protocol-monorepo/packages/hot-fuzz&commit=dev'
 ```
 
 > Check out how this works:


### PR DESCRIPTION
Now it's merged, we can use a more permanent link.