### PR TITLE
Missing transfer events for liquidation

### DIFF
--- a/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluidToken.sol
+++ b/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluidToken.sol
@@ -280,9 +280,9 @@ interface ISuperfluidToken {
      * @param liquidationTypeData Data regarding the version of the liquidation schema and the type
      * @param liquidatorAccount Address of the executor of the liquidation
      * @param useDefaultRewardAccount Whether or not the default reward account receives the rewardAmount
-     * @param targetAccount Account of the stream sender
-     * @param rewardAmount The amount the reward recepient account will receive
-     * @param targetAccountBalanceDelta The amount the sender account balance should change by
+     * @param targetAccount Account to be liquidated
+     * @param rewardAmount The amount the rewarded account will receive
+     * @param targetAccountBalanceDelta The delta amount the target account balance should change by
      *
      * - If a bailout is required (bailoutAmount > 0)
      *   - the actual reward (single deposit) goes to the executor,

--- a/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluidToken.sol
+++ b/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluidToken.sol
@@ -312,7 +312,7 @@ interface ISuperfluidToken {
      * @param id Agreement ID
      * @param liquidatorAccount Address of the executor of the liquidation
      * @param targetAccount Account of the stream sender
-     * @param rewardAccount Account that collects the reward or bails out insolvent accounts
+     * @param rewardAmountReceiver Account that collects the reward or bails out insolvent accounts
      * @param rewardAmount The amount the reward recipient account balance should change by
      * @param targetAccountBalanceDelta The amount the sender account balance should change by
      * @param liquidationTypeData The encoded liquidation type data including the version (how to decode)
@@ -320,14 +320,14 @@ interface ISuperfluidToken {
      * NOTE:
      * Reward account rule:
      * - if the agreement is liquidated during the PIC period
-     *   - the rewardAccount will get the rewardAmount (remaining deposit), regardless of the liquidatorAccount
+     *   - the rewardAmountReceiver will get the rewardAmount (remaining deposit), regardless of the liquidatorAccount
      *   - the targetAccount will pay for the rewardAmount
      * - if the agreement is liquidated after the PIC period AND the targetAccount is solvent
-     *   - the liquidatorAccount will get the rewardAmount (remaining deposit)
+     *   - the rewardAmountReceiver will get the rewardAmount (remaining deposit)
      *   - the targetAccount will pay for the rewardAmount
      * - if the targetAccount is insolvent
      *   - the liquidatorAccount will get the rewardAmount (single deposit)
-     *   - the rewardAccount will pay for both the rewardAmount and bailoutAmount
+     *   - the default reward account (governance) will pay for both the rewardAmount and bailoutAmount
      *   - the targetAccount will receive the bailoutAmount
      */
     event AgreementLiquidatedV2(
@@ -335,7 +335,7 @@ interface ISuperfluidToken {
         bytes32 id,
         address indexed liquidatorAccount,
         address indexed targetAccount,
-        address rewardAccount,
+        address rewardAmountReceiver,
         uint256 rewardAmount,
         int256 targetAccountBalanceDelta,
         bytes liquidationTypeData

--- a/packages/ethereum-contracts/contracts/libs/EventsEmitter.sol
+++ b/packages/ethereum-contracts/contracts/libs/EventsEmitter.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity 0.8.13;
+
+/**
+ * @title Events Emitter Library
+ * @author Superfluid
+ * @dev A library used for emitting missing and unaccessable events.
+ * 
+ */
+library EventsEmitter {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    function emitTransfer(address from, address to, uint256 value) internal {
+        emit Transfer(from, to, value);
+    }
+}

--- a/packages/ethereum-contracts/contracts/superfluid/SuperfluidToken.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperfluidToken.sol
@@ -346,7 +346,7 @@ abstract contract SuperfluidToken is ISuperfluidToken
             // NOTE: useDefaultRewardAccount being true is undefined behavior
             // because the default reward account isn't receiving the rewardAmount by default
             assert(!useDefaultRewardAccount);
-            _balances[rewardAccount] -= rewardAmount.toInt256() - targetAccountBalanceDelta;
+            _balances[rewardAccount] -= (rewardAmount.toInt256() + targetAccountBalanceDelta);
             _balances[liquidatorAccount] += rewardAmount.toInt256();
             _balances[targetAccount] += targetAccountBalanceDelta;
             EventsEmitter.emitTransfer(rewardAccount, liquidatorAccount, rewardAmount);

--- a/packages/ethereum-contracts/contracts/superfluid/SuperfluidToken.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperfluidToken.sol
@@ -7,6 +7,7 @@ import { ISuperfluidGovernance } from "../interfaces/superfluid/ISuperfluidGover
 import { ISuperfluidToken } from "../interfaces/superfluid/ISuperfluidToken.sol";
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { EventsEmitter } from "../libs/EventsEmitter.sol";
 import { FixedSizeData } from "../libs/FixedSizeData.sol";
 
 /**
@@ -336,7 +337,6 @@ abstract contract SuperfluidToken is ISuperfluidToken
         if (useDefaultRewardAccount) {
             _balances[rewardAccount] = _balances[rewardAccount]
                 + rewardAmount.toInt256();
-            _assemblyEmitTransfer();
         } else {
             _balances[liquidatorAccount] = _balances[liquidatorAccount]
                 + rewardAmount.toInt256();
@@ -352,6 +352,16 @@ abstract contract SuperfluidToken is ISuperfluidToken
         // if targetAccountBalanceDelta > 0, it is a bailout, else a solvent liquidation
         _balances[targetAccount] = _balances[targetAccount]
             + targetAccountBalanceDelta;
+        
+        // PIRATE PERIOD
+        if (targetAccountBalanceDelta > 0) {
+            EventsEmitter.emitTransfer(rewardAccount, liquidatorAccount, rewardAmount);
+            EventsEmitter.emitTransfer(rewardAccount, targetAccount, uint256(targetAccountBalanceDelta));
+        } else {
+            // PIC / PLEB PERIOD
+            address rewardedAccount = useDefaultRewardAccount ? rewardAccount : liquidatorAccount;
+            EventsEmitter.emitTransfer(targetAccount, rewardedAccount, rewardAmount);
+        }
 
         emit AgreementLiquidatedV2(
             msg.sender,
@@ -363,36 +373,6 @@ abstract contract SuperfluidToken is ISuperfluidToken
             targetAccountBalanceDelta,
             liquidationTypeData
         );
-    }
-
-    function _assemblyEmitTransfer() internal {
-            assembly {
-                function decodeAsAddress(offset) -> v {
-                    v := decodeAsUint(offset)
-                    if iszero(iszero(and(v, not(0xffffffffffffffffffffffffffffffffffffffff)))) {
-                        revert(0, 0)
-                    }
-                }
-                function decodeAsUint(offset) -> v {
-                    let pos := add(4, mul(offset, 0x20))
-                    if lt(calldatasize(), add(pos, 0x20)) {
-                        revert(0, 0)
-                    }
-                    v := calldataload(pos)
-                }
-                function emitTransfer(from, to, amount) {
-                    // keccak256(Transfer(address,address,uint256))
-                    let signatureHash := 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef
-                    emitEvent(signatureHash, from, to, amount)
-                }
-
-                function emitEvent(signatureHash, indexed1, indexed2, nonIndexed) {
-                    mstore(0, nonIndexed)
-                    log3(0, 0x20, signatureHash, indexed1, indexed2)
-                }
-
-                emitTransfer(decodeAsAddress(0), decodeAsAddress(1), decodeAsUint(0))
-            }
     }
 
     /**************************************************************************

--- a/packages/ethereum-contracts/test/contracts/agreements/ConstantFlowAgreementV1.behavior.js
+++ b/packages/ethereum-contracts/test/contracts/agreements/ConstantFlowAgreementV1.behavior.js
@@ -267,8 +267,8 @@ async function _shouldChangeFlow({
                 )
             );
             if (isSenderSolvent) {
-                // the reward recipient role depends on whether the time is still
-                // in the patrician period, if it is, the reward recipient is the
+                // the rewardAmountReceiver depends on whether the time is still
+                // in the patrician period, if it is, the rewardAmountReceiver is the
                 // rewardAccount, otherwise it is the "agent" or the person who
                 // executes the liquidation
 
@@ -324,7 +324,7 @@ async function _shouldChangeFlow({
                         agreementClass: testenv.sf.agreements.cfa.address,
                         liquidatorAccount: cfaDataModel.roles.agent,
                         targetAccount: cfaDataModel.roles.sender,
-                        rewardAccount: isPatricianPeriod
+                        rewardAmountReceiver: isPatricianPeriod
                             ? cfaDataModel.roles.reward
                             : cfaDataModel.roles.agent,
                         rewardAmount: expectedRewardAmount.toString(),
@@ -400,7 +400,7 @@ async function _shouldChangeFlow({
                         agreementClass: testenv.sf.agreements.cfa.address,
                         liquidatorAccount: cfaDataModel.roles.agent,
                         targetAccount: cfaDataModel.roles.sender,
-                        rewardAccount: cfaDataModel.roles.agent,
+                        rewardAmountReceiver: cfaDataModel.roles.agent,
                         rewardAmount: expectedRewardAmount.toString(),
                         targetAccountBalanceDelta:
                             expectedBailoutAmount.toString(),

--- a/packages/ethereum-contracts/test/contracts/agreements/ConstantFlowAgreementV1.behavior.js
+++ b/packages/ethereum-contracts/test/contracts/agreements/ConstantFlowAgreementV1.behavior.js
@@ -334,6 +334,21 @@ async function _shouldChangeFlow({
                         liquidationTypeData,
                     }
                 );
+
+                // targetAccount (sender) transferring remaining deposit to
+                // rewardAccount / liquidatorAccount depending on isPatricianPeriod
+                await expectEvent.inTransaction(
+                    tx.tx,
+                    testenv.sf.contracts.ISuperToken,
+                    "Transfer",
+                    {
+                        from: cfaDataModel.roles.sender,
+                        to: isPatricianPeriod
+                            ? cfaDataModel.roles.reward
+                            : cfaDataModel.roles.agent,
+                        value: expectedRewardAmount.toString(),
+                    }
+                );
             } else {
                 const expectedRewardAmount = toBN(
                     cfaDataModel.flows.main.flowInfoBefore.deposit
@@ -390,6 +405,31 @@ async function _shouldChangeFlow({
                         targetAccountBalanceDelta:
                             expectedBailoutAmount.toString(),
                         liquidationTypeData,
+                    }
+                );
+
+                // reward account transferring the single flow deposit to the
+                // liquidator (agent)
+                await expectEvent.inTransaction(
+                    tx.tx,
+                    testenv.sf.contracts.ISuperToken,
+                    "Transfer",
+                    {
+                        from: cfaDataModel.roles.reward,
+                        to: cfaDataModel.roles.agent,
+                        value: expectedRewardAmount.toString(),
+                    }
+                );
+
+                // reward account bailing out the targetAccount (sender)
+                await expectEvent.inTransaction(
+                    tx.tx,
+                    testenv.sf.contracts.ISuperToken,
+                    "Transfer",
+                    {
+                        from: cfaDataModel.roles.reward,
+                        to: cfaDataModel.roles.sender,
+                        value: expectedBailoutAmount.toString(),
                     }
                 );
             }

--- a/packages/ethereum-contracts/test/contracts/agreements/ConstantFlowAgreementV1.test.js
+++ b/packages/ethereum-contracts/test/contracts/agreements/ConstantFlowAgreementV1.test.js
@@ -990,7 +990,7 @@ describe("Using ConstantFlowAgreement v1", function () {
                     r.tx,
                     t.sf.contracts.ISuperToken,
                     "AgreementLiquidatedV2",
-                    {rewardAccount: admin}
+                    {rewardAmountReceiver: admin}
                 );
 
                 // reward account (here: admin) should have received the deposit
@@ -1044,7 +1044,7 @@ describe("Using ConstantFlowAgreement v1", function () {
                     r.tx,
                     t.sf.contracts.ISuperToken,
                     "AgreementLiquidatedV2",
-                    {rewardAccount: admin}
+                    {rewardAmountReceiver: admin}
                 );
 
                 // reward account (here: admin) should have received the deposit
@@ -1108,7 +1108,7 @@ describe("Using ConstantFlowAgreement v1", function () {
                     r.tx,
                     t.sf.contracts.ISuperToken,
                     "AgreementLiquidatedV2",
-                    {rewardAccount: admin}
+                    {rewardAmountReceiver: admin}
                 );
 
                 // reward account (here: admin) should have received the deposit
@@ -1162,7 +1162,7 @@ describe("Using ConstantFlowAgreement v1", function () {
                     r.tx,
                     t.sf.contracts.ISuperToken,
                     "AgreementLiquidatedV2",
-                    {rewardAccount: t.aliases[agent]}
+                    {rewardAmountReceiver: t.aliases[agent]}
                 );
 
                 // reward account (here: agent) should have received the deposit
@@ -1223,7 +1223,7 @@ describe("Using ConstantFlowAgreement v1", function () {
                     r.tx,
                     t.sf.contracts.ISuperToken,
                     "AgreementLiquidatedV2",
-                    {rewardAccount: t.aliases[agent]}
+                    {rewardAmountReceiver: t.aliases[agent]}
                 );
 
                 // reward account (here: agent) should have received the deposit
@@ -1286,7 +1286,7 @@ describe("Using ConstantFlowAgreement v1", function () {
                     r.tx,
                     t.sf.contracts.ISuperToken,
                     "AgreementLiquidatedV2",
-                    {rewardAccount: t.aliases[agent]}
+                    {rewardAmountReceiver: t.aliases[agent]}
                 );
 
                 // reward account (here: agent) should have received the deposit
@@ -1333,7 +1333,7 @@ describe("Using ConstantFlowAgreement v1", function () {
                     r.tx,
                     t.sf.contracts.ISuperToken,
                     "AgreementLiquidatedV2",
-                    {rewardAccount: t.aliases[agent]}
+                    {rewardAmountReceiver: t.aliases[agent]}
                 );
 
                 // reward account (here: agent) should have received the deposit
@@ -1385,7 +1385,7 @@ describe("Using ConstantFlowAgreement v1", function () {
                     r.tx,
                     t.sf.contracts.ISuperToken,
                     "AgreementLiquidatedV2",
-                    {rewardAccount: t.aliases[agent]}
+                    {rewardAmountReceiver: t.aliases[agent]}
                 );
             });
 

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -46,7 +46,7 @@
         "generate:graphql-types": "graphql-codegen --config subgraph-codegen.yml",
         "generate-graphql-schema": "yarn generate-graphql-schema:v1",
         "generate-graphql-schema:v1": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic > src/subgraph/schema.graphql",
-        "generate-graphql-schema:dev": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-dev-matic > src/subgraph/schema.graphql",
+        "generate-graphql-schema:dev": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-dev-goerli > src/subgraph/schema.graphql",
         "generate-graphql-schema:feature": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-feature-goerli > src/subgraph/schema.graphql",
         "cloc": "sh tasks/cloc.sh"
     },

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -47,7 +47,7 @@
         "generate-graphql-schema": "yarn generate-graphql-schema:v1",
         "generate-graphql-schema:v1": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic > src/subgraph/schema.graphql",
         "generate-graphql-schema:dev": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-dev-matic > src/subgraph/schema.graphql",
-        "generate-graphql-schema:feature": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-feature-matic > src/subgraph/schema.graphql",
+        "generate-graphql-schema:feature": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-feature-goerli > src/subgraph/schema.graphql",
         "cloc": "sh tasks/cloc.sh"
     },
     "bugs": {

--- a/packages/sdk-core/src/events.ts
+++ b/packages/sdk-core/src/events.ts
@@ -185,7 +185,7 @@ export interface AgreementLiquidatedV2Event extends EventBase {
     agreementClass: string;
     agreementId: string;
     targetAccount: string;
-    rewardAccount: string;
+    rewardAmountReceiver: string;
     rewardAmount: string;
     targetAccountBalanceDelta: string;
     version: string;

--- a/packages/sdk-core/src/mapGetAllEventsQueryEvents.ts
+++ b/packages/sdk-core/src/mapGetAllEventsQueryEvents.ts
@@ -74,7 +74,7 @@ export const mapGetAllEventsQueryEvents = (
                     agreementClass: x.agreementClass,
                     agreementId: x.agreementId,
                     targetAccount: x.targetAccount,
-                    rewardAccount: x.rewardAccount,
+                    rewardAmountReceiver: x.rewardAmountReceiver,
                     rewardAmount: x.rewardAmount,
                     targetAccountBalanceDelta: x.targetAccountBalanceDelta,
                     version: x.version,

--- a/packages/sdk-core/src/subgraph/events/events.graphql
+++ b/packages/sdk-core/src/subgraph/events/events.graphql
@@ -1158,7 +1158,7 @@ fragment agreementLiquidatedV2Event on AgreementLiquidatedV2Event {
     agreementClass
     agreementId
     targetAccount
-    rewardAccount
+    rewardAmountReceiver
     rewardAmount
     targetAccountBalanceDelta
     version

--- a/packages/sdk-core/src/subgraph/queries/getAllEvents.graphql
+++ b/packages/sdk-core/src/subgraph/queries/getAllEvents.graphql
@@ -284,7 +284,7 @@ query getAllEvents(
             agreementClass
             agreementId
             targetAccount
-            rewardAccount
+            rewardAmountReceiver
             rewardAmount
             targetAccountBalanceDelta
             version

--- a/packages/sdk-core/src/subgraph/schema.graphql
+++ b/packages/sdk-core/src/subgraph/schema.graphql
@@ -27,7 +27,7 @@ type _Meta_ {
   will be null if the _meta field has a block constraint that asks for
   a block number. It will be filled if the _meta field has no block constraint
   and therefore asks for the latest  block
-
+  
   """
   block: _Block_!
 
@@ -62,7 +62,7 @@ type Account {
 
   """
   Indicates whether the address/account is a super app.
-
+  
   """
   isSuperApp: Boolean!
   inflows(skip: Int = 0, first: Int = 100, orderBy: Stream_orderBy, orderDirection: OrderDirection, where: Stream_filter): [Stream!]!
@@ -121,6 +121,9 @@ input Account_filter {
   isSuperApp_not: Boolean
   isSuperApp_in: [Boolean!]
   isSuperApp_not_in: [Boolean!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum Account_orderBy {
@@ -149,7 +152,7 @@ interaction with a `token`.
 type AccountTokenSnapshot {
   """
   ID composed of: accountID-tokenID
-
+  
   """
   id: ID!
   updatedAtTimestamp: BigInt!
@@ -159,80 +162,80 @@ type AccountTokenSnapshot {
   isLiquidationEstimateOptimistic, If `totalSubscriptionsWithUnits > 0`, it is true.
   Optimistic means that it is the earliest time the user will be liquidated as
   they may receive ongoing distributions which aren't tracked by the subgraph
-
+  
   """
   isLiquidationEstimateOptimistic: Boolean!
 
   """
   Optimistic liquidation estimation property.
-
+  
   """
   maybeCriticalAtTimestamp: BigInt!
 
   """
   The number of currently open streams.
-
+  
   """
   totalNumberOfActiveStreams: Int!
 
   """
   The number of all-time closed streams.
-
+  
   """
   totalNumberOfClosedStreams: Int!
 
   """
   The current (as of updatedAt) number of subscriptions with units allocated to them tied to this `account`.
-
+  
   """
   totalSubscriptionsWithUnits: Int!
 
   """
   Counts all currently (as of updatedAt) approved subscriptions whether or not they have units.
-
+  
   """
   totalApprovedSubscriptions: Int!
 
   """
   Balance of `account` as of `updatedAtTimestamp`/`updatedAtBlock`.
-
+  
   """
   balanceUntilUpdatedAt: BigInt!
 
   """
   The total deposit this account has held by the CFA agreement for `account` active streams.
-
+  
   """
   totalDeposit: BigInt!
 
   """
   The total net flow rate of the `account` as of `updatedAtTimestamp`/`updatedAtBlock`.
-
+  
   """
   totalNetFlowRate: BigInt!
 
   """
   The total inflow rate (receive flowRate per second) of the `account`.
-
+  
   """
   totalInflowRate: BigInt!
 
   """
   The total outflow rate (send flowrate per second) of the `account`.
-
+  
   """
   totalOutflowRate: BigInt!
 
   """
   The total amount of `token` streamed to this `account` until
   the `updatedAtTimestamp`/`updatedAtBlock`.
-
+  
   """
   totalAmountStreamedUntilUpdatedAt: BigInt!
 
   """
   The total amount of `token` this `account` has transferred.
-
+  
   """
   totalAmountTransferredUntilUpdatedAt: BigInt!
   account: Account!
@@ -406,6 +409,9 @@ input AccountTokenSnapshot_filter {
   token_ends_with_nocase: String
   token_not_ends_with: String
   token_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum AccountTokenSnapshot_orderBy {
@@ -446,74 +452,74 @@ type AccountTokenSnapshotLog {
 
   """
   Optimistic liquidation estimation property.
-
+  
   """
   maybeCriticalAtTimestamp: BigInt!
 
   """
   The current (as of timestamp) number of currently open streams.
-
+  
   """
   totalNumberOfActiveStreams: Int!
 
   """
   The current (as of timestamp) number of all-time closed streams.
-
+  
   """
   totalNumberOfClosedStreams: Int!
 
   """
   The current (as of timestamp) number of subscriptions with units allocated to them tied to this `account`.
-
+  
   """
   totalSubscriptionsWithUnits: Int!
 
   """
   Counts all currently (as of timestamp) approved subscriptions whether or not they have units.
-
+  
   """
   totalApprovedSubscriptions: Int!
 
   """
   Balance of `account` as of `timestamp`/`block`.
-
+  
   """
   balance: BigInt!
 
   """
   The total (as of timestamp) deposit this account has held by the CFA agreement for `account` active streams.
-
+  
   """
   totalDeposit: BigInt!
 
   """
   The total (as of timestamp) net flow rate of the `account` as of `timestamp`/`block`.
-
+  
   """
   totalNetFlowRate: BigInt!
 
   """
   The total (as of timestamp) inflow rate (receive flowRate per second) of the `account`.
-
+  
   """
   totalInflowRate: BigInt!
 
   """
   The total (as of timestamp) outflow rate (send flowrate per second) of the `account`.
-
+  
   """
   totalOutflowRate: BigInt!
 
   """
   The total (as of timestamp) amount of `token` streamed to this `account` until
   the `timestamp`/`block`.
-
+  
   """
   totalAmountStreamed: BigInt!
 
   """
   The total (as of timestamp) amount of `token` this `account` has transferred.
-
+  
   """
   totalAmountTransferred: BigInt!
   account: Account!
@@ -744,6 +750,9 @@ input AccountTokenSnapshotLog_filter {
   accountTokenSnapshot_ends_with_nocase: String
   accountTokenSnapshot_not_ends_with: String
   accountTokenSnapshot_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum AccountTokenSnapshotLog_orderBy {
@@ -779,7 +788,7 @@ type AgreementClassRegisteredEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -874,6 +883,9 @@ input AgreementClassRegisteredEvent_filter {
   code_not_in: [Bytes!]
   code_contains: Bytes
   code_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum AgreementClassRegisteredEvent_orderBy {
@@ -897,7 +909,7 @@ type AgreementClassUpdatedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -992,6 +1004,9 @@ input AgreementClassUpdatedEvent_filter {
   code_not_in: [Bytes!]
   code_contains: Bytes
   code_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum AgreementClassUpdatedEvent_orderBy {
@@ -1015,7 +1030,7 @@ type AgreementLiquidatedByEvent implements Event {
 
   """
   Holds the token, liquidatorAccount, penaltyAccount and bondAccount addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -1156,6 +1171,9 @@ input AgreementLiquidatedByEvent_filter {
   bailoutAmount_lte: BigInt
   bailoutAmount_in: [BigInt!]
   bailoutAmount_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum AgreementLiquidatedByEvent_orderBy {
@@ -1184,8 +1202,8 @@ type AgreementLiquidatedV2Event implements Event {
   name: String!
 
   """
-  Holds the token, liquidatorAccount, targetAccount and rewardAccount addresses.
-
+  Holds the token, liquidatorAccount, targetAccount and rewardAmountReceiver addresses.
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -1196,7 +1214,7 @@ type AgreementLiquidatedV2Event implements Event {
   agreementClass: Bytes!
   agreementId: Bytes!
   targetAccount: Bytes!
-  rewardAccount: Bytes!
+  rewardAmountReceiver: Bytes!
   rewardAmount: BigInt!
   targetAccountBalanceDelta: BigInt!
   version: BigInt!
@@ -1306,12 +1324,12 @@ input AgreementLiquidatedV2Event_filter {
   targetAccount_not_in: [Bytes!]
   targetAccount_contains: Bytes
   targetAccount_not_contains: Bytes
-  rewardAccount: Bytes
-  rewardAccount_not: Bytes
-  rewardAccount_in: [Bytes!]
-  rewardAccount_not_in: [Bytes!]
-  rewardAccount_contains: Bytes
-  rewardAccount_not_contains: Bytes
+  rewardAmountReceiver: Bytes
+  rewardAmountReceiver_not: Bytes
+  rewardAmountReceiver_in: [Bytes!]
+  rewardAmountReceiver_not_in: [Bytes!]
+  rewardAmountReceiver_contains: Bytes
+  rewardAmountReceiver_not_contains: Bytes
   rewardAmount: BigInt
   rewardAmount_not: BigInt
   rewardAmount_gt: BigInt
@@ -1344,6 +1362,9 @@ input AgreementLiquidatedV2Event_filter {
   liquidationType_lte: Int
   liquidationType_in: [Int!]
   liquidationType_not_in: [Int!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum AgreementLiquidatedV2Event_orderBy {
@@ -1360,7 +1381,7 @@ enum AgreementLiquidatedV2Event_orderBy {
   agreementClass
   agreementId
   targetAccount
-  rewardAccount
+  rewardAmountReceiver
   rewardAmount
   targetAccountBalanceDelta
   version
@@ -1375,7 +1396,7 @@ type AppRegisteredEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -1463,6 +1484,9 @@ input AppRegisteredEvent_filter {
   app_not_in: [Bytes!]
   app_contains: Bytes
   app_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum AppRegisteredEvent_orderBy {
@@ -1481,22 +1505,14 @@ scalar BigDecimal
 
 scalar BigInt
 
-"""The block at which the query should be executed."""
 input Block_height {
-  """Value containing a block hash"""
   hash: Bytes
-
-  """Value containing a block number"""
   number: Int
-
-  """
-  Value containing the minimum block number.
-  In the case of `number_gte`, the query will be executed on the latest block only if
-  the subgraph has progressed to or past the minimum block number.
-  Defaults to the latest block when omitted.
-
-  """
   number_gte: Int
+}
+
+input BlockChangedFilter {
+  number_gte: Int!
 }
 
 type BurnedEvent implements Event {
@@ -1507,7 +1523,7 @@ type BurnedEvent implements Event {
 
   """
   Holds the token and from addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -1625,6 +1641,9 @@ input BurnedEvent_filter {
   operatorData_not_in: [Bytes!]
   operatorData_contains: Bytes
   operatorData_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum BurnedEvent_orderBy {
@@ -1653,7 +1672,7 @@ type CFAv1LiquidationPeriodChangedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -1762,6 +1781,9 @@ input CFAv1LiquidationPeriodChangedEvent_filter {
   liquidationPeriod_lte: BigInt
   liquidationPeriod_in: [BigInt!]
   liquidationPeriod_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum CFAv1LiquidationPeriodChangedEvent_orderBy {
@@ -1787,7 +1809,7 @@ type ConfigChangedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -1903,6 +1925,9 @@ input ConfigChangedEvent_filter {
   value_lte: BigInt
   value_in: [BigInt!]
   value_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum ConfigChangedEvent_orderBy {
@@ -1929,7 +1954,7 @@ type CustomSuperTokenCreatedEvent implements Event {
 
   """
   Holds the token address.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -2017,6 +2042,9 @@ input CustomSuperTokenCreatedEvent_filter {
   token_not_in: [Bytes!]
   token_contains: Bytes
   token_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum CustomSuperTokenCreatedEvent_orderBy {
@@ -2046,7 +2074,7 @@ interface Event {
 
   """
   Holds the addresses for accounts that were impacted by the event.
-
+  
   """
   addresses: [Bytes!]!
   timestamp: BigInt!
@@ -2126,6 +2154,9 @@ input Event_filter {
   transactionHash_not_in: [Bytes!]
   transactionHash_contains: Bytes
   transactionHash_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum Event_orderBy {
@@ -2146,7 +2177,7 @@ FlowOperator: A higher order entity that of a flow operator for an `AccountToken
 type FlowOperator {
   """
   ID composed of: flowOperator - token - sender
-
+  
   """
   id: ID!
   createdAtTimestamp: BigInt!
@@ -2157,7 +2188,7 @@ type FlowOperator {
   """
   The permissions granted to the `flowOperator`.
   Octo bitmask representation.
-
+  
   """
   permissions: Int!
 
@@ -2165,7 +2196,7 @@ type FlowOperator {
   The flow rate allowance granted to the `flowOperator`
   by the `sender`. This can be reset if the `sender`
   updates the `flowOperator` flow rate allowance.
-
+  
   """
   flowRateAllowanceGranted: BigInt!
 
@@ -2175,7 +2206,7 @@ type FlowOperator {
   (if they increase flowRate or create a new flow)
   and can only be reset if the `sender` updates the flow
   rate allowance.
-
+  
   """
   flowRateAllowanceRemaining: BigInt!
   flowOperator: Bytes!
@@ -2316,6 +2347,9 @@ input FlowOperator_filter {
   accountTokenSnapshot_ends_with_nocase: String
   accountTokenSnapshot_not_ends_with: String
   accountTokenSnapshot_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum FlowOperator_orderBy {
@@ -2342,7 +2376,7 @@ type FlowOperatorUpdatedEvent implements Event {
 
   """
   Holds the token, sender, and flowOperator addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -2351,7 +2385,7 @@ type FlowOperatorUpdatedEvent implements Event {
 
   """
   The address of the `token` being streamed.
-
+  
   """
   token: Bytes!
   sender: Bytes!
@@ -2359,7 +2393,7 @@ type FlowOperatorUpdatedEvent implements Event {
   """
   The permissions granted to the `flowOperator`.
   Octo bitmask representation.
-
+  
   """
   permissions: Int!
   flowRateAllowance: BigInt!
@@ -2487,6 +2521,9 @@ input FlowOperatorUpdatedEvent_filter {
   flowOperator_ends_with_nocase: String
   flowOperator_not_ends_with: String
   flowOperator_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum FlowOperatorUpdatedEvent_orderBy {
@@ -2518,7 +2555,7 @@ type FlowUpdatedEvent implements Event {
 
   """
   Holds the token, sender and receiver addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -2527,7 +2564,7 @@ type FlowUpdatedEvent implements Event {
 
   """
   The address of the `token` being streamed.
-
+  
   """
   token: Bytes!
   sender: Bytes!
@@ -2537,13 +2574,13 @@ type FlowUpdatedEvent implements Event {
   The address that is triggering the flow update.
   This will be the zero address until the flowOperator
   feature is live.
-
+  
   """
   flowOperator: Bytes!
 
   """
   The flow rate per second.
-
+  
   """
   flowRate: BigInt!
   totalSenderFlowRate: BigInt!
@@ -2553,7 +2590,7 @@ type FlowUpdatedEvent implements Event {
 
   """
   The previous flow rate.
-
+  
   """
   oldFlowRate: BigInt!
 
@@ -2562,20 +2599,20 @@ type FlowUpdatedEvent implements Event {
   0 = create
   1 = update
   2 = terminate
-
+  
   """
   type: Int!
 
   """
   The total amount streamed until the timestamp
   for the Stream entity linked to this event.
-
+  
   """
   totalAmountStreamedUntilTimestamp: BigInt!
 
   """
   The stream entity which is being modified.
-
+  
   """
   stream: Stream!
 }
@@ -2759,6 +2796,9 @@ input FlowUpdatedEvent_filter {
   stream_ends_with_nocase: String
   stream_not_ends_with: String
   stream_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum FlowUpdatedEvent_orderBy {
@@ -2797,7 +2837,7 @@ type GovernanceReplacedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   oldGovernance: Bytes!
   newGovernance: Bytes!
@@ -2888,6 +2928,9 @@ input GovernanceReplacedEvent_filter {
   newGovernance_not_in: [Bytes!]
   newGovernance_contains: Bytes
   newGovernance_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum GovernanceReplacedEvent_orderBy {
@@ -2910,7 +2953,7 @@ Index: An Index higher order entity.
 type Index {
   """
   ID composed of: publisherAddress-tokenAddress-indexId
-
+  
   """
   id: ID!
   createdAtTimestamp: BigInt!
@@ -2920,14 +2963,14 @@ type Index {
 
   """
   indexId is not the id of the `Index` entity.
-
+  
   """
   indexId: BigInt!
   indexValue: BigInt!
 
   """
   The number of subscriptions which have units allocated to them on the `Index`.
-
+  
   """
   totalSubscriptionsWithUnits: Int!
 
@@ -2935,7 +2978,7 @@ type Index {
   The number of units allocated by the `Index` that are pending.
   This refers to the current (as of updatedAt) `totalUnitsPending`
   - not all that has ever been pending.
-
+  
   """
   totalUnitsPending: BigInt!
 
@@ -2943,19 +2986,19 @@ type Index {
   The number of units allocated by the `Index` that are approved.
   This refers to the current (as of updatedAt) `totalUnitsApproved`
   - not all that has ever been approved.
-
+  
   """
   totalUnitsApproved: BigInt!
 
   """
   The sum of `totalUnitsPending` and `totalUnitsApproved`.
-
+  
   """
   totalUnits: BigInt!
 
   """
   The total amount distributed from this `Index`.
-
+  
   """
   totalAmountDistributedUntilUpdatedAt: BigInt!
   token: Token!
@@ -2964,13 +3007,13 @@ type Index {
   """
   The subscriptions of the index, it will include approved, unapproved
   and deleted subscriptions.
-
+  
   """
   subscriptions(skip: Int = 0, first: Int = 100, orderBy: IndexSubscription_orderBy, orderDirection: OrderDirection, where: IndexSubscription_filter): [IndexSubscription!]!
 
   """
   IndexCreated event, there will only be one.
-
+  
   """
   indexCreatedEvent: IndexCreatedEvent!
   indexDistributionClaimedEvents(skip: Int = 0, first: Int = 100, orderBy: IndexDistributionClaimedEvent_orderBy, orderDirection: OrderDirection, where: IndexDistributionClaimedEvent_filter): [IndexDistributionClaimedEvent!]!
@@ -3137,6 +3180,9 @@ input Index_filter {
   indexCreatedEvent_ends_with_nocase: String
   indexCreatedEvent_not_ends_with: String
   indexCreatedEvent_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum Index_orderBy {
@@ -3171,7 +3217,7 @@ type IndexCreatedEvent implements Event {
 
   """
   Holds the token and publisher addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -3303,6 +3349,9 @@ input IndexCreatedEvent_filter {
   index_ends_with_nocase: String
   index_not_ends_with: String
   index_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum IndexCreatedEvent_orderBy {
@@ -3329,7 +3378,7 @@ type IndexDistributionClaimedEvent implements Event {
 
   """
   Holds the token, publisher and subscriber addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -3470,6 +3519,9 @@ input IndexDistributionClaimedEvent_filter {
   index_ends_with_nocase: String
   index_not_ends_with: String
   index_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum IndexDistributionClaimedEvent_orderBy {
@@ -3497,7 +3549,7 @@ type IndexSubscribedEvent implements Event {
 
   """
   Holds the token, publisher and subscriber addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -3636,6 +3688,9 @@ input IndexSubscribedEvent_filter {
   index_ends_with_nocase: String
   index_not_ends_with: String
   index_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum IndexSubscribedEvent_orderBy {
@@ -3663,7 +3718,7 @@ IndexSubscription: A higher order entity that contains subscription data for a `
 type IndexSubscription {
   """
   ID composed of: subscriberAddress-publisherAddress-tokenAddress-IndexId
-
+  
   """
   id: ID!
   createdAtTimestamp: BigInt!
@@ -3675,21 +3730,21 @@ type IndexSubscription {
   """
   Approved subscriptions don't require subscribers to claim tokens that are distributed from
   the publisher.
-
+  
   """
   approved: Boolean!
 
   """
   If units is 0, it indicates that the subscription is "deleted". They are no longer
   subscribed to the index.
-
+  
   """
   units: BigInt!
 
   """
   The total amount of tokens you've received via IDA until
   `updatedAtTimestamp`/`updatedAtBlock`.
-
+  
   """
   totalAmountReceivedUntilUpdatedAt: BigInt!
 
@@ -3698,14 +3753,14 @@ type IndexSubscription {
   `index.updatedAtTimestamp`. The formula to get this value is:
   `IndexSubscription.totalAmountReceivedUntilUpdatedAt + ((index.newIndexValue -
   indexSubscription.indexValueUntilUpdatedAt) * indexSubscription.units)`.
-
+  
   """
   indexValueUntilUpdatedAt: BigInt!
   index: Index!
 
   """
   IndexSubscription approved events on the subscription.
-
+  
   """
   subscriptionApprovedEvents(skip: Int = 0, first: Int = 100, orderBy: SubscriptionApprovedEvent_orderBy, orderDirection: OrderDirection, where: SubscriptionApprovedEvent_filter): [SubscriptionApprovedEvent!]!
   subscriptionDistributionClaimedEvents(skip: Int = 0, first: Int = 100, orderBy: SubscriptionDistributionClaimedEvent_orderBy, orderDirection: OrderDirection, where: SubscriptionDistributionClaimedEvent_filter): [SubscriptionDistributionClaimedEvent!]!
@@ -3822,6 +3877,9 @@ input IndexSubscription_filter {
   index_ends_with_nocase: String
   index_not_ends_with: String
   index_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum IndexSubscription_orderBy {
@@ -3850,7 +3908,7 @@ type IndexUnitsUpdatedEvent implements Event {
 
   """
   Holds the token, publisher and subscriber addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -4007,6 +4065,9 @@ input IndexUnitsUpdatedEvent_filter {
   index_ends_with_nocase: String
   index_not_ends_with: String
   index_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum IndexUnitsUpdatedEvent_orderBy {
@@ -4036,7 +4097,7 @@ type IndexUnsubscribedEvent implements Event {
 
   """
   Holds the token, publisher and subscriber addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -4175,6 +4236,9 @@ input IndexUnsubscribedEvent_filter {
   index_ends_with_nocase: String
   index_not_ends_with: String
   index_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum IndexUnsubscribedEvent_orderBy {
@@ -4202,7 +4266,7 @@ type IndexUpdatedEvent implements Event {
 
   """
   Holds the token and publisher addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -4370,6 +4434,9 @@ input IndexUpdatedEvent_filter {
   index_ends_with_nocase: String
   index_not_ends_with: String
   index_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum IndexUpdatedEvent_orderBy {
@@ -4400,7 +4467,7 @@ type JailEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -4497,6 +4564,9 @@ input JailEvent_filter {
   reason_lte: BigInt
   reason_in: [BigInt!]
   reason_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum JailEvent_orderBy {
@@ -4520,7 +4590,7 @@ type MintedEvent implements Event {
 
   """
   Holds the token, operator and to addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -4638,6 +4708,9 @@ input MintedEvent_filter {
   operatorData_not_in: [Bytes!]
   operatorData_contains: Bytes
   operatorData_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum MintedEvent_orderBy {
@@ -4670,7 +4743,7 @@ type PPPConfigurationChangedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -4788,6 +4861,9 @@ input PPPConfigurationChangedEvent_filter {
   patricianPeriod_lte: BigInt
   patricianPeriod_in: [BigInt!]
   patricianPeriod_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum PPPConfigurationChangedEvent_orderBy {
@@ -6860,7 +6936,7 @@ type RewardAddressChangedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -6967,6 +7043,9 @@ input RewardAddressChangedEvent_filter {
   rewardAddress_not_in: [Bytes!]
   rewardAddress_contains: Bytes
   rewardAddress_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum RewardAddressChangedEvent_orderBy {
@@ -6992,7 +7071,7 @@ type RoleAdminChangedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -7094,6 +7173,9 @@ input RoleAdminChangedEvent_filter {
   newAdminRole_not_in: [Bytes!]
   newAdminRole_contains: Bytes
   newAdminRole_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum RoleAdminChangedEvent_orderBy {
@@ -7118,7 +7200,7 @@ type RoleGrantedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -7220,6 +7302,9 @@ input RoleGrantedEvent_filter {
   sender_not_in: [Bytes!]
   sender_contains: Bytes
   sender_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum RoleGrantedEvent_orderBy {
@@ -7244,7 +7329,7 @@ type RoleRevokedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -7346,6 +7431,9 @@ input RoleRevokedEvent_filter {
   sender_not_in: [Bytes!]
   sender_contains: Bytes
   sender_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum RoleRevokedEvent_orderBy {
@@ -7370,7 +7458,7 @@ type SentEvent implements Event {
 
   """
   Holds the token, operator and from addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -7495,6 +7583,9 @@ input SentEvent_filter {
   operatorData_not_in: [Bytes!]
   operatorData_contains: Bytes
   operatorData_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SentEvent_orderBy {
@@ -7517,7 +7608,7 @@ enum SentEvent_orderBy {
 type SFMeta {
   """
   The id is the commit hash.
-
+  
   """
   id: ID!
   timestamp: BigInt!
@@ -7525,13 +7616,13 @@ type SFMeta {
 
   """
   Whether the branch is feature/dev/v1.
-
+  
   """
   configuration: String!
 
   """
   The branch the current deployment is coming from.
-
+  
   """
   branch: String!
 }
@@ -7601,6 +7692,9 @@ input SFMeta_filter {
   branch_ends_with_nocase: String
   branch_not_ends_with: String
   branch_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SFMeta_orderBy {
@@ -7622,7 +7716,7 @@ between the same `sender` and `receiver`.
 type Stream {
   """
   ID composed of: senderAddress-receiverAddress-tokenAddress-revisionIndex
-
+  
   """
   id: ID!
   createdAtTimestamp: BigInt!
@@ -7636,7 +7730,7 @@ type Stream {
   The amount streamed until `updatedAtTimestamp`/`updatedAtBlock`. The formula to get the current streamed
   amount is:
   `streamedUntilUpdatedAt + ((currentTime in seconds) - updatedAtTimestamp) * currentFlowRate`.
-
+  
   """
   streamedUntilUpdatedAt: BigInt!
   token: Token!
@@ -7771,6 +7865,9 @@ input Stream_filter {
   receiver_ends_with_nocase: String
   receiver_not_ends_with: String
   receiver_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum Stream_orderBy {
@@ -7796,7 +7893,7 @@ StreamPeriod: A higher order entity that represents a period of time in a Stream
 type StreamPeriod {
   """
   ID composed of: streamId - periodRevisionIndex
-
+  
   """
   id: ID!
   stream: Stream!
@@ -7811,7 +7908,7 @@ type StreamPeriod {
 
   """
   Following values are null until the StreamPeriod is terminated
-
+  
   """
   stoppedAtTimestamp: BigInt
   stoppedAtBlockNumber: BigInt
@@ -8004,6 +8101,9 @@ input StreamPeriod_filter {
   totalAmountStreamed_lte: BigInt
   totalAmountStreamed_in: [BigInt!]
   totalAmountStreamed_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum StreamPeriod_orderBy {
@@ -8054,6 +8154,9 @@ input StreamRevision_filter {
   periodRevisionIndex_lte: Int
   periodRevisionIndex_in: [Int!]
   periodRevisionIndex_not_in: [Int!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum StreamRevision_orderBy {
@@ -10116,7 +10219,7 @@ type SubscriptionApprovedEvent implements Event {
 
   """
   Holds the token, publisher and subscriber addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -10255,6 +10358,9 @@ input SubscriptionApprovedEvent_filter {
   subscription_ends_with_nocase: String
   subscription_not_ends_with: String
   subscription_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SubscriptionApprovedEvent_orderBy {
@@ -10282,7 +10388,7 @@ type SubscriptionDistributionClaimedEvent implements Event {
 
   """
   Holds the token, publisher and subscriber addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -10423,6 +10529,9 @@ input SubscriptionDistributionClaimedEvent_filter {
   subscription_ends_with_nocase: String
   subscription_not_ends_with: String
   subscription_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SubscriptionDistributionClaimedEvent_orderBy {
@@ -10450,7 +10559,7 @@ type SubscriptionRevokedEvent implements Event {
 
   """
   Holds the token, publisher and subscriber addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -10589,6 +10698,9 @@ input SubscriptionRevokedEvent_filter {
   subscription_ends_with_nocase: String
   subscription_not_ends_with: String
   subscription_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SubscriptionRevokedEvent_orderBy {
@@ -10616,7 +10728,7 @@ type SubscriptionUnitsUpdatedEvent implements Event {
 
   """
   Holds the token, publisher and subscriber addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -10773,6 +10885,9 @@ input SubscriptionUnitsUpdatedEvent_filter {
   subscription_ends_with_nocase: String
   subscription_not_ends_with: String
   subscription_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SubscriptionUnitsUpdatedEvent_orderBy {
@@ -10802,7 +10917,7 @@ type SuperTokenCreatedEvent implements Event {
 
   """
   Holds the token address.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -10890,6 +11005,9 @@ input SuperTokenCreatedEvent_filter {
   token_not_in: [Bytes!]
   token_contains: Bytes
   token_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SuperTokenCreatedEvent_orderBy {
@@ -10912,7 +11030,7 @@ type SuperTokenFactoryUpdatedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -11000,6 +11118,9 @@ input SuperTokenFactoryUpdatedEvent_filter {
   newFactory_not_in: [Bytes!]
   newFactory_contains: Bytes
   newFactory_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SuperTokenFactoryUpdatedEvent_orderBy {
@@ -11022,7 +11143,7 @@ type SuperTokenLogicCreatedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -11110,6 +11231,9 @@ input SuperTokenLogicCreatedEvent_filter {
   tokenLogic_not_in: [Bytes!]
   tokenLogic_contains: Bytes
   tokenLogic_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SuperTokenLogicCreatedEvent_orderBy {
@@ -11132,7 +11256,7 @@ type SuperTokenLogicUpdatedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -11227,6 +11351,9 @@ input SuperTokenLogicUpdatedEvent_filter {
   code_not_in: [Bytes!]
   code_contains: Bytes
   code_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum SuperTokenLogicUpdatedEvent_orderBy {
@@ -11250,7 +11377,7 @@ Superfluid's host contract address set as the host).
 type Token {
   """
   ID: the token address
-
+  
   """
   id: ID!
   createdAtTimestamp: BigInt!
@@ -11262,20 +11389,20 @@ type Token {
 
   """
   This indicates whether the token is a part of our resolver list.
-
+  
   """
   isListed: Boolean!
 
   """
   The address of the underlying ERC20 token.
-
+  
   """
   underlyingAddress: Bytes!
 
   """
   The underlying ERC20 token for a SuperToken or
   null for a regular ERC20 token.
-
+  
   """
   underlyingToken: Token
 }
@@ -11387,6 +11514,9 @@ input Token_filter {
   underlyingToken_ends_with_nocase: String
   underlyingToken_not_ends_with: String
   underlyingToken_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum Token_orderBy {
@@ -11411,7 +11541,7 @@ type TokenDowngradedEvent implements Event {
 
   """
   Holds the token and account addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -11528,6 +11658,9 @@ input TokenDowngradedEvent_filter {
   amount_lte: BigInt
   amount_in: [BigInt!]
   amount_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum TokenDowngradedEvent_orderBy {
@@ -11551,7 +11684,7 @@ TokenStatistic: An aggregate entity which aggregates data of a single `token`.
 type TokenStatistic {
   """
   id: token address
-
+  
   """
   id: ID!
   updatedAtTimestamp: BigInt!
@@ -11559,76 +11692,76 @@ type TokenStatistic {
 
   """
   The total number of currently active `token` streams.
-
+  
   """
   totalNumberOfActiveStreams: Int!
 
   """
   The all-time number of closed streams.
-
+  
   """
   totalNumberOfClosedStreams: Int!
 
   """
   The total number of Indexes created with `token`.
-
+  
   """
   totalNumberOfIndexes: Int!
 
   """
   The total number of "active" (has greater than 0 units and has distributed it at
   least once) Indexes created with `token`.
-
+  
   """
   totalNumberOfActiveIndexes: Int!
 
   """
   The number of subscriptions which have units allocated to them
   created with Indexes that distribute `token`.
-
+  
   """
   totalSubscriptionsWithUnits: Int!
 
   """
   Counts all approved subscriptions whether or not they have units.
-
+  
   """
   totalApprovedSubscriptions: Int!
 
   """
   The total deposit held by the CFA agreement for this particular `token`.
-
+  
   """
   totalDeposit: BigInt!
 
   """
   The total outflow rate of the `token` (how much value is being moved).
-
+  
   """
   totalOutflowRate: BigInt!
 
   """
   The all-time total amount streamed until the `updatedAtTimestamp`/`updatedAtBlock`.
-
+  
   """
   totalAmountStreamedUntilUpdatedAt: BigInt!
 
   """
   The all-time total amount transferred until the `updatedAtTimestamp`/`updatedAtBlock`.
-
+  
   """
   totalAmountTransferredUntilUpdatedAt: BigInt!
 
   """
   The all-time total amount distributed until the `updatedAtTimestamp`/`updatedAtBlock`.
-
+  
   """
   totalAmountDistributedUntilUpdatedAt: BigInt!
 
   """
   The total supply of the token - this is impacted by users upgrading/downgrading their
   tokens.
-
+  
   """
   totalSupply: BigInt!
   token: Token!
@@ -11775,6 +11908,9 @@ input TokenStatistic_filter {
   token_ends_with_nocase: String
   token_not_ends_with: String
   token_not_ends_with_nocase: String
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum TokenStatistic_orderBy {
@@ -11805,7 +11941,7 @@ type TokenUpgradedEvent implements Event {
 
   """
   Holds the token and account addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -11922,6 +12058,9 @@ input TokenUpgradedEvent_filter {
   amount_lte: BigInt
   amount_in: [BigInt!]
   amount_not_in: [BigInt!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum TokenUpgradedEvent_orderBy {
@@ -11946,7 +12085,7 @@ type TransferEvent implements Event {
 
   """
   Holds the token, from and to addresses.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -12085,6 +12224,9 @@ input TransferEvent_filter {
   token_not_in: [Bytes!]
   token_contains: Bytes
   token_not_contains: Bytes
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum TransferEvent_orderBy {
@@ -12110,7 +12252,7 @@ type TrustedForwarderChangedEvent implements Event {
 
   """
   Empty addresses array.
-
+  
   """
   addresses: [Bytes!]!
   blockNumber: BigInt!
@@ -12222,6 +12364,9 @@ input TrustedForwarderChangedEvent_filter {
   enabled_not: Boolean
   enabled_in: [Boolean!]
   enabled_not_in: [Boolean!]
+
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
 }
 
 enum TrustedForwarderChangedEvent_orderBy {

--- a/packages/sdk-redux/src/reduxSlices/rtkQuery/cacheTags/invalidateSpecificCacheTagsForEvents.ts
+++ b/packages/sdk-redux/src/reduxSlices/rtkQuery/cacheTags/invalidateSpecificCacheTagsForEvents.ts
@@ -83,7 +83,7 @@ const getEventSpecificTags = (event: AllEvents, chainId: number) => {
                 createSpecificTags({
                     chainId,
                     address1: event.token,
-                    address2: event.rewardAccount,
+                    address2: event.rewardAmountReceiver,
                 }),
                 createSpecificTags({
                     chainId,

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -666,7 +666,7 @@ type AgreementLiquidatedV2Event implements Event @entity {
     name: String!
 
     """
-    Holds the token, liquidatorAccount, targetAccount and rewardAccount addresses.
+    Holds the token, liquidatorAccount, targetAccount and rewardAmountReceiver addresses.
     """
     addresses: [Bytes!]!
     blockNumber: BigInt!
@@ -677,7 +677,7 @@ type AgreementLiquidatedV2Event implements Event @entity {
     agreementClass: Bytes!
     agreementId: Bytes!
     targetAccount: Bytes!
-    rewardAccount: Bytes!
+    rewardAmountReceiver: Bytes!
     rewardAmount: BigInt!
     targetAccountBalanceDelta: BigInt!
     version: BigInt!

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -553,7 +553,8 @@ function updateATSBalanceAndUpdatedAt(
 /**
  * Updates the amount streamed, balance until updated at for the AccountTokenSnapshot
  * entity and also updates the updatedAt property on the account entity.
- * @dev Must call before updatedAt is updated.
+ * NOTE: call before the `updatedAt` property is updated otherwise you get incorrect data;
+ * NOTE: you should be calling updateTokenStatsStreamedUntilUpdatedAt whenever you call this
  */
 export function updateATSStreamedAndBalanceUntilUpdatedAt(
     accountAddress: Address,
@@ -589,6 +590,11 @@ export function updateATSStreamedAndBalanceUntilUpdatedAt(
     updateAccountUpdatedAt(accountAddress, block);
 }
 
+/**
+ * This function should always be called with updateATSStreamedAndBalanceUntilUpdatedAt
+ * @param tokenAddress 
+ * @param block 
+ */
 export function updateTokenStatsStreamedUntilUpdatedAt(
     tokenAddress: Address,
     block: ethereum.Block

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -603,6 +603,8 @@ export function updateTokenStatsStreamedUntilUpdatedAt(
         tokenStats.totalAmountStreamedUntilUpdatedAt.plus(
             amountStreamedSinceLastUpdatedAt
         );
+    tokenStats.updatedAtTimestamp = block.timestamp;
+    tokenStats.updatedAtBlockNumber = block.number;
     tokenStats.save();
 }
 

--- a/packages/subgraph/src/mappings/cfav1.ts
+++ b/packages/subgraph/src/mappings/cfav1.ts
@@ -1,11 +1,16 @@
-import {BigInt} from "@graphprotocol/graph-ts";
+import { BigInt } from "@graphprotocol/graph-ts";
 import {
     FlowOperatorUpdated,
     FlowUpdated,
     FlowUpdatedExtension,
     IConstantFlowAgreementV1,
 } from "../../generated/ConstantFlowAgreementV1/IConstantFlowAgreementV1";
-import {FlowOperatorUpdatedEvent, FlowUpdatedEvent, StreamPeriod, StreamRevision,} from "../../generated/schema";
+import {
+    FlowOperatorUpdatedEvent,
+    FlowUpdatedEvent,
+    StreamPeriod,
+    StreamRevision,
+} from "../../generated/schema";
 import {
     BIG_INT_ONE,
     BIG_INT_ZERO,
@@ -26,7 +31,7 @@ import {
     updateAggregateEntitiesStreamData,
     updateATSStreamedAndBalanceUntilUpdatedAt,
 } from "../mappingHelpers";
-import {getHostAddress} from "../addresses";
+import { getHostAddress } from "../addresses";
 
 enum FlowActionType {
     create,
@@ -316,7 +321,8 @@ export function handleStreamUpdated(event: FlowUpdated): void {
         tokenAddress,
         event.block
     );
-
+    // NOTE: EXCEPTION for not calling updateTokenStatsStreamedUntilUpdatedAt
+    // because updateAggregateEntitiesStreamData updates tokenStats.streamedUntilUpdatedAt
     updateAggregateEntitiesStreamData(
         senderAddress,
         receiverAddress,
@@ -328,8 +334,18 @@ export function handleStreamUpdated(event: FlowUpdated): void {
         isDelete,
         event.block
     );
-    createAccountTokenSnapshotLogEntity(event, senderAddress, tokenAddress, "FlowUpdated");
-    createAccountTokenSnapshotLogEntity(event, receiverAddress, tokenAddress, "FlowUpdated");
+    createAccountTokenSnapshotLogEntity(
+        event,
+        senderAddress,
+        tokenAddress,
+        "FlowUpdated"
+    );
+    createAccountTokenSnapshotLogEntity(
+        event,
+        receiverAddress,
+        tokenAddress,
+        "FlowUpdated"
+    );
 }
 
 // NOTE: This handler is run right after handleStreamUpdated as the FlowUpdatedExtension
@@ -416,5 +432,3 @@ export function updateFlowOperatorForFlowUpdated(
     }
     flowOperator.save();
 }
-
-

--- a/packages/subgraph/src/mappings/idav1.ts
+++ b/packages/subgraph/src/mappings/idav1.ts
@@ -1,4 +1,4 @@
-import {BigInt} from "@graphprotocol/graph-ts";
+import { BigInt } from "@graphprotocol/graph-ts";
 import {
     IndexCreated,
     IndexDistributionClaimed,
@@ -40,7 +40,7 @@ import {
     updateATSStreamedAndBalanceUntilUpdatedAt,
     updateTokenStatsStreamedUntilUpdatedAt,
 } from "../mappingHelpers";
-import {getHostAddress} from "../addresses";
+import { getHostAddress } from "../addresses";
 
 export function handleIndexCreated(event: IndexCreated): void {
     let hostAddress = getHostAddress();
@@ -79,7 +79,12 @@ export function handleIndexCreated(event: IndexCreated): void {
         event.block
     );
 
-    createAccountTokenSnapshotLogEntity(event, event.params.publisher, event.params.token, "IndexCreated");
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.publisher,
+        event.params.token,
+        "IndexCreated"
+    );
     createIndexCreatedEntity(event, index.id);
 }
 
@@ -152,7 +157,12 @@ export function handleIndexUpdated(event: IndexUpdated): void {
         event.params.token,
         event.block
     );
-    createAccountTokenSnapshotLogEntity(event, event.params.publisher, event.params.token, "IndexUpdated");
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.publisher,
+        event.params.token,
+        "IndexUpdated"
+    );
     createIndexUpdatedEntity(event, index.id);
 }
 
@@ -245,7 +255,12 @@ export function handleSubscriptionApproved(event: SubscriptionApproved): void {
             event.params.token,
             event.block
         );
-        createAccountTokenSnapshotLogEntity(event, event.params.publisher, event.params.token, "SubscriptionApproved");
+        createAccountTokenSnapshotLogEntity(
+            event,
+            event.params.publisher,
+            event.params.token,
+            "SubscriptionApproved"
+        );
     }
 
     subscription.save();
@@ -267,7 +282,12 @@ export function handleSubscriptionApproved(event: SubscriptionApproved): void {
     index.save();
 
     createSubscriptionApprovedEntity(event, subscription.id);
-    createAccountTokenSnapshotLogEntity(event, event.params.subscriber, event.params.token, "SubscriptionApproved")
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.subscriber,
+        event.params.token,
+        "SubscriptionApproved"
+    );
 }
 
 export function handleSubscriptionDistributionClaimed(
@@ -302,6 +322,9 @@ export function handleSubscriptionDistributionClaimed(
 
     createSubscriptionDistributionClaimedEntity(event, subscription.id);
 
+    // // update streamed until updated at field
+    updateTokenStatsStreamedUntilUpdatedAt(event.params.token, event.block);
+
     updateATSStreamedAndBalanceUntilUpdatedAt(
         event.params.publisher,
         event.params.token,
@@ -312,8 +335,18 @@ export function handleSubscriptionDistributionClaimed(
         event.params.token,
         event.block
     );
-    createAccountTokenSnapshotLogEntity(event, event.params.publisher, event.params.token, "SubscriptionDistributionClaimed");
-    createAccountTokenSnapshotLogEntity(event, event.params.subscriber, event.params.token, "SubscriptionDistributionClaimed");
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.publisher,
+        event.params.token,
+        "SubscriptionDistributionClaimed"
+    );
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.subscriber,
+        event.params.token,
+        "SubscriptionDistributionClaimed"
+    );
 }
 
 /**
@@ -403,8 +436,18 @@ export function handleSubscriptionRevoked(event: SubscriptionRevoked): void {
     subscription.save();
 
     createSubscriptionRevokedEntity(event, subscription.id);
-    createAccountTokenSnapshotLogEntity(event, event.params.subscriber, event.params.token, "SubscriptionRevoked")
-    createAccountTokenSnapshotLogEntity(event, event.params.publisher, event.params.token, "SubscriptionRevoked");
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.subscriber,
+        event.params.token,
+        "SubscriptionRevoked"
+    );
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.publisher,
+        event.params.token,
+        "SubscriptionRevoked"
+    );
 }
 
 /**
@@ -478,12 +521,12 @@ export function handleSubscriptionUnitsUpdated(
         event.block
     );
 
+    updateTokenStatsStreamedUntilUpdatedAt(event.params.token, event.block);
+
     // when units are set to 0, the graph marks this as a deletion
     // and therefore subtracts the number of totalSubscriptionWithUnits and
     // totalApprovedSubscriptions
     if (units.equals(BIG_INT_ZERO)) {
-        updateTokenStatsStreamedUntilUpdatedAt(event.params.token, event.block);
-
         updateAggregateIDASubscriptionsData(
             event.params.subscriber,
             event.params.token,
@@ -510,8 +553,6 @@ export function handleSubscriptionUnitsUpdated(
         index.totalSubscriptionsWithUnits =
             index.totalSubscriptionsWithUnits + 1;
 
-        updateTokenStatsStreamedUntilUpdatedAt(event.params.token, event.block);
-
         updateAggregateIDASubscriptionsData(
             event.params.subscriber,
             event.params.token,
@@ -529,8 +570,18 @@ export function handleSubscriptionUnitsUpdated(
     subscription.save();
 
     createSubscriptionUnitsUpdatedEntity(event, subscription.id, oldUnits);
-    createAccountTokenSnapshotLogEntity(event, event.params.publisher, event.params.token, "SubscriptionUnitsUpdated");
-    createAccountTokenSnapshotLogEntity(event, event.params.subscriber, event.params.token, "SubscriptionUnitsUpdated");
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.publisher,
+        event.params.token,
+        "SubscriptionUnitsUpdated"
+    );
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.subscriber,
+        event.params.token,
+        "SubscriptionUnitsUpdated"
+    );
 }
 
 /**************************************************************************

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -18,7 +18,12 @@ import {
     TokenUpgradedEvent,
     TransferEvent,
 } from "../../generated/schema";
-import {createEventID, getOrder, tokenHasValidHost, ZERO_ADDRESS} from "../utils";
+import {
+    createEventID,
+    getOrder,
+    tokenHasValidHost,
+    ZERO_ADDRESS,
+} from "../utils";
 import {
     createAccountTokenSnapshotLogEntity,
     getOrInitAccount,
@@ -28,15 +33,15 @@ import {
     updateATSStreamedAndBalanceUntilUpdatedAt,
     updateTokenStatsStreamedUntilUpdatedAt,
 } from "../mappingHelpers";
-import {getHostAddress} from "../addresses";
-import {Address, BigInt, ethereum, log} from "@graphprotocol/graph-ts";
+import { getHostAddress } from "../addresses";
+import { Address, BigInt, ethereum, log } from "@graphprotocol/graph-ts";
 
 function updateHOLEntitiesForLiquidation(
     event: ethereum.Event,
     liquidatorAccount: Address,
     targetAccount: Address,
     bondAccount: Address,
-    eventName: string,
+    eventName: string
 ): void {
     getOrInitSuperToken(event.address, event.block);
 
@@ -55,9 +60,25 @@ function updateHOLEntitiesForLiquidation(
         event.address,
         event.block
     );
-    createAccountTokenSnapshotLogEntity(event, targetAccount, event.address, eventName);
-    createAccountTokenSnapshotLogEntity(event, liquidatorAccount, event.address, eventName);
-    createAccountTokenSnapshotLogEntity(event, bondAccount, event.address, eventName);
+    updateTokenStatsStreamedUntilUpdatedAt(event.address, event.block);
+    createAccountTokenSnapshotLogEntity(
+        event,
+        targetAccount,
+        event.address,
+        eventName
+    );
+    createAccountTokenSnapshotLogEntity(
+        event,
+        liquidatorAccount,
+        event.address,
+        eventName
+    );
+    createAccountTokenSnapshotLogEntity(
+        event,
+        bondAccount,
+        event.address,
+        eventName
+    );
 }
 
 export function handleAgreementLiquidatedBy(
@@ -118,7 +139,13 @@ export function handleTokenUpgraded(event: TokenUpgraded): void {
         event.address,
         event.block
     );
-    createAccountTokenSnapshotLogEntity(event, event.params.account, event.address, "TokenUpgraded");
+    updateTokenStatsStreamedUntilUpdatedAt(event.address, event.block);
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.account,
+        event.address,
+        "TokenUpgraded"
+    );
 }
 
 export function handleTokenDowngraded(event: TokenDowngraded): void {
@@ -139,7 +166,13 @@ export function handleTokenDowngraded(event: TokenDowngraded): void {
         event.address,
         event.block
     );
-    createAccountTokenSnapshotLogEntity(event, event.params.account, event.address, "TokenDowngraded");
+    updateTokenStatsStreamedUntilUpdatedAt(event.address, event.block);
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.account,
+        event.address,
+        "TokenDowngraded"
+    );
 }
 
 export function handleTransfer(event: Transfer): void {
@@ -176,8 +209,18 @@ export function handleTransfer(event: Transfer): void {
 
     if (event.params.to.equals(ZERO_ADDRESS)) return;
     if (event.params.from.equals(ZERO_ADDRESS)) return; // Ignoring downgrade and upgrade transfer event logs.
-    createAccountTokenSnapshotLogEntity(event, event.params.to, event.address, "Transfer");
-    createAccountTokenSnapshotLogEntity(event, event.params.from, event.address, "Transfer");
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.to,
+        event.address,
+        "Transfer"
+    );
+    createAccountTokenSnapshotLogEntity(
+        event,
+        event.params.from,
+        event.address,
+        "Transfer"
+    );
 }
 
 export function handleSent(event: Sent): void {

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -36,7 +36,7 @@ function updateHOLEntitiesForLiquidation(
     liquidatorAccount: Address,
     targetAccount: Address,
     bondAccount: Address,
-    eventName: String,
+    eventName: string,
 ): void {
     getOrInitSuperToken(event.address, event.block);
 

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -116,7 +116,7 @@ export function handleAgreementLiquidatedV2(
         event,
         event.params.liquidatorAccount,
         event.params.targetAccount,
-        event.params.rewardAccount,
+        event.params.rewardAmountReceiver,
         "AgreementLiquidatedV2"
     );
 }
@@ -302,7 +302,7 @@ function createAgreementLiquidatedV2Entity(event: AgreementLiquidatedV2): void {
         event.address,
         event.params.liquidatorAccount,
         event.params.targetAccount,
-        event.params.rewardAccount,
+        event.params.rewardAmountReceiver,
     ];
     ev.blockNumber = event.block.number;
     ev.logIndex = event.logIndex;
@@ -312,7 +312,7 @@ function createAgreementLiquidatedV2Entity(event: AgreementLiquidatedV2): void {
     ev.agreementClass = event.params.agreementClass;
     ev.agreementId = event.params.id;
     ev.targetAccount = event.params.targetAccount;
-    ev.rewardAccount = event.params.rewardAccount;
+    ev.rewardAmountReceiver = event.params.rewardAmountReceiver;
     ev.rewardAmount = event.params.rewardAmount;
     ev.targetAccountBalanceDelta = event.params.targetAccountBalanceDelta;
 

--- a/packages/subgraph/test/helpers/testers.ts
+++ b/packages/subgraph/test/helpers/testers.ts
@@ -20,7 +20,6 @@ import {
     IFlowUpdatedEvent,
     IGetExpectedIDADataParams as IGetExpectedIDADataParams,
     IIDAEvents,
-    IIndexSubscription,
     ISubscriberDistributionTesterParams,
     ITestModifyFlowData,
     ITestModifyIDAData,
@@ -40,7 +39,6 @@ import {
 } from "../validation/validators";
 import {
     clipDepositNumber,
-    fetchEntityAndEnsureExistence,
     fetchEventAndEnsureExistence,
     getFlowOperatorId,
     getIndexId,
@@ -77,9 +75,7 @@ import {
 import { Framework } from "@superfluid-finance/sdk-core";
 import { BigNumber } from "@ethersproject/bignumber";
 import { BaseProvider, TransactionResponse } from "@ethersproject/providers";
-import { getSubscription } from "../queries/holQueries";
 import { ethers } from "hardhat";
-import { expect } from "chai";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 /**

--- a/packages/subgraph/test/helpers/testers.ts
+++ b/packages/subgraph/test/helpers/testers.ts
@@ -191,8 +191,7 @@ export async function testFlowUpdated(data: ITestModifyFlowData) {
                 txnResponse.hash,
                 "TransferEvents"
             );
-
-        // regardless of period, sender is transferring
+        
         expectedData.updatedSenderATS = {
             ...expectedData.updatedSenderATS,
             totalAmountTransferredUntilUpdatedAt: toBN(

--- a/packages/subgraph/test/helpers/updaters.ts
+++ b/packages/subgraph/test/helpers/updaters.ts
@@ -600,7 +600,6 @@ export const getExpectedDataForSubscriptionDistributionClaimed = async (
 
     let updatedTokenStats: ITokenStatistic = isEventEmitted
         ? {
-              // ...currentTokenStats,
               ...getExpectedTokenStatsForCFAEvent(
                   currentTokenStats,
                   atsArray,

--- a/packages/subgraph/test/helpers/updaters.ts
+++ b/packages/subgraph/test/helpers/updaters.ts
@@ -126,11 +126,12 @@ export const getExpectedATSForCFAEvent = async (
     provider: BaseProvider
 ): Promise<IAccountTokenSnapshot> => {
     const balanceUntilUpdatedAt = (
-        await superToken.balanceOf({
+        await superToken.realtimeBalanceOf({
             account: currentATS.account.id,
             providerOrSigner: provider,
+            timestamp: Number(updatedAtTimestamp),
         })
-    ).toString();
+    ).availableBalance;
 
     // Force casting because they will never be undefined
     const activeStreamsDelta =
@@ -586,8 +587,10 @@ export const getExpectedDataForSubscriptionDistributionClaimed = async (
         currentSubscriberATS,
         currentTokenStats,
         updatedAtBlockNumber,
+        isEventEmitted,
         timestamp,
         provider,
+        atsArray,
     } = data;
     const distributionDelta = toBN(currentSubscription.units).mul(
         toBN(currentIndex.indexValue).sub(
@@ -595,9 +598,21 @@ export const getExpectedDataForSubscriptionDistributionClaimed = async (
         )
     );
 
-    let updatedTokenStats: ITokenStatistic = {
-        ...currentTokenStats,
-    };
+    let updatedTokenStats: ITokenStatistic = isEventEmitted
+        ? {
+              // ...currentTokenStats,
+              ...getExpectedTokenStatsForCFAEvent(
+                  currentTokenStats,
+                  atsArray,
+                  updatedAtBlockNumber,
+                  timestamp,
+                  FlowActionType.Update,
+                  toBN(0),
+                  toBN(0),
+                  toBN(0)
+              ),
+          }
+        : currentTokenStats;
 
     let updatedIndex: IIndex = {
         ...currentIndex,
@@ -613,35 +628,39 @@ export const getExpectedDataForSubscriptionDistributionClaimed = async (
         indexValueUntilUpdatedAt: updatedIndex.indexValue,
     };
 
-    let updatedSubscriberATS: IAccountTokenSnapshot = {
-        ...(await getExpectedATSForCFAEvent(
-            token,
-            currentSubscriberATS,
-            updatedAtBlockNumber,
-            timestamp,
-            FlowActionType.Update,
-            true,
-            toBN(0),
-            toBN(0),
-            toBN(0),
-            provider
-        )),
-    };
+    let updatedSubscriberATS: IAccountTokenSnapshot = isEventEmitted
+        ? {
+              ...(await getExpectedATSForCFAEvent(
+                  token,
+                  currentSubscriberATS,
+                  updatedAtBlockNumber,
+                  timestamp,
+                  FlowActionType.Update,
+                  true,
+                  toBN(0),
+                  toBN(0),
+                  toBN(0),
+                  provider
+              )),
+          }
+        : currentSubscriberATS;
 
-    let updatedPublisherATS: IAccountTokenSnapshot = {
-        ...(await getExpectedATSForCFAEvent(
-            token,
-            currentPublisherATS,
-            updatedAtBlockNumber,
-            timestamp,
-            FlowActionType.Update,
-            true,
-            toBN(0),
-            toBN(0),
-            toBN(0),
-            provider
-        )),
-    };
+    let updatedPublisherATS: IAccountTokenSnapshot = isEventEmitted
+        ? {
+              ...(await getExpectedATSForCFAEvent(
+                  token,
+                  currentPublisherATS,
+                  updatedAtBlockNumber,
+                  timestamp,
+                  FlowActionType.Update,
+                  true,
+                  toBN(0),
+                  toBN(0),
+                  toBN(0),
+                  provider
+              )),
+          }
+        : currentPublisherATS;
 
     return {
         updatedIndex,
@@ -861,7 +880,16 @@ export const getExpectedDataForSubscriptionUnitsUpdated = async (
         )),
     };
     const subscriptionWithUnitsExists = currentSubscription.units !== "0";
-    let updatedTokenStats = { ...currentTokenStats };
+    let updatedTokenStats = getExpectedTokenStatsForCFAEvent(
+        currentTokenStats,
+        atsArray,
+        updatedAtBlockNumber,
+        timestamp,
+        FlowActionType.Update,
+        toBN(0),
+        toBN(0),
+        toBN(0)
+    );
 
     const unitsDelta = units.sub(toBN(currentSubscription.units));
     if (currentSubscription.approved) {
@@ -892,16 +920,7 @@ export const getExpectedDataForSubscriptionUnitsUpdated = async (
 
     if (units.eq(toBN(0))) {
         updatedTokenStats = {
-            ...getExpectedTokenStatsForCFAEvent(
-                updatedTokenStats,
-                atsArray,
-                updatedAtBlockNumber,
-                timestamp,
-                FlowActionType.Update,
-                toBN(0),
-                toBN(0),
-                toBN(0)
-            ),
+            ...updatedTokenStats,
             totalSubscriptionsWithUnits:
                 updatedTokenStats.totalSubscriptionsWithUnits +
                 totalSubscriptionsWithUnitsDelta,
@@ -936,16 +955,7 @@ export const getExpectedDataForSubscriptionUnitsUpdated = async (
         };
 
         updatedTokenStats = {
-            ...getExpectedTokenStatsForCFAEvent(
-                updatedTokenStats,
-                atsArray,
-                updatedAtBlockNumber,
-                timestamp,
-                FlowActionType.Update,
-                toBN(0),
-                toBN(0),
-                toBN(0)
-            ),
+            ...updatedTokenStats,
             totalSubscriptionsWithUnits:
                 updatedTokenStats.totalSubscriptionsWithUnits + 1,
         };

--- a/packages/subgraph/test/interfaces.ts
+++ b/packages/subgraph/test/interfaces.ts
@@ -641,4 +641,5 @@ export interface IGetExpectedIDADataParams {
     readonly updatedAtBlockNumber: string;
     readonly timestamp: string;
     readonly provider: BaseProvider;
+    readonly isEventEmitted: boolean;
 }

--- a/packages/subgraph/test/interfaces.ts
+++ b/packages/subgraph/test/interfaces.ts
@@ -50,8 +50,11 @@ export interface IFlowUpdatedEvent extends IEvent {
     readonly deposit: string;
     readonly oldFlowRate: string;
     readonly type: string;
-    readonly logIndex: string;
-    readonly order: string;
+}
+export interface ITransferEvent extends IEvent {
+    readonly from: string;
+    readonly to: string;
+    readonly value: string;
 }
 
 export interface IFlowOperatorUpdatedEvent extends IEvent {
@@ -70,8 +73,6 @@ export interface IIndexCreatedEvent extends IEvent {
     readonly publisher: string;
     readonly indexId: string;
     readonly userData: string;
-    readonly logIndex: string;
-    readonly order: string;
 }
 
 export interface IIndexUpdatedEvent extends IEvent {
@@ -93,8 +94,6 @@ export interface IIndexSubscribedEvent extends IEvent {
     readonly indexId: string;
     readonly subscriber: string;
     readonly userData: string;
-    readonly logIndex: string;
-    readonly order: string;
 }
 
 export interface IIndexUnitsUpdatedEvent extends IEvent {
@@ -114,8 +113,6 @@ export interface IIndexUnsubscribedEvent extends IEvent {
     readonly indexId: string;
     readonly subscriber: string;
     readonly userData: string;
-    readonly logIndex: string;
-    readonly order: string;
 }
 
 export interface ISubscriptionApprovedEvent extends IEvent {
@@ -125,8 +122,6 @@ export interface ISubscriptionApprovedEvent extends IEvent {
     readonly publisher: string;
     readonly indexId: string;
     readonly userData: string;
-    readonly logIndex: string;
-    readonly order: string;
 }
 
 export interface ISubscriptionRevokedEvent extends IEvent {
@@ -161,8 +156,6 @@ export interface ITokenUpgradedEvent extends IEvent {
     readonly blockNumber: string;
     readonly token: string;
     readonly amount: string;
-    readonly logIndex: string;
-    readonly order: string;
 }
 
 export interface ITokenDowngradedEvent extends IEvent {
@@ -173,8 +166,6 @@ export interface ITokenDowngradedEvent extends IEvent {
     readonly blockNumber: string;
     readonly token: string;
     readonly amount: string;
-    readonly logIndex: string;
-    readonly order: string;
 }
 
 export interface ITransferEvent extends IEvent {
@@ -186,8 +177,6 @@ export interface ITransferEvent extends IEvent {
     readonly to: string;
     readonly value: string;
     readonly token: string;
-    readonly logIndex: string;
-    readonly order: string;
 }
 
 /**

--- a/packages/subgraph/test/queries/eventQueries.ts
+++ b/packages/subgraph/test/queries/eventQueries.ts
@@ -299,3 +299,21 @@ export const getSubscriptionUnitsUpdatedEvents = gql`
         }
     }
 `;
+
+export const getTransferEvents = gql`
+    query getTransferEvents($transactionHash: Bytes!) {
+        response: transferEvents(
+            where: { transactionHash: $transactionHash }
+        ) {
+            id
+            order
+            transactionHash
+            name
+            blockNumber
+            logIndex
+            from
+            to
+            value
+        }
+    }
+`;

--- a/packages/subgraph/test/validation/eventValidators.ts
+++ b/packages/subgraph/test/validation/eventValidators.ts
@@ -10,17 +10,17 @@ export const fetchEventAndValidate = async <EventType extends IEvent,
     txnResponse: TransactionResponse,
     expectedData: ExpectedDataType,
     query: string,
-    queryName: string
+    eventName: string
 ) => {
     const event = await fetchEventAndEnsureExistence<EventType>(
         query,
         txnResponse.hash,
-        queryName
+        eventName
     );
 
     // Note: we parse the name of the query (e.g. FlowUpdatedEvent)
     // and use this to validate that the name property has been set properly.
-    const parsedQueryName = queryName.split("Event")[0];
+    const parsedQueryName = eventName.split("Event")[0];
     validateEventData(event, expectedData, txnResponse, parsedQueryName);
 
     return event;


### PR DESCRIPTION
### Contracts
* EventsEmitter library created to emit unaccessible ERC20 Transfer events in `SuperfluidToken.sol`'s `makeLiquidationPaymentsV2` function
* Test behavior logic changed: expect transfer events when liquidations occur
* `makeLiquidationPayoutsV2` logic refactored (same logical behavior, but easier to reason about with new branch logic check - checking the sign of targetAccountBalanceDelta instead of checking useDefaultRewardAccount)
  * add asserts
  * use nicer assignment operator syntax here
  * change `rewardAccount` => `rewardAmountReceiver`

### Subgraph
* [SUBGRAPH FIX] - tokenStats.totalAmountStreamedUntilUpdated updater function was not updating updatedAtTimestamp, updatedAtBlockNumber
* [SUBGRAPH FIX] - totalAmountStreamedUntilUpdated was missing updates in some places 
* Test behavior logic changed
   * liquidation transferred amount tracking for ATS
   * remove old claim specific logic
   * handle no event emit case for distributions
* change `rewardAccount` => `rewardAmountReceiver`

### SDK-Core/SDK-Redux
* change `rewardAccount` => `rewardAmountReceiver`
