### PR TITLE
CI Pre Release Draft Fix + CI Canary Cleanup

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -50,10 +50,12 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn lint
+          yarn --cwd packages/sdk-core generate-graphql-schema:dev
           yarn build
           yarn test
         env:
           POLYGON_MAINNET_PROVIDER_URL: ${{ secrets.POLYGON_MAINNET_PROVIDER_URL }}
+          SUBGRAPH_RELEASE_TAG: dev
 
   test-subgraph:
     uses: superfluid-finance/protocol-monorepo/.github/workflows/call.setup-deploy-and-test-local-subgraph.yml@dev

--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -10,7 +10,6 @@ on:
       - ".github/workflows/ci.canary.yml"
       - "codecov.yml"
       - ".github/workflows/call.setup-deploy-and-test-local-subgraph.yml"
-      - ".github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml"
 
 jobs:
   essential-build-and-test:

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -15,9 +15,7 @@ on:
   pull_request:
     paths:
       - "packages/**"
-      - ".github/workflows/ci.feature.yml"
-      - ".github/workflows/call.setup-deploy-and-test-local-subgraph.yml"
-      - ".github/workflows/call.test-sdk-core.yml"
+      - ".github/workflows/**"
 
 jobs:
   check:

--- a/.github/workflows/ci.pre-release-draft-test-sdk-core-subgraph-integration.yml
+++ b/.github/workflows/ci.pre-release-draft-test-sdk-core-subgraph-integration.yml
@@ -36,7 +36,9 @@ jobs:
     name: Build and Test Subgraph (Release Branch)
     with:
       local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
-      subgraph-release: v1
+      # we must use dev endpoint here because v1 endpoints won't be deployed yet
+      # we want to test what is to be deployed
+      subgraph-release: dev
 
   # ensure subgraph indexing is complete on all v1 endpoints before allowing sdk-core release
   check-subgraph-indexing-completeness:

--- a/.github/workflows/ci.pre-release-draft-test-sdk-core-subgraph-integration.yml
+++ b/.github/workflows/ci.pre-release-draft-test-sdk-core-subgraph-integration.yml
@@ -60,4 +60,7 @@ jobs:
     name: Build and test current subgraph release with previous sdk-core versions
     if: github.base_ref == 'release-subgraph-v1'
     with:
-      subgraph-release: v1
+      # we check with dev endpoint here because v1 endpoints won't be deployed yet
+      # we want to check here if it's safe to merge what we have in dev 
+      # endpoints to v1 (backwards compatible)
+      subgraph-release: dev

--- a/.github/workflows/ci.pre-release-sdk-core.yml
+++ b/.github/workflows/ci.pre-release-sdk-core.yml
@@ -1,18 +1,16 @@
-name: CI | Pre-Release Draft SDK Core-Subgraph Integration Test
+name: CI | Pre-Release Draft SDK Core Integration Test
 
 on:
   pull_request:
     branches:
-      - "release-subgraph-v1"
       - "release-sdk-core-stable"
     paths:
-      - "packages/subgraph/**"
       - "packages/sdk-core/**"
-      - ".github/workflows/ci.pre-release-draft-test-sdk-core-subgraph-integration.yml"
+      - "packages/subgraph/**"
+      - ".github/workflows/ci.pre-release-sdk-core.yml"
       - ".github/workflows/call.setup-deploy-and-test-local-subgraph.yml"
       - ".github/workflows/call.check-subgraph-indexing-statuses.yml"
       - ".github/workflows/call.test-sdk-core.yml"
-      - ".github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml"
 
 jobs:
   show-contexts:
@@ -36,9 +34,9 @@ jobs:
     name: Build and Test Subgraph (Release Branch)
     with:
       local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
-      # we must use dev endpoint here because v1 endpoints won't be deployed yet
-      # we want to test what is to be deployed
-      subgraph-release: dev
+      # we can use v1 endpoint here because v1 endpoints must be deployed if
+      # we want to merge 
+      subgraph-release: v1
 
   # ensure subgraph indexing is complete on all v1 endpoints before allowing sdk-core release
   check-subgraph-indexing-completeness:
@@ -55,14 +53,3 @@ jobs:
     if: github.base_ref == 'release-sdk-core-stable'
     with:
       subgraph-release: v1
-
-  # build and test live subgraph with previous sdk-core releases
-  build-and-test-live-subgraph-previous-releases:
-    uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
-    name: Build and test current subgraph release with previous sdk-core versions
-    if: github.base_ref == 'release-subgraph-v1'
-    with:
-      # we check with dev endpoint here because v1 endpoints won't be deployed yet
-      # we want to check here if it's safe to merge what we have in dev 
-      # endpoints to v1 (backwards compatible)
-      subgraph-release: dev

