### PR TITLE
[Subgraph] Get correct Subgraph schema for dev & stable release builds

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -262,6 +262,7 @@ jobs:
       - name: Build
         run: |
           yarn --cwd packages/sdk-core set-default-subgraph-release-tag
+          yarn --cwd packages/sdk-core generate-graphql-schema:dev
           yarn build
         env:
           SUBGRAPH_RELEASE_TAG: dev

--- a/.github/workflows/handler.publish-release-packages.yml
+++ b/.github/workflows/handler.publish-release-packages.yml
@@ -42,7 +42,11 @@ jobs:
       - name: Build package
         run: |
           yarn install --frozen-lockfile
+          yarn --cwd packages/sdk-core set-default-subgraph-release-tag
+          yarn --cwd packages/sdk-core generate-graphql-schema:v1
           yarn build
+        env:
+          SUBGRAPH_RELEASE_TAG: v1
 
       - name: Publish ethereum-contracts package
         if: env.PUBLISH_ETHEREUM_CONTRACTS == 1

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -43,7 +43,10 @@
         "generate:abi-files": "rm -rf src/abi && mkdir -p src/abi && tasks/build-abi-json.sh",
         "generate:web3-types": "typechain --target=ethers-v5 --out-dir=./src/typechain \"./src/abi/**/*.json\"",
         "generate:graphql-types": "graphql-codegen --config subgraph-codegen.yml",
-        "generate-graphql-schema": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-feature-goerli > src/subgraph/schema.graphql",
+        "generate-graphql-schema": "yarn generate-graphql-schema:v1",
+        "generate-graphql-schema:v1": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli > src/subgraph/schema.graphql",
+        "generate-graphql-schema:dev": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-dev-goerli > src/subgraph/schema.graphql",
+        "generate-graphql-schema:feature": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-feature-goerli > src/subgraph/schema.graphql",
         "cloc": "sh tasks/cloc.sh"
     },
     "bugs": {


### PR DESCRIPTION
Why?
We had a situation where stable SDK release got published with wrong Subgraph schema, leading to a Subgraph query failing. The purpose of this PR is to automatically get the correct Subgraph schema as a build step which will hopefully lead to either build or tests failing.