### PR TITLE
Workflow Edits + Subgraph 1.4.1 Patch

### DIFF
--- a/.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
+++ b/.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
@@ -53,7 +53,7 @@ jobs:
       - name: "Docker compose"
         run: docker-compose up &
         working-directory: ./graph-node/docker
-      #
+      #                                                                     #
 
       - name: "Run subgraph integration test suite"
         if: inputs.local-subgraph-url == ''
@@ -73,5 +73,5 @@ jobs:
           yarn generate
           npx hardhat test --network localhost
         working-directory: ./packages/sdk-core
-        env: 
+        env:
           LOCAL_SUBGRAPH_URL: ${{ inputs.local-subgraph-url }}

--- a/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+++ b/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
@@ -23,15 +23,15 @@ jobs:
     env:
       contracts-working-directory: ./packages/ethereum-contracts
       sdk-core-working-directory: ./packages/sdk-core
-    
+
     steps:
       - uses: actions/checkout@v3
-    
+
       - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
           node-version: 16.x
-          
+
       - name: "Install contract dependencies"
         run: yarn install
         working-directory: ${{ env.contracts-working-directory }}
@@ -68,7 +68,7 @@ jobs:
         if: inputs.local-subgraph-url != ''
         run: docker-compose up &
         working-directory: ./graph-node/docker
-      #
+      #                                                             #
 
       - name: "Setup subgraph test environment"
         if: inputs.local-subgraph-url != ''

--- a/.github/workflows/ci.pre-release-sdk-core.yml
+++ b/.github/workflows/ci.pre-release-sdk-core.yml
@@ -64,7 +64,7 @@ jobs:
     with:
       subgraph-release: v1
 
-  # D. check previous versions of sdk-core with released v1 endpoints
+  # D. check previous versions of sdk-core with indexed v1 endpoints
   # purpose: ensure that the currently deployed v1 subgraph endpoint will work with previous sdk-core versions
   # assumption: v1 is fully indexed
   # result: this will break previous sdk-core versions if there is an intentional breaking change (must document)

--- a/.github/workflows/ci.pre-release-sdk-core.yml
+++ b/.github/workflows/ci.pre-release-sdk-core.yml
@@ -28,17 +28,23 @@ jobs:
           echo github.head_ref: ${{ github.head_ref }}
           echo github.base_ref: ${{ github.base_ref }}
 
-  # build and run sdk-core tests with local subgraph
+  # A. build and run sdk-core tests with local subgraph
+  # purpose: ensure the new sdk-core version works with the current subgraph implementation
+  # assumption: current subgraph implementation is equal to TBD (or deployed) v1 endpoints
+  # result: this should ALWAYS work otherwise there is an issue with sdk-core implementation and is NG for release
   build-and-test-local-subgraph:
     uses: ./.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
     name: Build and Test Subgraph (Release Branch)
     with:
       local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
-      # we can use v1 endpoint here because v1 endpoints must be deployed if
-      # we want to merge 
-      subgraph-release: v1
+      subgraph-release: local
 
-  # ensure subgraph indexing is complete on all v1 endpoints before allowing sdk-core release
+  # B. ensure subgraph indexing is complete on all v1 endpoints before allowing sdk-core release
+  # purpose: ensure the new sdk-core version can be released, it will ALWAYS fail if v1 is
+  #          still indexing on any network
+  # assumption: releasing sdk-core before v1 is indexed on all networks may lead to a broken release
+  #             and we usually release subgraph before sdk-core so we assume subgraph is properly deployed
+  # result: this should work once the v1 endpoints are fully indexed, otherwise it will ALWAYS fail and is NG for release
   check-subgraph-indexing-completeness:
     uses: ./.github/workflows/call.check-subgraph-indexing-statuses.yml
     name: Check Subgraph Indexing Status for v1 Endpoints
@@ -46,10 +52,25 @@ jobs:
     with:
       subgraph-release: v1
 
-  # build and test live subgraph with release sdk-core
+  # C. build and test live subgraph with release sdk-core
+  # purpose: ensure the new sdk-core version works with the currently deployed v1 matic endpoint
+  # assumption: matic is the indexing blocker and if this passes, it will pass on all other networks
+  # result: this should work once matic v1 endpoint is indexed and thus A and B should be passing as well
+  #         otherwise it's NG for release
   build-and-test-live-subgraph-current-release:
     uses: ./.github/workflows/call.test-sdk-core.yml
     name: Build and Test SDK-Core (Release branch)
     if: github.base_ref == 'release-sdk-core-stable'
