### PR TITLE
SDK-Core 0.4.3 

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -5,8 +5,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.4.3] - 2022-05-31
+
+### Breaking
+- Subgraph Query: `rewardAccount` renamed to `rewardAmountReceiver` on `AgreementLiquidatedV2Event` entity
 ### Added
 - `QueryHandler` for transfer events
+
+## [0.4.2] - 2022-05-17
+
+### Fixed
+- Patched SDK-Core Subgraph files to be in sync with V1 Subgraph endpoint
 
 ## [0.4.1] - 2022-05-14
 
@@ -47,7 +56,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - The `SuperToken` class is now an abstract base class and no longer contains the functions `upgrade` and `downgrade`.
 - `underlyingToken` is possibly undefined on `SuperToken`: `WrapperSuperToken` has `underlyingToken`, but `PureSuperToken` and `NativeAssetSuperToken` do not.
 > NOTE: These changes are due to the split of `SuperToken` into `WrapperSuperToken`, `PureSuperToken` and `NativeAssetSuperToken` classes.
-  - Migration: 
+  - Migration:
       - if you are unsure of the type of the super token, you can use: `await framework.loadSuperToken("0x...");`
       - if you want to load a wrapper super token, use: `await framework.loadWrapperSuperToken("DAIx");`
       - if you want to load a native asset super token, use: `await framework.loadNativeAssetSuperToken("ETHx");`
@@ -69,7 +78,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Typo for `networkName: "arbitrum-rinkeby"` fixed (was expecting `"arbitrium-rinkeby"`) in `Framework.create` ([#637])
 
 ### Breaking
-- Using `"xdai"` as the `networkName` will no longer work. Updated to `"gnosis"` 
+- Using `"xdai"` as the `networkName` will no longer work. Updated to `"gnosis"`
   - Migration: change `networkName` from `"xdai"` to `"gnosis"`
 
 ## [0.3.0] - 2022-02-02
@@ -127,7 +136,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - New `SuperToken` class with `SuperToken` CRUD functionality and an underlying `Token` class with basic `ERC20` functionality
   - New `BatchCall` class for creating and executing batch calls with supported `Operation's`
 
-[Unreleased]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.4.1...HEAD
+[Unreleased]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.4.3...HEAD
+[0.4.3]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.4.2...sdk-core%40v0.4.3
+[0.4.2]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.4.1...sdk-core%40v0.4.2
 [0.4.1]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.4.0...sdk-core%40v0.4.1
 [0.4.0]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.3.2...sdk-core%40v0.4.0
 [0.3.2]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.3.1...sdk-core%40v0.3.2

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-core",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "SDK Core for building with Superfluid Protocol",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/sdk-core#readme",
     "repository": {

--- a/packages/sdk-core/previous-versions-testing/package.json
+++ b/packages/sdk-core/previous-versions-testing/package.json
@@ -6,6 +6,6 @@
         "run-query-tests": "npx hardhat test ./runQueryTests.ts"
     },
     "devDependencies": {
-        "@superfluid-finance/sdk-core": "0.4.1"
+        "@superfluid-finance/sdk-core": "0.4.3"
     }
 }

--- a/packages/sdk-redux/package.json
+++ b/packages/sdk-redux/package.json
@@ -48,7 +48,7 @@
     },
     "peerDependencies": {
         "@reduxjs/toolkit": "^1.6.0 || ^1.7.0",
-        "@superfluid-finance/sdk-core": "~0.4.2"
+        "@superfluid-finance/sdk-core": "~0.4.3"
     },
     "files": [
         "dist/main",

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -52,7 +52,7 @@
     "dependencies": {
         "@graphprotocol/graph-cli": "0.29.0",
         "@graphprotocol/graph-ts": "0.26.0",
-        "@superfluid-finance/sdk-core": "0.4.1",
+        "@superfluid-finance/sdk-core": "0.4.3",
         "mustache": "^4.2.0"
     },
     "devDependencies": {


### PR DESCRIPTION
* bump versions in relevant packages
* update CHANGELOG.md

> NOTE: SDK-Core events query will be broken when v1 endpoints are synced because of the renaming of the `rewardAccount` property