### PR TITLE
Increase Code Coverage

### DIFF
--- a/packages/ethereum-contracts/contracts/mocks/CFAAppMocks.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFAAppMocks.sol
@@ -36,7 +36,7 @@ contract ExclusiveInflowTestApp is SuperAppBase {
             // | SuperAppDefinitions.AFTER_AGREEMENT_TERMINATED_NOOP
             ;
 
-        _host.registerApp(configWord);
+        _host.registerAppWithKey(configWord, "");
     }
 
     function afterAgreementCreated(
@@ -121,7 +121,7 @@ contract NonClosableOutflowTestApp is SuperAppBase {
             // | SuperAppDefinitions.AFTER_AGREEMENT_TERMINATED_NOOP
             ;
 
-        _host.registerApp(configWord);
+        _host.registerAppWithKey(configWord, "");
     }
 
     function setupOutflow(
@@ -210,7 +210,7 @@ contract SelfDeletingFlowTestApp is SuperAppBase {
             | SuperAppDefinitions.AFTER_AGREEMENT_TERMINATED_NOOP
             ;
 
-        _host.registerApp(configWord);
+        _host.registerAppWithKey(configWord, "");
     }
 
     function afterAgreementCreated(
@@ -267,7 +267,7 @@ contract ClosingOnUpdateFlowTestApp is SuperAppBase {
             | SuperAppDefinitions.AFTER_AGREEMENT_TERMINATED_NOOP
             ;
 
-        _host.registerApp(configWord);
+        _host.registerAppWithKey(configWord, "");
     }
 
     function afterAgreementUpdated(
@@ -326,7 +326,7 @@ contract FlowExchangeTestApp is SuperAppBase {
             | SuperAppDefinitions.AFTER_AGREEMENT_TERMINATED_NOOP
             ;
 
-        _host.registerApp(configWord);
+        _host.registerAppWithKey(configWord, "");
     }
 
     function afterAgreementCreated(

--- a/packages/ethereum-contracts/contracts/mocks/CFALibraryMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFALibraryMock.sol
@@ -161,7 +161,7 @@ contract CFALibrarySuperAppMock is SuperAppBase {
             SuperAppDefinitions.BEFORE_AGREEMENT_TERMINATED_NOOP |
             SuperAppDefinitions.AFTER_AGREEMENT_TERMINATED_NOOP;
 
-        host.registerApp(configWord);
+        host.registerAppWithKey(configWord, "");
     }
 
     function createFlow(ISuperToken token) external {

--- a/packages/ethereum-contracts/contracts/mocks/IDASuperAppTester.sol
+++ b/packages/ethereum-contracts/contracts/mocks/IDASuperAppTester.sol
@@ -26,7 +26,7 @@ contract IDASuperAppTester is ISuperApp {
         uint32 indexId)
     {
         _host = host;
-        _host.registerApp(configWord);
+        _host.registerAppWithKey(configWord, "");
         _ida = ida;
         _token = token;
         _indexId = indexId;

--- a/packages/ethereum-contracts/contracts/mocks/IDAv1LibraryMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/IDAv1LibraryMock.sol
@@ -157,7 +157,7 @@ contract IDAv1LibraryMock {
     /**************************************************************************
      * Subscription Operations
      *************************************************************************/
-    
+
     function approveSubscriptionTest(
         ISuperfluidToken token,
         address publisher,
@@ -265,7 +265,7 @@ contract IDAv1LibrarySuperAppMock is IDAv1LibraryMock, SuperAppBase {
             SuperAppDefinitions.BEFORE_AGREEMENT_TERMINATED_NOOP |
             SuperAppDefinitions.AFTER_AGREEMENT_TERMINATED_NOOP;
 
-        host.registerApp(configWord);
+        host.registerAppWithKey(configWord, "");
     }
 
     function afterAgreementCreated(

--- a/packages/ethereum-contracts/contracts/mocks/MultiFlowTesterApp.sol
+++ b/packages/ethereum-contracts/contracts/mocks/MultiFlowTesterApp.sol
@@ -41,7 +41,7 @@ contract MultiFlowTesterApp is SuperAppBase {
             SuperAppDefinitions.BEFORE_AGREEMENT_CREATED_NOOP |
             SuperAppDefinitions.BEFORE_AGREEMENT_TERMINATED_NOOP;
 
-        _host.registerApp(configWord);
+        _host.registerAppWithKey(configWord, "");
     }
 
     function _parseUserData(

--- a/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
@@ -51,9 +51,9 @@ contract SuperAppMock is ISuperApp {
 
     constructor(ISuperfluid host, uint256 configWord, bool doubleRegistration) {
         _host = host;
-        _host.registerApp(configWord);
+        _host.registerAppWithKey(configWord, "");
         if (doubleRegistration) {
-            _host.registerApp(configWord);
+            _host.registerAppWithKey(configWord, "");
         }
         _aux = new SuperAppMockAux();
     }
@@ -461,7 +461,7 @@ contract SuperAppMockReturningEmptyCtx {
 
     constructor(ISuperfluid host) {
         _host = host;
-        _host.registerApp(SuperAppDefinitions.APP_LEVEL_FINAL);
+        _host.registerAppWithKey(SuperAppDefinitions.APP_LEVEL_FINAL, "");
     }
 
     function beforeAgreementCreated(
@@ -522,7 +522,7 @@ contract SuperAppMockReturningInvalidCtx {
 
     constructor(ISuperfluid host) {
         _host = host;
-        _host.registerApp(SuperAppDefinitions.APP_LEVEL_FINAL);
+        _host.registerAppWithKey(SuperAppDefinitions.APP_LEVEL_FINAL, "");
     }
 
     function afterAgreementCreated(
@@ -563,7 +563,7 @@ contract SuperAppMock2ndLevel {
 
     constructor(ISuperfluid host, SuperAppMock app, AgreementMock agreement) {
         _host = host;
-        _host.registerApp(SuperAppDefinitions.APP_LEVEL_SECOND);
+        _host.registerAppWithKey(SuperAppDefinitions.APP_LEVEL_SECOND, "");
         _app = app;
         _agreement = agreement;
     }
@@ -597,14 +597,17 @@ contract SuperAppMock2ndLevel {
     }
 }
 
-// The default SuperApp mock that does many tricks
+// An Super App that uses registerAppWithKey
 contract SuperAppMockWithRegistrationkey {
-
-    ISuperfluid private _host;
-
     constructor(ISuperfluid host, uint256 configWord, string memory registrationKey) {
-        _host = host;
-        _host.registerAppWithKey(configWord, registrationKey);
+        host.registerAppWithKey(configWord, registrationKey);
+    }
+}
+
+// An Super App that uses registerAppWithKey
+contract SuperAppMockUsingDeprecatedRegisterApp {
+    constructor(ISuperfluid host, uint256 configWord) {
+        host.registerApp(configWord);
     }
 }
 

--- a/packages/ethereum-contracts/contracts/mocks/SuperfluidMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperfluidMock.sol
@@ -171,7 +171,7 @@ contract SuperfluidMock is Superfluid {
     function jailApp(ISuperApp app)
         external
     {
-        _jailApp(app, 0);
+        _jailApp(app, 6942);
     }
 
 }

--- a/packages/ethereum-contracts/contracts/superfluid/FullUpgradableSuperTokenProxy.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/FullUpgradableSuperTokenProxy.sol
@@ -32,7 +32,7 @@ contract FullUpgradableSuperTokenProxy is Proxy {
         assembly { // solium-disable-line
             factory := sload(_FACTORY_SLOT)
         }
-        require(address(factory) != address(0), "Not initialized");
+        assert(address(factory) != address(0));
         return address(factory.getSuperTokenLogic());
     }
 

--- a/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
@@ -255,7 +255,7 @@ contract Superfluid is
         external view override
         returns (address logic)
     {
-        if (address(_superTokenFactory) == address(0)) return address(0);
+        assert(address(_superTokenFactory) != address(0));
         if (NON_UPGRADABLE_DEPLOYMENT) return address(_superTokenFactory);
         else return UUPSProxiable(address(_superTokenFactory)).getCodeAddress();
     }

--- a/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
@@ -1076,9 +1076,9 @@ contract Superfluid is
         if (actionSelector == ISuperApp.beforeAgreementCreated.selector ||
             actionSelector == ISuperApp.afterAgreementCreated.selector ||
             actionSelector == ISuperApp.beforeAgreementUpdated.selector ||
-            actionSelector == ISuperApp.afterAgreementCreated.selector ||
+            actionSelector == ISuperApp.afterAgreementUpdated.selector ||
             actionSelector == ISuperApp.beforeAgreementTerminated.selector ||
-            actionSelector == ISuperApp.afterAgreementCreated.selector) {
+            actionSelector == ISuperApp.afterAgreementTerminated.selector) {
             revert("SF: agreement callback is not action");
         }
         _;

--- a/packages/ethereum-contracts/contracts/utils/TestToken.sol
+++ b/packages/ethereum-contracts/contracts/utils/TestToken.sol
@@ -23,7 +23,7 @@ contract TestToken is ERC20 {
      * @dev See {ERC20-_mint}.
      */
     function mint(address account, uint256 amount) public returns (bool) {
-        require(amount <= MINT_LIMIT, "Don't mint too many");
+        assert(amount <= MINT_LIMIT); // no revert msg for you, bad boy
         ERC20._mint(account, amount);
         return true;
     }

--- a/packages/ethereum-contracts/test/contracts/superfluid/SuperTokenFactory.test.js
+++ b/packages/ethereum-contracts/test/contracts/superfluid/SuperTokenFactory.test.js
@@ -8,6 +8,9 @@ const SuperTokenFactory = artifacts.require("SuperTokenFactory");
 const SuperTokenFactoryMockHelper = artifacts.require(
     "SuperTokenFactoryMockHelper"
 );
+const FullUpgradableSuperTokenProxy = artifacts.require(
+    "FullUpgradableSuperTokenProxy"
+);
 const SuperTokenMock = artifacts.require("SuperTokenMock");
 
 const TestEnvironment = require("../../TestEnvironment");
@@ -165,6 +168,9 @@ describe("SuperTokenFactory Contract", function () {
                 let superToken1 = await t.sf.createERC20Wrapper(token1, {
                     upgradability: 2,
                 });
+                let proxy = await FullUpgradableSuperTokenProxy.at(
+                    superToken1.address
+                );
                 await expectEvent(superToken1.tx.receipt, "SuperTokenCreated", {
                     token: superToken1.address,
                 });
@@ -179,6 +185,10 @@ describe("SuperTokenFactory Contract", function () {
                         superToken1.address,
                     ]),
                     "UUPSProxiable: not upgradable"
+                );
+                await expectRevertedWith(
+                    proxy.initialize(),
+                    "Already initialized"
                 );
             });
 

--- a/packages/ethereum-contracts/test/contracts/superfluid/Superfluid.test.js
+++ b/packages/ethereum-contracts/test/contracts/superfluid/Superfluid.test.js
@@ -1218,6 +1218,25 @@ describe("Superfluid Host Contract", function () {
                         );
                     }
                 });
+
+                it("#6.19 Jail event should not be emitted twice", async () => {
+                    let tx = await superfluid.jailApp(app.address);
+                    await expectEvent.inTransaction(
+                        tx.tx,
+                        superfluid.contract,
+                        "Jail",
+                        {
+                            app: app.address,
+                            reason: "6942", // it is scientific, check the code
+                        }
+                    );
+                    tx = await superfluid.jailApp(app.address);
+                    await expectEvent.notEmitted.inTransaction(
+                        tx.tx,
+                        superfluid.contract,
+                        "Jail"
+                    );
+                });
             });
 
             context("#6.2x callback gas limit", () => {

--- a/packages/ethereum-contracts/test/contracts/upgradability/UUPS.test.js
+++ b/packages/ethereum-contracts/test/contracts/upgradability/UUPS.test.js
@@ -62,6 +62,11 @@ describe("Miscellaneous for test coverages", function () {
                 proxiable.updateCode(mock2.address),
                 "UUPSProxiable: not compatible logic"
             );
+
+            await expectRevertedWith(
+                proxiable.updateCode(proxiable.address),
+                "UUPSProxiable: proxy loop"
+            );
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,7 +873,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.6.0"
 
-"@ethersproject/contracts@5.6.0", "@ethersproject/contracts@^5.6.0":
+"@ethersproject/contracts@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.6.0.tgz#60f2cfc7addd99a865c6c8cfbbcec76297386067"
   integrity sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==
@@ -4488,7 +4488,7 @@
   version "0.2.0"
   resolved "https://codeload.github.com/Digital-MOB-Filecoin/filecoin-signing-tools-js/tar.gz/8f8e92157cac2556d35cab866779e9a8ea8a4e25"
   dependencies:
-    axios "^0.20.0"
+    axios "0.26.1"
     base32-decode "^1.0.0"
     base32-encode "^1.1.1"
     bip32 "^2.0.5"


### PR DESCRIPTION
Closing #596 

**DONE**

- Superfluid.sol fully covered
- FullUpgradableSuperTokenProxy.sol fully covered
- TestToken fully covered
-  UUPSProxiable.sol fully covered

**DEFERRED**

-  ConstantFlowAgreementV1.sol - need 2nd-level app app credit.
-  SuperfluidGovernanceBase.sol - some trivial input validations and setConfig not tested.
-  SuperToken.sol - inflation/deflationary tokens.
-  MaticBridgedNativeSuperToken.sol  - to be moved to other repo.
-  SuperfluidFrameworkDeployer.sol - to be used
-  TOGA.sol - a constructor input check & reentrance
-  TestGovernance.sol - non empty trustedForwarders not tested

to be continued in #892 