+    with:
+      subgraph-release: v1
+
+  # D. check previous versions of sdk-core with released v1 endpoints
+  # purpose: ensure that the currently deployed v1 subgraph endpoint will work with previous sdk-core versions
+  # assumption: v1 is fully indexed
+  # result: this will break previous sdk-core versions if there is an intentional breaking change (must document)
+  #         otherwise it should ALWAYS work
+  check-deployed-subgraph-on-previous-sdk-versions:
+    uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+    name: Build and test current subgraph release with previous sdk-core versions
     with:
       subgraph-release: v1

--- a/.github/workflows/ci.pre-release-subgraph.yml
+++ b/.github/workflows/ci.pre-release-subgraph.yml
@@ -39,8 +39,8 @@ jobs:
       local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
       subgraph-release: local
 
-  # B. build and test live subgraph with previous sdk-core releases
-  # purpose: ensure that the currently deployed v1 subgraph endpoint will work with previous sdk-core versions
+  # B. check previous versions of sdk-core with indexed dev endpoints
+  # purpose: ensure that the currently deployed dev subgraph endpoint will work with previous sdk-core versions
   # assumption: dev is fully indexed
   # result: this will break previous sdk-core versions if there is an intentional breaking change (must document)
   #         otherwise it should ALWAYS work
@@ -53,3 +53,16 @@ jobs:
       # we want to check here if the subgraph implementation in dev is safe to use
       # for v1 endpoints (backwards compatible)
       subgraph-release: dev
+
+  # C. check previous versions of sdk-core with current subgraph implementation
+  # purpose: ensure that the current implementation of the subgraph will work with previous sdk-core versions
+  # assumption: current implementation is equal to what exists on dev (this may invalidate if B passes and this fails)
+  # result: this will break previous sdk-core versions if there is an intentional breaking change (must document)
+  #         otherwise it should ALWAYS work
+  build-and-test-local-subgraph-previous-releases:
+    uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+    name: Build and test current subgraph release with previous sdk-core versions
+    if: github.base_ref == 'release-subgraph-v1'
+    with:
+      local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
+      subgraph-release: local

--- a/.github/workflows/ci.pre-release-subgraph.yml
+++ b/.github/workflows/ci.pre-release-subgraph.yml
@@ -27,23 +27,29 @@ jobs:
           echo github.head_ref: ${{ github.head_ref }}
           echo github.base_ref: ${{ github.base_ref }}
 
-  # build and run sdk-core tests with local subgraph
+  # A. build and run sdk-core tests with local subgraph
+  # purpose: ensure the current sdk-core version works with the current subgraph implementation
+  # assumption: current subgraph implementation will not break sdk-core implementation
+  # result: this will break if there is an intentional breaking change (must document),
+  #         otherwise it should ALWAYS work
   build-and-test-local-subgraph:
     uses: ./.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
     name: Build and Test Subgraph (Release Branch)
     with:
       local-subgraph-url: http://localhost:8000/subgraphs/name/superfluid-test
-      # we must use dev endpoint here because v1 endpoints won't be deployed yet
-      # we want to test what is to be deployed
-      subgraph-release: dev
+      subgraph-release: local
 
-  # build and test live subgraph with previous sdk-core releases
+  # B. build and test live subgraph with previous sdk-core releases
+  # purpose: ensure that the currently deployed v1 subgraph endpoint will work with previous sdk-core versions
+  # assumption: dev is fully indexed
+  # result: this will break previous sdk-core versions if there is an intentional breaking change (must document)
+  #         otherwise it should ALWAYS work
   build-and-test-live-subgraph-previous-releases:
     uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
     name: Build and test current subgraph release with previous sdk-core versions
     if: github.base_ref == 'release-subgraph-v1'
     with:
       # we check with dev endpoint here because v1 endpoints won't be deployed yet
-      # we want to check here if it's safe to merge what we have in dev 
-      # endpoints to v1 endpoints (backwards compatible)
+      # we want to check here if the subgraph implementation in dev is safe to use
+      # for v1 endpoints (backwards compatible)
       subgraph-release: dev

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -45,6 +45,7 @@
         "generate:web3-types": "typechain --target=ethers-v5 --out-dir=./src/typechain \"./src/abi/**/*.json\"",
         "generate:graphql-types": "graphql-codegen --config subgraph-codegen.yml",
         "generate-graphql-schema": "yarn generate-graphql-schema:v1",