--- a/.github/workflows/ci.pre-release-subgraph.yml
+++ b/.github/workflows/ci.pre-release-subgraph.yml
@@ -1,0 +1,49 @@
+name: CI | Pre-Release Draft Subgraph Integration Test
+
+on:
+  pull_request:
+    branches:
+      - "release-subgraph-v1"
+    paths:
+      - "packages/sdk-core/**"
+      - "packages/subgraph/**"
+      - ".github/workflows/ci.pre-release-subgraph.yml"
+      - ".github/workflows/call.setup-deploy-and-test-local-subgraph.yml"
+      - ".github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml"
+
+jobs:
+  show-contexts:
+    name: Show Contexts
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Show contexts
+        run: |
+          echo github.event_name: ${{ github.event_name }}
+          echo github.sha: ${{ github.sha }}
+          echo github.repository: ${{ github.repository }}
+          echo github.ref: ${{ github.ref }}
+          echo github.head_ref: ${{ github.head_ref }}
+          echo github.base_ref: ${{ github.base_ref }}
+
+  # build and run sdk-core tests with local subgraph
+  build-and-test-local-subgraph:
+    uses: ./.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
+    name: Build and Test Subgraph (Release Branch)
+    with:
+      local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
+      # we must use dev endpoint here because v1 endpoints won't be deployed yet
+      # we want to test what is to be deployed
+      subgraph-release: dev
+
+  # build and test live subgraph with previous sdk-core releases
+  build-and-test-live-subgraph-previous-releases:
+    uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+    name: Build and test current subgraph release with previous sdk-core versions
+    if: github.base_ref == 'release-subgraph-v1'
+    with:
+      # we check with dev endpoint here because v1 endpoints won't be deployed yet
+      # we want to check here if it's safe to merge what we have in dev 
+      # endpoints to v1 endpoints (backwards compatible)
+      subgraph-release: dev

--- a/.github/workflows/handler.deploy-subgraph.yml
+++ b/.github/workflows/handler.deploy-subgraph.yml
@@ -17,14 +17,25 @@ jobs:
   build-and-test-tbd-subgraph-with-previous-release:
     uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
     name: Build and Test to be deployed Subgraph with previous SDK-Core Versions
+    # we only run this job when deploying to dev because we test this for v1
+    # in ci.pre-release-draft-test-sdk-core-subgraph-integration.yml
+    if: ${{ github.event.inputs.release_branch == "dev" }}
     with:
-      subgraph-release: ${{ github.events.inputs.release_branch }}
+      subgraph-release: feature
       local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
+
+  require-correct-branch-for-v1-release:
+    if: ${{ github.event.inputs.release_branch == "v1" }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Can only deploy to v1 from release-subgraph-v1"
+        if: ${{ github.ref_name != "release-subgraph-v1" }}
+        run: exit 1
 
   deploy-subgraph:
     name: Deploy Subgraph
 
-    needs: [build-and-test-tbd-subgraph-with-previous-release]
+    needs: [require-correct-branch-for-v1-release, build-and-test-tbd-subgraph-with-previous-release]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/handler.deploy-subgraph.yml
+++ b/.github/workflows/handler.deploy-subgraph.yml
@@ -17,25 +17,17 @@ jobs:
   build-and-test-tbd-subgraph-with-previous-release:
     uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
     name: Build and Test to be deployed Subgraph with previous SDK-Core Versions
-    # we only run this job when deploying to dev because we test this for v1
-    # in ci.pre-release-draft-test-sdk-core-subgraph-integration.yml
-    if: ${{ github.event.inputs.release_branch == "dev" }}
-    with:
-      subgraph-release: feature
-      local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
-
-  require-correct-branch-for-v1-release:
+    # we will run this job again when deploying to v1 endpoints just in case
+    # it is repetitive, but more important here than for dev endpoints
     if: ${{ github.event.inputs.release_branch == "v1" }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Can only deploy to v1 from release-subgraph-v1"
-        if: ${{ github.ref_name != "release-subgraph-v1" }}
-        run: exit 1
+    with:
+      subgraph-release: dev
+      local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
 
   deploy-subgraph:
     name: Deploy Subgraph
 
-    needs: [require-correct-branch-for-v1-release, build-and-test-tbd-subgraph-with-previous-release]
+    needs: [build-and-test-tbd-subgraph-with-previous-release]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
* remove ".github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml" from paths
* generate dev schema-graphql + include SUBGRAPH_RELEASE_TAG env variable
* use `dev` as `subgraph-release` in pre-release ci
* only run `build-and-test-tbd-subgraph-with-previous-release` for v1 subgraph endpoint deploy