### PR TITLE
[SDK-REDUX] Pass in `signer` and `overrides` through mutation payload

### DIFF
--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/App.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/App.tsx
@@ -36,10 +36,12 @@ import { StreamPeriods } from "./features/generic-entity-queries/StreamPeriods";
 import { Tokens } from "./features/generic-entity-queries/Tokens";
 import { IndexSubscriptions } from "./features/generic-entity-queries/IndexSubscriptions";
 import { TokenStatistics } from "./features/generic-entity-queries/TokenStatistics";
+import { Signer } from "ethers";
 
 function App() {
     const [superfluidSdk, setSuperfluidSdk] = useState<Framework | undefined>();
     const [signerAddress, setSignerAddress] = useState<string | undefined>();
+    const [signer, setSigner] = useState<Signer>();
     const [chainId, setChainId] = useState<number | undefined>();
 
     const onSuperfluidSdkInitialized = async (
@@ -48,11 +50,10 @@ function App() {
     ) => {
         setSuperfluidSdk(superfluidSdk);
 
-        provider
-            .getSigner()
-            .getAddress()
-            .then((address) => setSignerAddress(address));
+        const _signer = provider.getSigner();
+        setSigner(_signer);
 
+        _signer.getAddress().then((address) => setSignerAddress(address));
         provider.getNetwork().then((network) => setChainId(network.chainId));
     };
 
@@ -114,10 +115,10 @@ function App() {
                             onSuperfluidSdkInitialized(x, provider)
                         }
                     />
-                ) : !chainId || !signerAddress ? (
+                ) : !chainId || !signerAddress || !signer ? (
                     <Loader />
                 ) : (
-                    <SignerContext.Provider value={[chainId, signerAddress]}>
+                    <SignerContext.Provider value={[chainId, signerAddress, signer]}>
                         <Box maxWidth="sm">
                             <Typography sx={{ mb: 4 }}>
                                 You are connected. You are on network [{chainId}

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/InitializeSuperfluidSdk.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/InitializeSuperfluidSdk.tsx
@@ -1,10 +1,10 @@
-import React, { FC, ReactElement } from "react";
+import { FC, ReactElement } from "react";
 import { Framework } from "@superfluid-finance/sdk-core";
 import { Web3Provider } from "@ethersproject/providers";
 import { Button } from "@mui/material";
 import { ethers } from "ethers";
 import Web3Modal from "web3modal";
-import { setFrameworkForSdkRedux, setSignerForSdkRedux } from "@superfluid-finance/sdk-redux";
+import { setFrameworkForSdkRedux } from "@superfluid-finance/sdk-redux";
 
 interface Props {
     onSuperfluidSdkInitialized: (sf: Framework, provider: Web3Provider) => void;
@@ -64,16 +64,10 @@ export const InitializeSuperfluidSdk: FC<Props> = ({
 
         // Set active provider & signer from MetaMask
         setFrameworkForSdkRedux(currentNetwork.chainId, superfluidSdk);
-        setSignerForSdkRedux(currentNetwork.chainId, ethersWeb3Provider.getSigner());
 
         onSuperfluidSdkInitialized(superfluidSdk, ethersWeb3Provider);
 
         web3ModalProvider.on("accountsChanged", (accounts: string[]) => {
-            setSignerForSdkRedux(
-                currentNetwork.chainId,
-                ethersWeb3Provider.getSigner()
-            );
-
             onSuperfluidSdkInitialized(superfluidSdk, ethersWeb3Provider);
         });
 
@@ -95,7 +89,6 @@ export const InitializeSuperfluidSdk: FC<Props> = ({
 
             // Set active provider & signer from MetaMask
             setFrameworkForSdkRedux(parsedChainId, newSdk);
-            setSignerForSdkRedux(parsedChainId, ethersWeb3Provider.getSigner());
 
             onSuperfluidSdkInitialized(newSdk, ethersWeb3Provider);
         });

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/SignerContext.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/SignerContext.tsx
@@ -1,5 +1,6 @@
+import { ethers } from "ethers";
 import { createContext } from "react";
 
 export const SignerContext = createContext<
-    [chainId: number, signerAddress: string]
+    [chainId: number, signerAddress: string, signer: ethers.Signer]
 >(undefined!);

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/DeleteStream.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/DeleteStream.tsx
@@ -8,7 +8,7 @@ import { sfApi } from "../redux/store";
 export const DeleteStream: FC = (): ReactElement => {
     const [deleteFlow, { isLoading, error }] = sfApi.useFlowDeleteMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
 
     const [receiver, setReceiver] = useState<string>("");
     const [superToken, setSuperToken] = useState<string>("");
@@ -23,7 +23,8 @@ export const DeleteStream: FC = (): ReactElement => {
             chainId,
             superTokenAddress: superToken,
             waitForConfirmation,
-            userDataBytes
+            userDataBytes,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/DistributeToIndex.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/DistributeToIndex.tsx
@@ -8,7 +8,7 @@ import { sfApi } from "../redux/store";
 export const DistributeToIndex: FC = (): ReactElement => {
     const [distribute, { isLoading, error }] = sfApi.useIndexDistributeMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
     const [superToken, setSuperToken] = useState<string>("");
     const [indexId, setIndexId] = useState<string>("");
     const [amountWei, setAmountWei] = useState<string>("");
@@ -24,6 +24,7 @@ export const DistributeToIndex: FC = (): ReactElement => {
             indexId,
             amountWei,
             userDataBytes,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/FlowCreate.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/FlowCreate.tsx
@@ -8,7 +8,7 @@ import { sfApi } from "../redux/store";
 export const FlowCreate: FC = (): ReactElement => {
     const [createFlow, { isLoading, error }] = sfApi.useFlowCreateMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
 
     const [receiver, setReceiver] = useState<string>("");
     const [superToken, setSuperToken] = useState<string>("");
@@ -25,7 +25,8 @@ export const FlowCreate: FC = (): ReactElement => {
             chainId,
             superTokenAddress: superToken,
             waitForConfirmation,
-            userDataBytes
+            userDataBytes,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/FlowUpdate.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/FlowUpdate.tsx
@@ -8,7 +8,7 @@ import { sfApi } from "../redux/store";
 export const FlowUpdate: FC = (): ReactElement => {
     const [updateFlow, { isLoading, error }] = sfApi.useFlowUpdateMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
 
     const [receiver, setReceiver] = useState<string>("");
     const [superToken, setSuperToken] = useState<string>("");
@@ -25,7 +25,8 @@ export const FlowUpdate: FC = (): ReactElement => {
             superTokenAddress: superToken,
             flowRateWei: flowRate,
             waitForConfirmation,
-            userDataBytes: userDataBytes
+            userDataBytes: userDataBytes,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexCreate.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexCreate.tsx
@@ -8,7 +8,7 @@ import { sfApi } from "../redux/store";
 export const IndexCreate: FC = (): ReactElement => {
     const [createIndex, { isLoading, error }] = sfApi.useIndexCreateMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
     const [superToken, setSuperToken] = useState<string>("");
     const [indexId, setIndexId] = useState<string>("");
     const [userDataBytes, setUserDataBytes] = useState<string>("");
@@ -22,6 +22,7 @@ export const IndexCreate: FC = (): ReactElement => {
             superTokenAddress: superToken,
             indexId,
             userDataBytes,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexDeleteSubscription.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexDeleteSubscription.tsx
@@ -9,7 +9,7 @@ export const IndexDeleteSubscription: FC = (): ReactElement => {
     const [trigger, { isLoading, error }] =
         sfApi.useIndexDeleteSubscriptionMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
     const [superToken, setSuperToken] = useState<string>("");
     const [publisherAddress, setPublisherAddress] = useState<string>("");
     const [indexId, setIndexId] = useState<string>("");
@@ -26,6 +26,7 @@ export const IndexDeleteSubscription: FC = (): ReactElement => {
             userDataBytes,
             publisherAddress,
             subscriberAddress: signerAddress,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexSubscriptionApprove.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexSubscriptionApprove.tsx
@@ -9,7 +9,7 @@ export const IndexSubscriptionApprove: FC = (): ReactElement => {
     const [approve, { isLoading, error }] =
         sfApi.useIndexSubscriptionApproveMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
     const [superToken, setSuperToken] = useState<string>("");
     const [publisherAddress, setPublisherAddress] = useState<string>("");
     const [indexId, setIndexId] = useState<string>("");
@@ -25,6 +25,7 @@ export const IndexSubscriptionApprove: FC = (): ReactElement => {
             indexId,
             userDataBytes,
             publisherAddress,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexSubscriptionClaim.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexSubscriptionClaim.tsx
@@ -9,7 +9,7 @@ export const IndexSubscriptionClaim: FC = (): ReactElement => {
     const [claim, { isLoading, error }] =
         sfApi.useIndexSubscriptionClaimMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
     const [superToken, setSuperToken] = useState<string>("");
     const [publisherAddress, setPublisherAddress] = useState<string>("");
     const [indexId, setIndexId] = useState<string>("");
@@ -26,6 +26,7 @@ export const IndexSubscriptionClaim: FC = (): ReactElement => {
             userDataBytes,
             publisherAddress,
             subscriberAddress: signerAddress,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexSubscriptionRevoke.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexSubscriptionRevoke.tsx
@@ -9,7 +9,7 @@ export const IndexSubscriptionRevoke: FC = (): ReactElement => {
     const [trigger, { isLoading, error }] =
         sfApi.useIndexSubscriptionRevokeMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
     const [superToken, setSuperToken] = useState<string>("");
     const [publisherAddress, setPublisherAddress] = useState<string>("");
     const [indexId, setIndexId] = useState<string>("");
@@ -24,7 +24,8 @@ export const IndexSubscriptionRevoke: FC = (): ReactElement => {
             superTokenAddress: superToken,
             indexId,
             userDataBytes,
-            publisherAddress
+            publisherAddress,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexUpdateSubscriptionUnits.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/IndexUpdateSubscriptionUnits.tsx
@@ -9,7 +9,7 @@ export const IndexUpdateSubscriptionUnits: FC = (): ReactElement => {
     const [update, { isLoading, error }] =
         sfApi.useIndexUpdateSubscriptionUnitsMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
     const [superToken, setSuperToken] = useState<string>("");
     const [subscriberAddress, setSubscriberAddress] = useState<string>("");
     const [indexId, setIndexId] = useState<string>("");
@@ -27,6 +27,7 @@ export const IndexUpdateSubscriptionUnits: FC = (): ReactElement => {
             userDataBytes,
             unitsNumber,
             subscriberAddress,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/SuperTokenDowngrade.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/SuperTokenDowngrade.tsx
@@ -9,7 +9,7 @@ export const SuperTokenDowngrade: FC = (): ReactElement => {
     const [downgradeFromSuperToken, { isLoading, error }] =
         sfApi.useSuperTokenDowngradeMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
 
     const [amount, setAmount] = useState<string>("");
     const [superToken, setSuperToken] = useState<string>("");
@@ -17,11 +17,12 @@ export const SuperTokenDowngrade: FC = (): ReactElement => {
         useState<boolean>(false);
 
     const handleDowngradeFromSuperToken = (e: SyntheticEvent) => {
-        downgradeFromSuperToken({
+        downgradeFromSuperToken({   
             chainId,
             superTokenAddress: superToken,
             amountWei: amount,
-            waitForConfirmation
+            waitForConfirmation,
+            signer
         });
     };
 

--- a/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/SuperTokenUpgrade.tsx
+++ b/examples/sdk-redux-examples/sdk-redux-react-typecript/src/features/SuperTokenUpgrade.tsx
@@ -9,7 +9,7 @@ export const SuperTokenUpgrade: FC = (): ReactElement => {
     const [upgradeToSuperToken, { isLoading, error }] =
         sfApi.useSuperTokenUpgradeMutation();
 
-    const [chainId, signerAddress] = useContext(SignerContext);
+    const [chainId, signerAddress, signer] = useContext(SignerContext);
 
     const [amount, setAmount] = useState<string>("");
     const [superToken, setSuperToken] = useState<string>("");
@@ -37,6 +37,7 @@ export const SuperTokenUpgrade: FC = (): ReactElement => {
             chainId,
             superTokenAddress: superToken,
             amountWei: amount,
+            signer
         });
     };
 

--- a/packages/sdk-redux/CHANGELOG.md
+++ b/packages/sdk-redux/CHANGELOG.md
@@ -3,8 +3,13 @@ All notable changes to the SDK-redux will be documented in this file.
 
 ## [Unreleased]
 
+### Breaking
+- Pass in `signer` through mutation payload
+- Remove `setSignerForSdkRedux`
+
 ### Added
 - Query for transfer events
+- Make it possible to pass in Ether's `Overrides` object through mutations
 
 ## [0.3.0] - 2022-04-13
 

--- a/packages/sdk-redux/README.md
+++ b/packages/sdk-redux/README.md
@@ -117,12 +117,11 @@ export const store = configureStore({
 });
 ```
 
-Somewhere in your code, give instructions to the `sdkReduxConfig` to locate `Framework` and `Signer`:
+Somewhere in your code, give instructions to the `sdkReduxConfig` to locate `Framework`:
 ```ts
-import { setFrameworkForSdkRedux, setSignerForSdkRedux } from "@superfluid-finance/sdk-redux";
+import { setFrameworkForSdkRedux } from "@superfluid-finance/sdk-redux";
 
 setFrameworkForSdkRedux(chainId, sdkCoreFramework);
-setSignerForSdkRedux(chainId, ethersWeb3Provider.getSigner());
 ```
 
 That should be it! You should now be able to dispatch messages to Superfluid reducers & use the React hooks.
@@ -165,12 +164,13 @@ Read about RTK-Query queries here: https://redux-toolkit.js.org/rtk-query/usage/
 Example using React Hook:
 ```ts
 const tx = await rpcApi.createFlow({
-    senderAddress: signerAddress,
+    signer,
+    chainId,
+    waitForConfirmation,
+    senderAddress: senderAddress,
     receiverAddress: receiver,
     flowRateWei: flowRate,
-    chainId,
-    superTokenAddress: superToken,
-    waitForConfirmation,
+    superTokenAddress: superToken
 }).unwrap();
 ```
 

--- a/packages/sdk-redux/src/reduxSlices/argTypes.ts
+++ b/packages/sdk-redux/src/reduxSlices/argTypes.ts
@@ -1,3 +1,8 @@
+import {ISuperTokenModifyFlowParams} from '@superfluid-finance/sdk-core';
+import {Signer} from 'ethers';
+
+import {mutationOverridesKey, mutationSignerKey} from '../utils';
+
 /**
  * Information about the transaction to locate it.
  */
@@ -43,6 +48,9 @@ export interface BaseSuperTokenMutation {
      * Custom data to included in transaction tracking. Has to be serializable for redux!
      */
     transactionExtraData?: Record<string, unknown>;
+
+    [mutationOverridesKey]?: ISuperTokenModifyFlowParams['overrides'];
+    [mutationSignerKey]: Signer;
 }
 
 /**

--- a/packages/sdk-redux/src/reduxSlices/rtkQuery/getSerializeQueryArgs.ts
+++ b/packages/sdk-redux/src/reduxSlices/rtkQuery/getSerializeQueryArgs.ts
@@ -1,9 +1,11 @@
 import {isPlainObject} from '@reduxjs/toolkit';
 import {SerializeQueryArgs} from '@reduxjs/toolkit/dist/query/defaultSerializeQueryArgs';
 
+import {mutationOverridesKey, mutationSignerKey} from '../../utils';
+
 export const getSerializeQueryArgs =
     (): SerializeQueryArgs<any> =>
-    ({endpointName, queryArgs}) => {
+    ({endpointName, queryArgs, endpointDefinition}) => {
         // NOTE: The code below is taken from Redux Toolkit's repository from `defaultSerializeQueryArgs.ts`.
 
         // Comment from RTK-Query: Sort the object keys before stringifying, to prevent useQuery({ a: 1, b: 2 }) having a different cache key than useQuery({ b: 2, a: 1 })
@@ -12,6 +14,13 @@ export const getSerializeQueryArgs =
                 ? Object.keys(value)
                       .sort()
                       .reduce<any>((acc, key) => {
+                          // Don't cache non-serializable data from mutation args.
+                          if (endpointDefinition.type === 'mutation') {
+                              if (key === mutationOverridesKey || key === mutationSignerKey) {
+                                  return acc;
+                              }
+                          }
+
                           acc[key] = normalizeValue((value as any)[key]);
                           return acc;
                       }, {})

--- a/packages/sdk-redux/src/reduxSlices/rtkQuery/rpcApiSlice/endpoints/flowEndpoints.ts
+++ b/packages/sdk-redux/src/reduxSlices/rtkQuery/rpcApiSlice/endpoints/flowEndpoints.ts
@@ -1,4 +1,4 @@
-import {getFramework, getSigner} from '../../../../sdkReduxConfig';
+import {getFramework} from '../../../../sdkReduxConfig';
 import {TransactionInfo} from '../../../argTypes';
 import {registerNewTransactionAndReturnQueryFnResult} from '../../../transactionTrackerSlice/registerNewTransaction';
 import {RpcEndpointBuilder} from '../rpcEndpointBuilder';
@@ -8,11 +8,10 @@ import {FlowCreateMutation, FlowDeleteMutation, FlowUpdateMutation} from './flow
 export const createFlowEndpoints = (builder: RpcEndpointBuilder) => ({
     flowCreate: builder.mutation<TransactionInfo, FlowCreateMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
-            const senderAddress = arg.senderAddress ? arg.senderAddress : await signer.getAddress();
+            const senderAddress = arg.senderAddress ? arg.senderAddress : await arg.signer.getAddress();
 
             const transactionResponse = await superToken
                 .createFlow({
@@ -20,8 +19,9 @@ export const createFlowEndpoints = (builder: RpcEndpointBuilder) => ({
                     receiver: arg.receiverAddress,
                     flowRate: arg.flowRateWei,
                     userData: arg.userDataBytes,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
@@ -36,10 +36,9 @@ export const createFlowEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     flowUpdate: builder.mutation<TransactionInfo, FlowUpdateMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
-            const senderAddress = arg.senderAddress ? arg.senderAddress : await signer.getAddress();
+            const senderAddress = arg.senderAddress ? arg.senderAddress : await arg.signer.getAddress();
 
             const transactionResponse = await superToken
                 .updateFlow({
@@ -47,8 +46,9 @@ export const createFlowEndpoints = (builder: RpcEndpointBuilder) => ({
                     receiver: arg.receiverAddress,
                     flowRate: arg.flowRateWei,
                     userData: arg.userDataBytes,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
@@ -63,19 +63,19 @@ export const createFlowEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     flowDelete: builder.mutation<TransactionInfo, FlowDeleteMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
-            const senderAddress = arg.senderAddress ? arg.senderAddress : await signer.getAddress();
+            const senderAddress = arg.senderAddress ? arg.senderAddress : await arg.signer.getAddress();
 
             const transactionResponse = await superToken
                 .deleteFlow({
                     sender: senderAddress,
                     receiver: arg.receiverAddress,
                     userData: arg.userDataBytes,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,

--- a/packages/sdk-redux/src/reduxSlices/rtkQuery/rpcApiSlice/endpoints/indexEndpoints.ts
+++ b/packages/sdk-redux/src/reduxSlices/rtkQuery/rpcApiSlice/endpoints/indexEndpoints.ts
@@ -1,4 +1,4 @@
-import {getFramework, getSigner} from '../../../../sdkReduxConfig';
+import {getFramework} from '../../../../sdkReduxConfig';
 import {TransactionInfo} from '../../../argTypes';
 import {registerNewTransactionAndReturnQueryFnResult} from '../../../transactionTrackerSlice/registerNewTransaction';
 import {RpcEndpointBuilder} from '../rpcEndpointBuilder';
@@ -16,7 +16,6 @@ import {
 export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
     indexCreate: builder.mutation<TransactionInfo, IndexCreateMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -24,13 +23,14 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
                 .createIndex({
                     indexId: arg.indexId,
                     userData: arg.userDataBytes,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Create Index',
@@ -40,7 +40,6 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     indexDistribute: builder.mutation<TransactionInfo, IndexDistributeMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -49,13 +48,14 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
                     indexId: arg.indexId,
                     userData: arg.userDataBytes,
                     amount: arg.amountWei,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Distribute Index',
@@ -65,7 +65,6 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     indexUpdateSubscriptionUnits: builder.mutation<TransactionInfo, IndexUpdateSubscriptionUnitsMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -75,13 +74,14 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
                     subscriber: arg.subscriberAddress,
                     units: arg.unitsNumber,
                     userData: arg.userDataBytes,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Update Index Subscription Units',
@@ -91,7 +91,6 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     indexSubscriptionApprove: builder.mutation<TransactionInfo, IndexSubscriptionApproveMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -100,13 +99,14 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
                     indexId: arg.indexId,
                     publisher: arg.publisherAddress,
                     userData: arg.userDataBytes,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Approve Index Subscription',
@@ -116,7 +116,6 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     indexSubscriptionClaim: builder.mutation<TransactionInfo, IndexSubscriptionClaimMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -126,13 +125,14 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
                     publisher: arg.publisherAddress,
                     subscriber: arg.subscriberAddress,
                     userData: arg.userDataBytes,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Claim from Index Subscription',
@@ -142,7 +142,6 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     indexDeleteSubscription: builder.mutation<TransactionInfo, IndexDeleteSubscriptionMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -152,13 +151,14 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
                     publisher: arg.publisherAddress,
                     subscriber: arg.subscriberAddress,
                     userData: arg.userDataBytes,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Delete Index Subscription',
@@ -168,7 +168,6 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     indexSubscriptionRevoke: builder.mutation<TransactionInfo, IndexSubscriptionRevokeMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -177,13 +176,14 @@ export const createIndexEndpoints = (builder: RpcEndpointBuilder) => ({
                     indexId: arg.indexId,
                     publisher: arg.publisherAddress,
                     userData: arg.userDataBytes,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Revoke Index Subscription',

--- a/packages/sdk-redux/src/reduxSlices/rtkQuery/rpcApiSlice/endpoints/superTokenEndpoints.ts
+++ b/packages/sdk-redux/src/reduxSlices/rtkQuery/rpcApiSlice/endpoints/superTokenEndpoints.ts
@@ -1,6 +1,6 @@
 import {NativeAssetSuperToken, WrapperSuperToken} from '@superfluid-finance/sdk-core';
 
-import {getFramework, getSigner} from '../../../../sdkReduxConfig';
+import {getFramework} from '../../../../sdkReduxConfig';
 import {TransactionInfo} from '../../../argTypes';
 import {registerNewTransactionAndReturnQueryFnResult} from '../../../transactionTrackerSlice/registerNewTransaction';
 import {createGeneralTags, createSpecificTags} from '../../cacheTags/CacheTagTypes';
@@ -16,7 +16,6 @@ import {
 export const createSuperTokenEndpoints = (builder: RpcEndpointBuilder) => ({
     superTokenUpgrade: builder.mutation<TransactionInfo, SuperTokenUpgradeMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -29,13 +28,14 @@ export const createSuperTokenEndpoints = (builder: RpcEndpointBuilder) => ({
             const transactionResponse = await superToken
                 .upgrade({
                     amount: arg.amountWei,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Upgrade to Super Token',
@@ -68,7 +68,6 @@ export const createSuperTokenEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     superTokenDowngrade: builder.mutation<TransactionInfo, SuperTokenDowngradeMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -81,13 +80,14 @@ export const createSuperTokenEndpoints = (builder: RpcEndpointBuilder) => ({
             const transactionResponse = await superToken
                 .downgrade({
                     amount: arg.amountWei,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Downgrade from Super Token',
@@ -97,7 +97,6 @@ export const createSuperTokenEndpoints = (builder: RpcEndpointBuilder) => ({
     }),
     superTokenTransfer: builder.mutation<TransactionInfo, SuperTokenTransferMutation>({
         queryFn: async (arg, queryApi) => {
-            const signer = await getSigner(arg.chainId);
             const framework = await getFramework(arg.chainId);
             const superToken = await framework.loadSuperToken(arg.superTokenAddress);
 
@@ -105,13 +104,14 @@ export const createSuperTokenEndpoints = (builder: RpcEndpointBuilder) => ({
                 .transfer({
                     amount: arg.amountWei,
                     receiver: arg.receiverAddress,
+                    overrides: arg.overrides,
                 })
-                .exec(signer);
+                .exec(arg.signer);
 
             return await registerNewTransactionAndReturnQueryFnResult({
                 transactionResponse,
                 chainId: arg.chainId,
-                signer: await signer.getAddress(),
+                signer: await arg.signer.getAddress(),
                 waitForConfirmation: !!arg.waitForConfirmation,
                 dispatch: queryApi.dispatch,
                 title: 'Transfer Super Token',

--- a/packages/sdk-redux/src/sdkReduxInitialization.ts
+++ b/packages/sdk-redux/src/sdkReduxInitialization.ts
@@ -1,7 +1,6 @@
 import {CreateApi} from '@reduxjs/toolkit/dist/query';
 import type {ModuleName} from '@reduxjs/toolkit/dist/query/apiTypes';
 import {Framework} from '@superfluid-finance/sdk-core';
-import {Signer} from 'ethers';
 
 import {createRpcApiSlice} from './reduxSlices/rtkQuery/rpcApiSlice/rpcApiSlice';
 import {createSubgraphApiSlice} from './reduxSlices/rtkQuery/subgraphApiSlice/subgraphApiSlice';
@@ -40,14 +39,6 @@ export const initializeTransactionTrackerSlice = () => {
     getConfig().setTransactionTrackerSlice(transactiontTrackerSlice);
     return transactiontTrackerSlice;
 };
-
-/**
- * SDK-Redux needs to know where to get the signer for mutations (i.e. transaction signing & broadcasting)
- * @param chainId The chain.
- * @param signer The Ethers signer getter. Can be either Promise or instance.
- */
-export const setSignerForSdkRedux = (chainId: number, signer: (() => Promise<Signer>) | Signer) =>
-    getConfig().setSigner(chainId, signer);
 
 /**
  * SDK-Redux needs to know where to get SDK-Core's Framework for data querying.

--- a/packages/sdk-redux/src/utils.ts
+++ b/packages/sdk-redux/src/utils.ts
@@ -27,3 +27,13 @@ export enum MillisecondTimes {
     ThreeMinutes = 180000,
     FiveMinutes = 300000,
 }
+
+/**
+ * @private
+ */
+export const mutationOverridesKey = 'overrides' as const;
+
+/**
+ * @private
+ */
+export const mutationSignerKey = 'signer' as const;


### PR DESCRIPTION
Why?
* Enable passing in Ether's `Overrides` to override gas settings
* Pass in `signer` through mutation payload because it's much more straightforward in its readability

Why not before?
* Was not aware that passing in non-serializable data through mutations is OK if the data is removed from the cache key as then it will not hit the store's state and serializability will not be an issue. (source: https://github.com/reduxjs/redux-toolkit/pull/1318)