### PR TITLE
Use `abi.encodeCall`

### DIFF
--- a/examples/budget-nft/contracts/BudgetNFT.sol
+++ b/examples/budget-nft/contracts/BudgetNFT.sol
@@ -203,12 +203,14 @@ contract BudgetNFT is ERC721, Ownable {
         if (to == address(this) || to == address(0)) return;
         _host.callAgreement(
             _cfa,
-            abi.encodeWithSelector(
-                _cfa.createFlow.selector,
-                _acceptedToken,
-                to,
-                flowRate,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                _cfa.createFlow,
+                (
+                    _acceptedToken,
+                    to,
+                    flowRate,
+                    new bytes(0) // placeholder
+                )
             ),
             "0x"
         );
@@ -218,12 +220,14 @@ contract BudgetNFT is ERC721, Ownable {
         if (to == address(this) || to == address(0)) return;
         _host.callAgreement(
             _cfa,
-            abi.encodeWithSelector(
-                _cfa.updateFlow.selector,
-                _acceptedToken,
-                to,
-                flowRate,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                _cfa.updateFlow,
+                (
+                    _acceptedToken,
+                    to,
+                    flowRate,
+                    new bytes(0) // placeholder
+                )
             ),
             "0x"
         );
@@ -232,12 +236,14 @@ contract BudgetNFT is ERC721, Ownable {
     function _deleteFlow(address from, address to) internal {
         _host.callAgreement(
             _cfa,
-            abi.encodeWithSelector(
-                _cfa.deleteFlow.selector,
-                _acceptedToken,
-                from,
-                to,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                _cfa.deleteFlow,
+                (
+                    _acceptedToken,
+                    from,
+                    to,
+                    new bytes(0) // placeholder
+                )
             ),
             "0x"
         );

--- a/examples/simple-acl-close/src/SimpleACLCloseResolver.sol
+++ b/examples/simple-acl-close/src/SimpleACLCloseResolver.sol
@@ -98,11 +98,13 @@ contract SimpleACLCloseResolver is IResolver, Ownable {
         // NOTE: this can be modified to execute pretty much any function
         // given the permissions
         // e.g. other host contract functions, supertoken upgrades/downgrades
-        execPayload = abi.encodeWithSelector(
-            ISuperfluid.callAgreement.selector,
-            IConstantFlowAgreementV1(cfa),
-            callData,
-            "0x"
+        execPayload = abi.encodeCall(
+            ISuperfluid(superToken.getHost()).callAgreement,
+            (
+                IConstantFlowAgreementV1(cfa),
+                callData,
+                "0x"
+            )
         );
     }
 }

--- a/examples/simple-acl-close/src/SimpleACLCloseResolver.sol
+++ b/examples/simple-acl-close/src/SimpleACLCloseResolver.sol
@@ -85,12 +85,14 @@ contract SimpleACLCloseResolver is IResolver, Ownable {
         // e.g. supertoken balance reaches a specific amount
         canExec = block.timestamp >= endTime && timestamp != 0;
 
-        bytes memory callData = abi.encodeWithSelector(
-            IConstantFlowAgreementV1.deleteFlowByOperator.selector,
-            superToken,
-            flowSender,
-            flowReceiver,
-            new bytes(0)
+        bytes memory callData = abi.encodeCall(
+            cfa.deleteFlowByOperator,
+            (
+                superToken,
+                flowSender,
+                flowReceiver,
+                new bytes(0)
+            )
         );
 
         // NOTE: this can be modified to execute pretty much any function

--- a/examples/simple-acl-close/src/test/SimpleACLCloseResolver.t.sol
+++ b/examples/simple-acl-close/src/test/SimpleACLCloseResolver.t.sol
@@ -301,13 +301,15 @@ contract SimpleACLCloseResolverTest is Test {
     ) internal {
         _host.callAgreement(
             _cfa,
-            abi.encodeWithSelector(
-                _cfa.updateFlowOperatorPermissions.selector,
-                _flowSuperToken,
-                _flowOperator,
-                4,
-                0,
-                new bytes(0)
+            abi.encodeCall(
+                _cfa.updateFlowOperatorPermissions,
+                (
+                    _flowSuperToken,
+                    _flowOperator,
+                    4,
+                    0,
+                    new bytes(0)
+                )
             ),
             "0x"
         );

--- a/packages/ethereum-contracts/contracts/apps/CFAv1Library.sol
+++ b/packages/ethereum-contracts/contracts/apps/CFAv1Library.sol
@@ -54,7 +54,7 @@ library CFAv1Library {
      * @param userData The user provided data
      */
     function createFlow(
-        InitData storage cfaLibrary, 
+        InitData storage cfaLibrary,
         address receiver,
         ISuperfluidToken token,
         int96 flowRate,
@@ -62,12 +62,14 @@ library CFAv1Library {
     ) internal {
         cfaLibrary.host.callAgreement(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.createFlow.selector,
-                token,
-                receiver,
-                flowRate,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                cfaLibrary.cfa.createFlow,
+                (
+                    token,
+                    receiver,
+                    flowRate,
+                    new bytes(0) // placeholder
+                )
             ),
             userData
         );
@@ -106,12 +108,14 @@ library CFAv1Library {
     ) internal {
         cfaLibrary.host.callAgreement(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.updateFlow.selector,
-                token,
-                receiver,
-                flowRate,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                cfaLibrary.cfa.updateFlow,
+                (
+                    token,
+                    receiver,
+                    flowRate,
+                    new bytes(0) // placeholder
+                )
             ),
             userData
         );
@@ -150,12 +154,14 @@ library CFAv1Library {
     ) internal {
         cfaLibrary.host.callAgreement(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.deleteFlow.selector,
-                token,
-                sender,
-                receiver,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                cfaLibrary.cfa.deleteFlow,
+                (
+                    token,
+                    sender,
+                    receiver,
+                    new bytes(0) // placeholder
+                )
             ),
             userData
         );
@@ -198,12 +204,14 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = cfaLibrary.host.callAgreementWithContext(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.createFlow.selector,
-                token,
-                receiver,
-                flowRate,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                cfaLibrary.cfa.createFlow,
+                (
+                    token,
+                    receiver,
+                    flowRate,
+                    new bytes(0) // placeholder
+                )
             ),
             userData,
             ctx
@@ -247,12 +255,14 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = cfaLibrary.host.callAgreementWithContext(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.updateFlow.selector,
-                token,
-                receiver,
-                flowRate,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                cfaLibrary.cfa.updateFlow,
+                (
+                    token,
+                    receiver,
+                    flowRate,
+                    new bytes(0) // placeholder
+                )
             ),
             userData,
             ctx
@@ -296,12 +306,14 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = cfaLibrary.host.callAgreementWithContext(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.deleteFlow.selector,
-                token,
-                sender,
-                receiver,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                cfaLibrary.cfa.deleteFlow,
+                (
+                    token,
+                    sender,
+                    receiver,
+                    new bytes(0) // placeholder
+                )
             ),
             userData,
             ctx
@@ -345,13 +357,15 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         return cfaLibrary.host.callAgreement(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.createFlowByOperator.selector,
-                token,
-                sender,
-                receiver,
-                flowRate,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                cfaLibrary.cfa.createFlowByOperator,
+                (
+                    token,
+                    sender,
+                    receiver,
+                    flowRate,
+                    new bytes(0) // placeholder
+                )
             ),
             userData
         );
@@ -406,13 +420,15 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = cfaLibrary.host.callAgreementWithContext(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.createFlowByOperator.selector,
-                token,
-                sender,
-                receiver,
-                flowRate,
-                new bytes(0) // placeholder
+            abi.encodeCall(
+                cfaLibrary.cfa.createFlowByOperator,
+                (
+                    token,
+                    sender,
+                    receiver,
+                    flowRate,
+                    new bytes(0) // placeholder
+                )
             ),
             userData,
             ctx
@@ -456,13 +472,15 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         return cfaLibrary.host.callAgreement(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.updateFlowByOperator.selector,
-                token,
-                sender,
-                receiver,
-                flowRate,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.updateFlowByOperator,
+                (
+                    token,
+                    sender,
+                    receiver,
+                    flowRate,
+                    new bytes(0)
+                )
             ),
             userData
         );
@@ -517,13 +535,15 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = cfaLibrary.host.callAgreementWithContext(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.updateFlowByOperator.selector,
-                token,
-                sender,
-                receiver,
-                flowRate,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.updateFlowByOperator,
+                (
+                    token,
+                    sender,
+                    receiver,
+                    flowRate,
+                    new bytes(0)
+                )
             ),
             userData,
             ctx
@@ -563,12 +583,14 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         return cfaLibrary.host.callAgreement(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.deleteFlowByOperator.selector,
-                token,
-                sender,
-                receiver,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.deleteFlowByOperator,
+                (
+                    token,
+                    sender,
+                    receiver,
+                    new bytes(0)
+                )
             ),
             userData
         );
@@ -611,12 +633,14 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = cfaLibrary.host.callAgreementWithContext(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.deleteFlowByOperator.selector,
-                token,
-                sender,
-                receiver,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.deleteFlowByOperator,
+                (
+                    token,
+                    sender,
+                    receiver,
+                    new bytes(0)
+                )
             ),
             userData,
             ctx
@@ -641,13 +665,15 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         return cfaLibrary.host.callAgreement(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.updateFlowOperatorPermissions.selector,
-                token,
-                flowOperator,
-                permissions,
-                flowRateAllowance,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.updateFlowOperatorPermissions,
+                (
+                    token,
+                    flowOperator,
+                    permissions,
+                    flowRateAllowance,
+                    new bytes(0)
+                )
             ),
             new bytes(0)
         );
@@ -673,13 +699,15 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = cfaLibrary.host.callAgreementWithContext(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.updateFlowOperatorPermissions.selector,
-                token,
-                flowOperator,
-                permissions,
-                flowRateAllowance,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.updateFlowOperatorPermissions,
+                (
+                    token,
+                    flowOperator,
+                    permissions,
+                    flowRateAllowance,
+                    new bytes(0)
+                )
             ),
             new bytes(0),
             ctx
@@ -699,11 +727,13 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         return cfaLibrary.host.callAgreement(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.authorizeFlowOperatorWithFullControl.selector,
-                token,
-                flowOperator,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.authorizeFlowOperatorWithFullControl,
+                (
+                    token,
+                    flowOperator,
+                    new bytes(0)
+                )
             ),
             new bytes(0)
         );
@@ -724,11 +754,13 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = cfaLibrary.host.callAgreementWithContext(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.authorizeFlowOperatorWithFullControl.selector,
-                token,
-                flowOperator,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.authorizeFlowOperatorWithFullControl,
+                (
+                    token,
+                    flowOperator,
+                    new bytes(0)
+                )
             ),
             new bytes(0),
             ctx
@@ -748,11 +780,13 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         return cfaLibrary.host.callAgreement(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.revokeFlowOperatorWithFullControl.selector,
-                token,
-                flowOperator,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.revokeFlowOperatorWithFullControl,
+                (
+                    token,
+                    flowOperator,
+                    new bytes(0)
+                )
             ),
             new bytes(0)
         );
@@ -773,11 +807,13 @@ library CFAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = cfaLibrary.host.callAgreementWithContext(
             cfaLibrary.cfa,
-            abi.encodeWithSelector(
-                cfaLibrary.cfa.revokeFlowOperatorWithFullControl.selector,
-                token,
-                flowOperator,
-                new bytes(0)
+            abi.encodeCall(
+                cfaLibrary.cfa.revokeFlowOperatorWithFullControl,
+                (
+                    token,
+                    flowOperator,
+                    new bytes(0)
+                )
             ),
             new bytes(0),
             ctx

--- a/packages/ethereum-contracts/contracts/apps/IDAv1Library.sol
+++ b/packages/ethereum-contracts/contracts/apps/IDAv1Library.sol
@@ -186,11 +186,13 @@ library IDAv1Library {
     ) internal {
         idaLibrary.host.callAgreement(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.createIndex.selector,
-                token,
-                indexId,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.createIndex,
+                (
+                    token,
+                    indexId,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData
         );
@@ -225,11 +227,13 @@ library IDAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = idaLibrary.host.callAgreementWithContext(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.createIndex.selector,
-                token,
-                indexId,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.createIndex,
+                (
+                    token,
+                    indexId,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData,
             ctx
@@ -268,12 +272,14 @@ library IDAv1Library {
     ) internal {
         idaLibrary.host.callAgreement(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.updateIndex.selector,
-                token,
-                indexId,
-                indexValue,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.updateIndex,
+                (
+                    token,
+                    indexId,
+                    indexValue,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData
         );
@@ -321,12 +327,14 @@ library IDAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = idaLibrary.host.callAgreementWithContext(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.updateIndex.selector,
-                token,
-                indexId,
-                indexValue,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.updateIndex,
+                (
+                    token,
+                    indexId,
+                    indexValue,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData,
             ctx
@@ -365,12 +373,14 @@ library IDAv1Library {
     ) internal {
         idaLibrary.host.callAgreement(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.distribute.selector,
-                token,
-                indexId,
-                amount,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.distribute,
+                (
+                    token,
+                    indexId,
+                    amount,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData
         );
@@ -411,13 +421,15 @@ library IDAv1Library {
         bytes memory userData
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = idaLibrary.host.callAgreementWithContext(
-            idaLibrary.ida, 
-            abi.encodeWithSelector(
-                idaLibrary.ida.distribute.selector,
-                token,
-                indexId,
-                amount,
-                new bytes(0) // ctx placeholder
+            idaLibrary.ida,
+            abi.encodeCall(
+                idaLibrary.ida.distribute,
+                (
+                    token,
+                    indexId,
+                    amount,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData,
             ctx
@@ -462,12 +474,14 @@ library IDAv1Library {
     ) internal {
         idaLibrary.host.callAgreement(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.approveSubscription.selector,
-                token,
-                publisher,
-                indexId,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.approveSubscription,
+                (
+                    token,
+                    publisher,
+                    indexId,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData
         );
@@ -517,12 +531,14 @@ library IDAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = idaLibrary.host.callAgreementWithContext(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.approveSubscription.selector,
-                token,
-                publisher,
-                indexId,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.approveSubscription,
+                (
+                    token,
+                    publisher,
+                    indexId,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData,
             ctx
@@ -558,12 +574,14 @@ library IDAv1Library {
     ) internal {
         idaLibrary.host.callAgreement(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.revokeSubscription.selector,
-                token,
-                publisher,
-                indexId,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.revokeSubscription,
+                (
+                    token,
+                    publisher,
+                    indexId,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData
         );
@@ -610,12 +628,14 @@ library IDAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = idaLibrary.host.callAgreementWithContext(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.revokeSubscription.selector,
-                token,
-                publisher,
-                indexId,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.revokeSubscription,
+                (
+                    token,
+                    publisher,
+                    indexId,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData,
             ctx
@@ -657,13 +677,15 @@ library IDAv1Library {
     ) internal {
         idaLibrary.host.callAgreement(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.updateSubscription.selector,
-                token,
-                indexId,
-                subscriber,
-                units,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.updateSubscription,
+                (
+                    token,
+                    indexId,
+                    subscriber,
+                    units,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData
         );
@@ -716,13 +738,15 @@ library IDAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = idaLibrary.host.callAgreementWithContext(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.updateSubscription.selector,
-                token,
-                indexId,
-                subscriber,
-                units,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.updateSubscription,
+                (
+                    token,
+                    indexId,
+                    subscriber,
+                    units,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData,
             ctx
@@ -763,13 +787,15 @@ library IDAv1Library {
     ) internal {
         idaLibrary.host.callAgreement(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.deleteSubscription.selector,
-                token,
-                publisher,
-                indexId,
-                subscriber,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.deleteSubscription,
+                (
+                    token,
+                    publisher,
+                    indexId,
+                    subscriber,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData
         );
@@ -821,13 +847,15 @@ library IDAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = idaLibrary.host.callAgreementWithContext(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.deleteSubscription.selector,
-                token,
-                publisher,
-                indexId,
-                subscriber,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.deleteSubscription,
+                (
+                    token,
+                    publisher,
+                    indexId,
+                    subscriber,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData,
             ctx
@@ -868,13 +896,15 @@ library IDAv1Library {
     ) internal {
         idaLibrary.host.callAgreement(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.claim.selector,
-                token,
-                publisher,
-                indexId,
-                subscriber,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.claim,
+                (
+                    token,
+                    publisher,
+                    indexId,
+                    subscriber,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData
         );
@@ -925,13 +955,15 @@ library IDAv1Library {
     ) internal returns (bytes memory newCtx) {
         (newCtx, ) = idaLibrary.host.callAgreementWithContext(
             idaLibrary.ida,
-            abi.encodeWithSelector(
-                idaLibrary.ida.claim.selector,
-                token,
-                publisher,
-                indexId,
-                subscriber,
-                new bytes(0) // ctx placeholder
+            abi.encodeCall(
+                idaLibrary.ida.claim,
+                (
+                    token,
+                    publisher,
+                    indexId,
+                    subscriber,
+                    new bytes(0) // ctx placeholder
+                )
             ),
             userData,
             ctx

--- a/packages/ethereum-contracts/contracts/mocks/CFAAppMocks.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFAAppMocks.sol
@@ -53,12 +53,14 @@ contract ExclusiveInflowTestApp is SuperAppBase {
         newCtx = ctx;
         ISuperfluid.Context memory context = _host.decodeCtx(ctx);
         if (_currentSender != address(0)) {
-            bytes memory callData = abi.encodeWithSelector(
-                _cfa.deleteFlow.selector,
-                superToken,
-                _currentSender,
-                address(this),
-                new bytes(0)
+            bytes memory callData = abi.encodeCall(
+                _cfa.deleteFlow,
+                (
+                    superToken,
+                    _currentSender,
+                    address(this),
+                    new bytes(0)
+                )
             );
             (newCtx, ) = _host.callAgreementWithContext(
                 _cfa,
@@ -133,12 +135,14 @@ contract NonClosableOutflowTestApp is SuperAppBase {
         _flowRate = flowRate;
         _host.callAgreement(
             _cfa,
-            abi.encodeWithSelector(
-                _cfa.createFlow.selector,
-                superToken,
-                receiver,
-                flowRate,
-                new bytes(0)
+            abi.encodeCall(
+                _cfa.createFlow,
+                (
+                    superToken,
+                    receiver,
+                    flowRate,
+                    new bytes(0)
+                )
             ),
             new bytes(0) // user data
         );
@@ -158,16 +162,22 @@ contract NonClosableOutflowTestApp is SuperAppBase {
         (address flowSender, address flowReceiver) = abi.decode(agreementData, (address, address));
         assert(flowSender == address(this));
         assert(flowReceiver == _receiver);
-        // recreate the flow
-        (newCtx, ) = _host.callAgreementWithContext(
-            _cfa,
-            abi.encodeWithSelector(
-                _cfa.createFlow.selector,
+
+        // moved out to avoid stack too deep error
+        bytes memory callData = abi.encodeCall(
+            _cfa.createFlow,
+            (
                 superToken,
                 flowReceiver,
                 _flowRate,
                 new bytes(0)
-            ),
+            )
+        );
+
+        // recreate the flow
+        (newCtx, ) = _host.callAgreementWithContext(
+            _cfa,
+            callData,
             "0x",
             ctx
         );
@@ -218,12 +228,14 @@ contract SelfDeletingFlowTestApp is SuperAppBase {
         ISuperfluid.Context memory context = _host.decodeCtx(ctx);
         (newCtx, ) = _host.callAgreementWithContext(
             _cfa,
-            abi.encodeWithSelector(
-                _cfa.deleteFlow.selector,
-                superToken,
-                context.msgSender,
-                address(this),
-                new bytes(0)
+            abi.encodeCall(
+                _cfa.deleteFlow,
+                (
+                    superToken,
+                    context.msgSender,
+                    address(this),
+                    new bytes(0)
+                )
             ),
             new bytes(0), // user data
             newCtx
@@ -273,12 +285,14 @@ contract ClosingOnUpdateFlowTestApp is SuperAppBase {
         ISuperfluid.Context memory context = _host.decodeCtx(ctx);
         (newCtx, ) = _host.callAgreementWithContext(
             _cfa,
-            abi.encodeWithSelector(
-                _cfa.deleteFlow.selector,
-                superToken,
-                context.msgSender,
-                address(this),
-                new bytes(0)
+            abi.encodeCall(
+                _cfa.deleteFlow,
+                (
+                    superToken,
+                    context.msgSender,
+                    address(this),
+                    new bytes(0)
+                )
             ),
             new bytes(0), // user data
             newCtx
@@ -331,12 +345,14 @@ contract FlowExchangeTestApp is SuperAppBase {
         (,int96 flowRate,,) = _cfa.getFlow(superToken, context.msgSender, address(this));
         (newCtx, ) = _host.callAgreementWithContext(
             _cfa,
-            abi.encodeWithSelector(
-                _cfa.createFlow.selector,
-                _targetToken,
-                context.msgSender,
-                flowRate,
-                new bytes(0)
+            abi.encodeCall(
+                _cfa.createFlow,
+                (
+                    _targetToken,
+                    context.msgSender,
+                    flowRate,
+                    new bytes(0)
+                )
             ),
             new bytes(0), // user data
             newCtx

--- a/packages/ethereum-contracts/contracts/mocks/CustomSuperTokenMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CustomSuperTokenMock.sol
@@ -60,9 +60,16 @@ contract CustomSuperTokenProxyMock is CustomSuperTokenBaseMock {
     ) external {
         address logic = _implementation();
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, ) = logic.delegatecall(abi.encodeWithSelector(
-            ISuperToken.selfMint.selector,
-            to, amount, userData));
+        (bool success, ) = logic.delegatecall(
+            abi.encodeCall(
+                ISuperToken(address(this)).selfMint,
+                (
+                    to,
+                    amount,
+                    userData
+                )
+            )
+        );
         assert(success);
     }
 
@@ -75,7 +82,7 @@ contract CustomSuperTokenProxyMock is CustomSuperTokenBaseMock {
         // this makes msg.sender to self
         ISuperToken(address(this)).selfBurn(to, amount, userData);
     }
-    
+
     // this function self calls transferFrom
     function callSelfTransferFrom(
         address holder,

--- a/packages/ethereum-contracts/contracts/mocks/IDASuperAppTester.sol
+++ b/packages/ethereum-contracts/contracts/mocks/IDASuperAppTester.sol
@@ -33,11 +33,13 @@ contract IDASuperAppTester is ISuperApp {
 
         _host.callAgreement(
             _ida,
-            abi.encodeWithSelector(
-                _ida.createIndex.selector,
-                _token,
-                _indexId,
-                new bytes(0) // placeholder ctx
+            abi.encodeCall(
+                _ida.createIndex,
+                (
+                    _token,
+                    _indexId,
+                    new bytes(0) // placeholder ctx
+                )
             ),
             new bytes(0) // user data
         );
@@ -51,13 +53,15 @@ contract IDASuperAppTester is ISuperApp {
     {
         _host.callAgreement(
             _ida,
-            abi.encodeWithSelector(
-                _ida.updateSubscription.selector,
-                _token,
-                _indexId,
-                subscriber,
-                units,
-                new bytes(0) // placeholder ctx
+            abi.encodeCall(
+                _ida.updateSubscription,
+                (
+                    _token,
+                    _indexId,
+                    subscriber,
+                    units,
+                    new bytes(0) // placeholder ctx
+                )
             ),
             new bytes(0) // user data
         );
@@ -70,12 +74,14 @@ contract IDASuperAppTester is ISuperApp {
     {
         _host.callAgreement(
             _ida,
-            abi.encodeWithSelector(
-                _ida.distribute.selector,
-                _token,
-                _indexId,
-                amount,
-                new bytes(0) // placeholder ctx
+            abi.encodeCall(
+                _ida.distribute,
+                (
+                    _token,
+                    _indexId,
+                    amount,
+                    new bytes(0) // placeholder ctx
+                )
             ),
             new bytes(0) // user data
         );

--- a/packages/ethereum-contracts/contracts/mocks/MultiFlowTesterApp.sol
+++ b/packages/ethereum-contracts/contracts/mocks/MultiFlowTesterApp.sol
@@ -131,12 +131,15 @@ contract MultiFlowTesterApp is SuperAppBase {
         external
         returns (bytes memory newCtx)
     {
-        bytes memory callData = abi.encodeWithSelector(
-            _cfa.createFlow.selector,
-            superToken,
-            receiver,
-            flowRate,
-            new bytes(0));
+        bytes memory callData = abi.encodeCall(
+            _cfa.createFlow,
+            (
+                superToken,
+                receiver,
+                flowRate,
+                new bytes(0)
+            )
+        );
         (newCtx, ) = _host.callAgreementWithContext(
             _cfa,
             callData,
@@ -269,12 +272,14 @@ contract MultiFlowTesterApp is SuperAppBase {
         newCtx = ctx;
         if (vars.flowReceiver == address(this)) {
             for(uint256 i = 0; i < vars.configuration.receivers.length; i++) {
-                callData = abi.encodeWithSelector(
-                    _cfa.deleteFlow.selector,
-                    superToken,
-                    address(this),
-                    vars.configuration.receivers[i].to,
-                    new bytes(0) //placeholder ctx
+                callData = abi.encodeCall(
+                    _cfa.deleteFlow,
+                    (
+                        superToken,
+                        address(this),
+                        vars.configuration.receivers[i].to,
+                        new bytes(0) //placeholder ctx
+                    )
                 );
                 (newCtx, ) = _host.callAgreementWithContext(
                     _cfa,
@@ -288,12 +293,14 @@ contract MultiFlowTesterApp is SuperAppBase {
                 // skip current closed flow
                 if (vars.configuration.receivers[i].to == vars.flowReceiver) continue;
                 // close the rest of the mfa receiver flows
-                callData = abi.encodeWithSelector(
-                    _cfa.deleteFlow.selector,
-                    superToken,
-                    address(this),
-                    vars.configuration.receivers[i].to,
-                    new bytes(0) //placeholder ctx
+                callData = abi.encodeCall(
+                    _cfa.deleteFlow,
+                    (
+                        superToken,
+                        address(this),
+                        vars.configuration.receivers[i].to,
+                        new bytes(0) //placeholder ctx
+                    )
                 );
                 (newCtx, ) = _host.callAgreementWithContext(
                     _cfa,
@@ -303,12 +310,14 @@ contract MultiFlowTesterApp is SuperAppBase {
                 );
             }
             // close the mfa sender flow
-            callData = abi.encodeWithSelector(
-                _cfa.deleteFlow.selector,
-                superToken,
-                vars.mfaSender,
-                address(this),
-                new bytes(0) //placeholder ctx
+            callData = abi.encodeCall(
+                _cfa.deleteFlow,
+                (
+                    superToken,
+                    vars.mfaSender,
+                    address(this),
+                    new bytes(0) //placeholder ctx
+                )
             );
             (newCtx, ) = _host.callAgreementWithContext(
                 _cfa,

--- a/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
@@ -18,11 +18,13 @@ contract SuperAppMockAux {
     {
         host.callAgreementWithContext(
             agreement,
-            abi.encodeWithSelector(
-                AgreementMock.pingMe.selector,
-                address(this), // expectedMsgSender
-                ping,
-                new bytes(0)
+            abi.encodeCall(
+                agreement.pingMe,
+                (
+                    address(this), // expectedMsgSender
+                    ping,
+                    new bytes(0)
+                )
             ),
             new bytes(0), // user data
             ctx);
@@ -33,9 +35,9 @@ contract SuperAppMockAux {
     {
         host.callAppActionWithContext(
             app,
-            abi.encodeWithSelector(
-                SuperAppMock.actionNoop.selector,
-                new bytes(0)
+            abi.encodeCall(
+                app.actionNoop,
+                (new bytes(0))
             ),
             ctx);
     }
@@ -157,11 +159,13 @@ contract SuperAppMock is ISuperApp {
     {
         (newCtx, ) = _host.callAgreementWithContext(
             agreement,
-            abi.encodeWithSelector(
-                AgreementMock.pingMe.selector,
-                address(this), // expectedMsgSender
-                ping,
-                new bytes(0)
+            abi.encodeCall(
+                agreement.pingMe,
+                (
+                    address(this), // expectedMsgSender
+                    ping,
+                    new bytes(0)
+                )
             ),
             new bytes(0), // user data
             ctx);
@@ -174,10 +178,12 @@ contract SuperAppMock is ISuperApp {
     {
         (newCtx, ) = _host.callAgreementWithContext(
             agreement,
-            abi.encodeWithSelector(
-                AgreementMock.doRevert.selector,
-                reason,
-                new bytes(0)
+            abi.encodeCall(
+                agreement.doRevert,
+                (
+                    reason,
+                    new bytes(0)
+                )
             ),
             new bytes(0), // user data
             ctx);
@@ -190,9 +196,9 @@ contract SuperAppMock is ISuperApp {
     {
         newCtx = _host.callAppActionWithContext(
             this,
-            abi.encodeWithSelector(
-                SuperAppMock.actionNoop.selector,
-                new bytes(0)
+            abi.encodeCall(
+                this.actionNoop,
+                (new bytes(0))
             ),
             ctx);
     }
@@ -204,10 +210,12 @@ contract SuperAppMock is ISuperApp {
     {
         newCtx = _host.callAppActionWithContext(
             this,
-            abi.encodeWithSelector(
-                SuperAppMock.actionRevertWithReason.selector,
-                reason,
-                new bytes(0)
+            abi.encodeCall(
+                this.actionRevertWithReason,
+                (
+                    reason,
+                    new bytes(0)
+                )
             ),
             ctx);
     }
@@ -219,11 +227,13 @@ contract SuperAppMock is ISuperApp {
     {
         (newCtx, ) = _host.callAgreementWithContext(
             agreement,
-            abi.encodeWithSelector(
-                AgreementMock.pingMe.selector,
-                address(this), // expectedMsgSender
-                42,
-                new bytes(0)
+            abi.encodeCall(
+                agreement.pingMe,
+                (
+                    address(this), // expectedMsgSender
+                    42,
+                    new bytes(0)
+                )
             ),
             new bytes(0), // user data
             abi.encode(42));
@@ -236,10 +246,12 @@ contract SuperAppMock is ISuperApp {
     {
         newCtx = _host.callAppActionWithContext(
             this,
-            abi.encodeWithSelector(
-                SuperAppMock.actionRevertWithReason.selector,
-                reason,
-                new bytes(0)
+            abi.encodeCall(
+                this.actionRevertWithReason,
+                (
+                    reason,
+                    new bytes(0)
+                )
             ),
             abi.encode(42));
     }
@@ -250,9 +262,9 @@ contract SuperAppMock is ISuperApp {
     {
         _host.callAppActionWithContext(
             this,
-            abi.encodeWithSelector(
-                SuperAppMock.actionAlteringCtx.selector,
-                new bytes(0)
+            abi.encodeCall(
+                this.actionAlteringCtx,
+                (new bytes(0))
             ),
             ctx);
         assert(false);
@@ -573,10 +585,12 @@ contract SuperAppMock2ndLevel {
     {
         (newCtx, ) = _host.callAgreementWithContext(
             _agreement,
-            abi.encodeWithSelector(
-                AgreementMock.callAppAfterAgreementCreatedCallback.selector,
-                _app,
-                new bytes(0)
+            abi.encodeCall(
+                _agreement.callAppAfterAgreementCreatedCallback,
+                (
+                    _app,
+                    new bytes(0)
+                )
             ),
             new bytes(0), // user data
             ctx);

--- a/packages/ethereum-contracts/contracts/utils/BatchLiquidator.sol
+++ b/packages/ethereum-contracts/contracts/utils/BatchLiquidator.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPLv3
 pragma solidity 0.8.13;
 
-import { ISuperfluid, ISuperAgreement } from "../interfaces/superfluid/ISuperfluid.sol";
+import { ISuperfluid, ISuperAgreement, ISuperToken } from "../interfaces/superfluid/ISuperfluid.sol";
 import { IConstantFlowAgreementV1 } from "../interfaces/agreements/IConstantFlowAgreementV1.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
@@ -33,17 +33,21 @@ contract BatchLiquidator {
             // It could be due to flow had been liquidated by others.
             // solhint-disable-next-line avoid-low-level-calls
             (success, ) = address(host).call(
-                abi.encodeWithSelector(
-                    ISuperfluid.callAgreement.selector,
-                    cfa,
-                    abi.encodeWithSelector(
-                        IConstantFlowAgreementV1.deleteFlow.selector,
-                        superToken,
-                        senders[i],
-                        receivers[i],
+                abi.encodeCall(
+                    ISuperfluid(host).callAgreement,
+                    (
+                        ISuperAgreement(cfa),
+                        abi.encodeCall(
+                            IConstantFlowAgreementV1(cfa).deleteFlow,
+                            (
+                                ISuperToken(superToken),
+                                senders[i],
+                                receivers[i],
+                                new bytes(0)
+                            )
+                        ),
                         new bytes(0)
-                    ),
-                    new bytes(0)
+                    )
                 )
             );
         }

--- a/packages/ethereum-contracts/contracts/utils/TOGA.sol
+++ b/packages/ethereum-contracts/contracts/utils/TOGA.sol
@@ -197,12 +197,14 @@ contract TOGA is ITOGAv2, IERC777Recipient {
             // need to update existing flow
             _host.callAgreement(
                 _cfa,
-                abi.encodeWithSelector(
-                    _cfa.updateFlow.selector,
-                    token,
-                    currentPICAddr,
-                    newExitRate,
-                    new bytes(0)
+                abi.encodeCall(
+                    _cfa.updateFlow,
+                    (
+                        token,
+                        currentPICAddr,
+                        newExitRate,
+                        new bytes(0)
+                    )
                 ),
                 "0x"
             );
@@ -210,12 +212,14 @@ contract TOGA is ITOGAv2, IERC777Recipient {
             // no pre-existing flow, need to create
             _host.callAgreement(
                 _cfa,
-                abi.encodeWithSelector(
-                    _cfa.createFlow.selector,
-                    token,
-                    currentPICAddr,
-                    newExitRate,
-                    new bytes(0)
+                abi.encodeCall(
+                    _cfa.createFlow,
+                    (
+                        token,
+                        currentPICAddr,
+                        newExitRate,
+                        new bytes(0)
+                    )
                 ),
                 "0x"
             );
@@ -223,12 +227,14 @@ contract TOGA is ITOGAv2, IERC777Recipient {
             // need to close existing flow
             _host.callAgreement(
                 _cfa,
-                abi.encodeWithSelector(
-                    _cfa.deleteFlow.selector,
-                    token,
-                    address(this),
-                    currentPICAddr,
-                    new bytes(0)
+                abi.encodeCall(
+                    _cfa.deleteFlow,
+                    (
+                        token,
+                        address(this),
+                        currentPICAddr,
+                        new bytes(0)
+                    )
                 ),
                 "0x"
             );
@@ -267,12 +273,14 @@ contract TOGA is ITOGAv2, IERC777Recipient {
         if (curFlowRate > 0) {
             _host.callAgreement(
                 _cfa,
-                abi.encodeWithSelector(
-                    _cfa.deleteFlow.selector,
-                    token,
-                    address(this),
-                    currentPICAddr,
-                    new bytes(0)
+                abi.encodeCall(
+                    _cfa.deleteFlow,
+                    (
+                        token,
+                        address(this),
+                        currentPICAddr,
+                        new bytes(0)
+                    )
                 ),
                 "0x"
             );
@@ -300,12 +308,14 @@ contract TOGA is ITOGAv2, IERC777Recipient {
         if (exitRate > 0) {
             _host.callAgreement(
                 _cfa,
-                abi.encodeWithSelector(
-                    _cfa.createFlow.selector,
-                    token,
-                    newPIC,
-                    exitRate,
-                    new bytes(0)
+                abi.encodeCall(
+                    _cfa.createFlow,
+                    (
+                        token,
+                        newPIC,
+                        exitRate,
+                        new bytes(0)
+                    )
                 ),
                 "0x"
             );


### PR DESCRIPTION
* abi.encodeWithSelector replaced by abi.encodeCall
* There are a few places where this was not replaced because there was no access to the function pointer or we had to return/take a function pointer for the function