+        "generate-graphql-schema:local": "get-graphql-schema http://localhost:8000/subgraphs/name/superfluid-test > src/subgraph/schema.graphql",
         "generate-graphql-schema:v1": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic > src/subgraph/schema.graphql",
         "generate-graphql-schema:dev": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-dev-goerli > src/subgraph/schema.graphql",
         "generate-graphql-schema:feature": "get-graphql-schema https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-feature-goerli > src/subgraph/schema.graphql",

--- a/packages/sdk-core/src/events.ts
+++ b/packages/sdk-core/src/events.ts
@@ -190,6 +190,9 @@ export interface AgreementLiquidatedV2Event extends EventBase {
     targetAccountBalanceDelta: string;
     version: string;
     liquidationType: number;
+
+    // TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead
+    rewardAccount: string;
 }
 
 export interface AppRegisteredEvent extends EventBase {

--- a/packages/sdk-core/src/events.ts
+++ b/packages/sdk-core/src/events.ts
@@ -191,7 +191,7 @@ export interface AgreementLiquidatedV2Event extends EventBase {
     version: string;
     liquidationType: number;
 
-    // TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead
+    /** @deprecated TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead */
     rewardAccount: string;
 }
 

--- a/packages/sdk-core/src/mapGetAllEventsQueryEvents.ts
+++ b/packages/sdk-core/src/mapGetAllEventsQueryEvents.ts
@@ -79,6 +79,9 @@ export const mapGetAllEventsQueryEvents = (
                     targetAccountBalanceDelta: x.targetAccountBalanceDelta,
                     version: x.version,
                     liquidationType: x.liquidationType,
+
+                    // TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead
+                    rewardAccount: x.rewardAccount,
                 });
             case "BurnedEvent":
                 return typeGuard<events.BurnedEvent>({

--- a/packages/sdk-core/src/subgraph/entities/accountTokenSnapshot/accountTokenSnapshot.ts
+++ b/packages/sdk-core/src/subgraph/entities/accountTokenSnapshot/accountTokenSnapshot.ts
@@ -31,7 +31,7 @@ export interface AccountTokenSnapshot {
     totalNetFlowRate: BigNumber;
     totalNumberOfActiveStreams: number;
     totalOutflowRate: BigNumber;
-    maybeCriticalAtTimestamp: BigNumber;
+    maybeCriticalAtTimestamp: Timestamp;
     isLiquidationEstimateOptimistic: boolean;
     totalNumberOfClosedStreams: number;
     totalSubscriptionsWithUnits: number;
@@ -76,6 +76,7 @@ export class AccountTokenSnapshotQueryHandler extends SubgraphQueryHandler<
             account: x.account.id,
             token: x.token.id,
             tokenSymbol: x.token.symbol,
+            maybeCriticalAtTimestamp: Number(x.maybeCriticalAtTimestamp),
             updatedAtBlockNumber: Number(x.updatedAtBlockNumber),
             updatedAtTimestamp: Number(x.updatedAtTimestamp),
         }));

--- a/packages/sdk-core/src/subgraph/entities/accountTokenSnapshotLog/accountTokenSnapshotLog.ts
+++ b/packages/sdk-core/src/subgraph/entities/accountTokenSnapshotLog/accountTokenSnapshotLog.ts
@@ -29,7 +29,7 @@ export interface AccountTokenSnapshotLog {
     timestamp: Timestamp;
     blockNumber: BlockNumber;
     balance: BigNumber;
-    maybeCriticalAtTimestamp: BigNumber;
+    maybeCriticalAtTimestamp: Timestamp;
     totalAmountStreamed: BigNumber;
     totalAmountTransferred: BigNumber;
     totalApprovedSubscriptions: number;
@@ -80,6 +80,7 @@ export class AccountTokenSnapshotLogQueryHandler extends SubgraphQueryHandler<
             account: x.account.id,
             token: x.token.id,
             tokenSymbol: x.token.symbol,
+            maybeCriticalAtTimestamp: Number(x.maybeCriticalAtTimestamp),
             blockNumber: Number(x.blockNumber),
             timestamp: Number(x.timestamp),
             order: Number(x.order),

--- a/packages/sdk-core/src/subgraph/events/events.graphql
+++ b/packages/sdk-core/src/subgraph/events/events.graphql
@@ -1163,6 +1163,9 @@ fragment agreementLiquidatedV2Event on AgreementLiquidatedV2Event {
     targetAccountBalanceDelta
     version
     liquidationType
+
+    # TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead
+    rewardAccount
 }
 
 fragment pppConfigurationChangedEvent on PPPConfigurationChangedEvent {

--- a/packages/sdk-core/src/subgraph/queries/getAllEvents.graphql
+++ b/packages/sdk-core/src/subgraph/queries/getAllEvents.graphql
@@ -289,6 +289,9 @@ query getAllEvents(
             targetAccountBalanceDelta
             version
             liquidationType
+
+            # TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead
+            rewardAccount
         }
         ... on BurnedEvent {
             ...eventFields

--- a/packages/sdk-core/src/subgraph/schema.graphql
+++ b/packages/sdk-core/src/subgraph/schema.graphql
@@ -1219,6 +1219,7 @@ type AgreementLiquidatedV2Event implements Event {
   targetAccountBalanceDelta: BigInt!
   version: BigInt!
   liquidationType: Int!
+  rewardAccount: Bytes!
 }
 
 input AgreementLiquidatedV2Event_filter {
@@ -1362,6 +1363,12 @@ input AgreementLiquidatedV2Event_filter {
   liquidationType_lte: Int
   liquidationType_in: [Int!]
   liquidationType_not_in: [Int!]
+  rewardAccount: Bytes
+  rewardAccount_not: Bytes
+  rewardAccount_in: [Bytes!]
+  rewardAccount_not_in: [Bytes!]
+  rewardAccount_contains: Bytes
+  rewardAccount_not_contains: Bytes
 
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
@@ -1386,6 +1393,7 @@ enum AgreementLiquidatedV2Event_orderBy {
   targetAccountBalanceDelta
   version
   liquidationType
+  rewardAccount
 }
 
 type AppRegisteredEvent implements Event {

--- a/packages/sdk-core/src/subgraph/schema.graphql
+++ b/packages/sdk-core/src/subgraph/schema.graphql
@@ -1219,6 +1219,11 @@ type AgreementLiquidatedV2Event implements Event {
   targetAccountBalanceDelta: BigInt!
   version: BigInt!
   liquidationType: Int!
+
+  """
+  TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead
+  
+  """
   rewardAccount: Bytes!
 }
 

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/subgraph",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Subgraph for the Superfluid Ethereum contracts.",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/subgraph",
     "repository": {

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -682,6 +682,9 @@ type AgreementLiquidatedV2Event implements Event @entity {
     targetAccountBalanceDelta: BigInt!
     version: BigInt!
     liquidationType: Int!
+
+    # TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead
+    rewardAccount: Bytes!
 }
 
 type BurnedEvent implements Event @entity {

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -683,8 +683,8 @@ type AgreementLiquidatedV2Event implements Event @entity {
     version: BigInt!
     liquidationType: Int!
 
-    # TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead
-    rewardAccount: Bytes!
+    """TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead"""
+    rewardAccount: Bytes! @deprecated(reason: "use rewardAmountReceiver")
 }
 
 type BurnedEvent implements Event @entity {

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -313,6 +313,7 @@ function createAgreementLiquidatedV2Entity(event: AgreementLiquidatedV2): void {
     ev.agreementId = event.params.id;
     ev.targetAccount = event.params.targetAccount;
     ev.rewardAmountReceiver = event.params.rewardAmountReceiver;
+    ev.rewardAccount = event.params.rewardAmountReceiver;
     ev.rewardAmount = event.params.rewardAmount;
     ev.targetAccountBalanceDelta = event.params.targetAccountBalanceDelta;
 


### PR DESCRIPTION
* workflow comments added to jobs in pre-release CI files
* `generate-graphql-schema:local` script to test local subgraph endpoints without dependency on deployed endpoint
* Subgraph v1.4.1 patch keep rewardAccount in subgraph to not break previous + current versions of sdk-core
   * essentially reverting breaking change to previous SDK-core versions

> NOTE: after some discussions with @kasparkallas this morning, it makes sense not to break previous SDK-core versions as a result of subgraph updates. It does seem to make the most sense to keep these kinds of breaking changes (changing the name of a property) for a brand new v2 subgraph endpoint which can be released/supported with a new SDK-core version and then deprecating the v1 endpoint completely.