### PR TITLE
Query and Subgraph Sync Workflow

### DIFF
--- a/.github/workflows/call.check-query-schema-against-subgraph.yml
+++ b/.github/workflows/call.check-query-schema-against-subgraph.yml
@@ -1,4 +1,4 @@
-name: Reusable Workflow | Check Subgraph Indexing Statuses on All Networks
+name: Reusable Workflow | Check SDK-Core Schema Against Deployed Subgraphs
 
 on:
   workflow_call:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-subgraph-indexing-statuses-on-deployed-networks:
-    name: Check Subgraph Indexing Statuses for ${{ inputs.subgraph-release }} Release
+    name: Check SDK-Core Schema Against Deployed Subgraphs (${{ inputs.subgraph-release }})
 
     runs-on: ubuntu-latest
 
@@ -21,11 +21,11 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Run indexing statuses check
+      - name: Run schema check
         run: |
           yarn install
-          yarn check-indexing-completeness
-        working-directory: ./packages/subgraph
+          ./tasks/testSchemasAndQueries.sh
+        working-directory: ./packages/sdk-core
         env:
           SUBGRAPH_RELEASE_TAG:  ${{ inputs.subgraph-release }}
-                    
+

--- a/.github/workflows/call.check-query-schema-against-subgraph.yml
+++ b/.github/workflows/call.check-query-schema-against-subgraph.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Install packages and start hardhat node"
         run: |
           yarn install
-          ./tasks/startHardhatNode.sh
+          ./tasks/startHardhatNode.sh start
         working-directory: ${{ env.sdk-core-working-directory }}
 
       - name: Run schema check

--- a/.github/workflows/call.check-query-schema-against-subgraph.yml
+++ b/.github/workflows/call.check-query-schema-against-subgraph.yml
@@ -39,6 +39,31 @@ jobs:
           ./tasks/startHardhatNode.sh start
         working-directory: ${{ env.sdk-core-working-directory }}
 
+      # duplicated in call.test-subgraph-on-previous-sdk-core-versions, call.setup-deploy-and-test-local-subgraph
+      - name: "Checkout graph node repo and set up local graph node"
+        uses: actions/checkout@v3
+        with:
+          repository: graphprotocol/graph-node
+          path: graph-node
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Run setup because linux and docker-compose"
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          chmod +x setup.sh
+          ./setup.sh
+        working-directory: ./graph-node/docker
+
+      - name: "Docker compose"
+        run: docker-compose up &
+        working-directory: ./graph-node/docker
+
+      - name: "Prepare and Deploy Local Subgraph"
+        run: yarn testenv:start
+        working-directory: ./packages/subgraph
+      #
+
       - name: Run schema check
         run: |
           ./tasks/setupTestEnvironment.sh

--- a/.github/workflows/call.check-query-schema-against-subgraph.yml
+++ b/.github/workflows/call.check-query-schema-against-subgraph.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run schema check
         run: |
           yarn install
+          ./tasks/setupTestEnvironment.sh
           ./tasks/testSchemasAndQueries.sh
         working-directory: ./packages/sdk-core
         env:

--- a/.github/workflows/call.check-query-schema-against-subgraph.yml
+++ b/.github/workflows/call.check-query-schema-against-subgraph.yml
@@ -15,6 +15,7 @@ jobs:
 
     env:
       contracts-working-directory: ./packages/ethereum-contracts
+      sdk-core-working-directory: ./packages/sdk-core
 
     steps:
       - uses: actions/checkout@v3
@@ -32,13 +33,17 @@ jobs:
         run: yarn build:contracts
         working-directory: ${{ env.contracts-working-directory }}
 
-      - name: Run schema check
+      - name: "Install packages and start hardhat node"
         run: |
           yarn install
           ./tasks/startHardhatNode.sh
+        working-directory: ${{ env.sdk-core-working-directory }}
+
+      - name: Run schema check
+        run: |
           ./tasks/setupTestEnvironment.sh
           ./tasks/testSchemasAndQueries.sh
-        working-directory: ./packages/sdk-core
+        working-directory: ${{ env.sdk-core-working-directory }}
         env:
           SUBGRAPH_RELEASE_TAG:  ${{ inputs.subgraph-release }}
 

--- a/.github/workflows/call.check-query-schema-against-subgraph.yml
+++ b/.github/workflows/call.check-query-schema-against-subgraph.yml
@@ -13,6 +13,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      contracts-working-directory: ./packages/ethereum-contracts
+
     steps:
       - uses: actions/checkout@v3
 
@@ -20,6 +23,14 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16.x
+
+      - name: "Install contract dependencies"
+        run: yarn install
+        working-directory: ${{ env.contracts-working-directory }}
+
+      - name: "Build contracts"
+        run: yarn build:contracts
+        working-directory: ${{ env.contracts-working-directory }}
 
       - name: Run schema check
         run: |

--- a/.github/workflows/call.check-query-schema-against-subgraph.yml
+++ b/.github/workflows/call.check-query-schema-against-subgraph.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run schema check
         run: |
           yarn install
+          ./tasks/startHardhatNode.sh
           ./tasks/setupTestEnvironment.sh
           ./tasks/testSchemasAndQueries.sh
         working-directory: ./packages/sdk-core

--- a/.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
+++ b/.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
@@ -33,6 +33,7 @@ jobs:
           ./tasks/startHardhatNode.sh start
         working-directory: ./packages/sdk-core
 
+      # duplicated in call.test-subgraph-on-previous-sdk-core-versions, call.check-query-schema-against-subgraph
       - name: "Checkout graph node repo and set up local graph node"
         uses: actions/checkout@v3
         with:
@@ -56,6 +57,7 @@ jobs:
         if: inputs.run-sdk-core-tests == false
         run: yarn test
         working-directory: ${{ env.subgraph-working-directory }}
+      #
 
       # test local subgraph w/ SDK-core
       - name: "Setup subgraph test environment"

--- a/.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
+++ b/.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
@@ -33,7 +33,6 @@ jobs:
           ./tasks/startHardhatNode.sh start
         working-directory: ./packages/sdk-core
 
-      # duplicated in call.test-subgraph-on-previous-sdk-core-versions.yml #
       - name: "Checkout graph node repo and set up local graph node"
         uses: actions/checkout@v3
         with:
@@ -52,7 +51,6 @@ jobs:
       - name: "Docker compose"
         run: docker-compose up &
         working-directory: ./graph-node/docker
-      #                                                                     #
 
       - name: "Run subgraph integration test suite"
         if: inputs.run-sdk-core-tests == false

--- a/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+++ b/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
@@ -6,9 +6,6 @@ on:
       subgraph-release:
         required: true
         type: string
-      run-sdk-core-tests:
-        required: true
-        type: boolean
 
 jobs:
   build-and-test-live-subgraph-previous-releases:
@@ -18,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [0.3.2, 0.4.0, 0.4.1]
+        version: [0.3.2, 0.4.0, 0.4.1, 0.4.2, latest]
 
     env:
       contracts-working-directory: ./packages/ethereum-contracts
@@ -45,49 +42,6 @@ jobs:
           yarn install
           ./tasks/startHardhatNode.sh start
         working-directory: ${{ env.sdk-core-working-directory }}
-
-      # duplicated in call.setup-deploy-and-test-local-subgraph.yml #
-      - name: "Checkout graph node repo and set up local graph node"
-        if: inputs.run-sdk-core-tests == true
-        uses: actions/checkout@v3
-        with:
-          repository: graphprotocol/graph-node
-          path: graph-node
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Run setup because linux and docker-compose"
-        if: inputs.run-sdk-core-tests == true
-        run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-          chmod +x setup.sh
-          ./setup.sh
-        working-directory: ./graph-node/docker
-
-      - name: "Docker compose"
-        if: inputs.run-sdk-core-tests == true
-        run: docker-compose up &
-        working-directory: ./graph-node/docker
-      #                                                             #
-
-      - name: "Setup subgraph test environment"
-        if: inputs.run-sdk-core-tests == true
-        run: ./tasks/testenv-ctl.sh start
-        working-directory: ./packages/subgraph
-
-      - name: "Set up SDK-Core test environment"
-        run: |
-          yarn generate-graphql-schema:${{ inputs.subgraph-release }}
-          yarn generate
-        working-directory: ${{ env.sdk-core-working-directory }}
-
-      # If we use a local endpoint for testing, we need to generate data in the graph to query
-      - name: "Run SDK-Core tests"
-        if: inputs.run-sdk-core-tests == true
-        run: npx hardhat test --network localhost
-        working-directory: ${{ env.sdk-core-working-directory }}
-        env:
-          SUBGRAPH_RELEASE_TAG: ${{ inputs.subgraph-release }}
 
       - name: "Install @superfluid-finance/sdk-core@${{ matrix.version}} and test subgraph queries"
         run: |

--- a/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+++ b/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
@@ -43,11 +43,15 @@ jobs:
           ./tasks/startHardhatNode.sh start
         working-directory: ${{ env.sdk-core-working-directory }}
 
-      - name: "Install @superfluid-finance/sdk-core@${{ matrix.version}} and test subgraph queries"
+      - name: "Install @superfluid-finance/sdk-core@${{ matrix.version}}"
         run: |
           yarn add -D @superfluid-finance/sdk-core@v${{ matrix.version }}
-          ../tasks/testSchemasAndQueries.sh
         working-directory: ./packages/sdk-core/previous-versions-testing
+
+      - name: "Test Schemas and Attempt Query Execution"
+        run: |
+          ./tasks/testSchemasAndQueries.sh
+        working-directory: ./packages/sdk-core
         env:
           SUBGRAPH_RELEASE_TAG: ${{ inputs.subgraph-release }}
 

--- a/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+++ b/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [0.3.2, 0.4.0, 0.4.1, 0.4.2, latest]
+        version: [v0.3.2, v0.4.0, v0.4.1, v0.4.2, latest]
 
     env:
       contracts-working-directory: ./packages/ethereum-contracts
@@ -45,7 +45,7 @@ jobs:
 
       - name: "Install @superfluid-finance/sdk-core@${{ matrix.version}}"
         run: |
-          yarn add -D @superfluid-finance/sdk-core@v${{ matrix.version }}
+          yarn add -D @superfluid-finance/sdk-core@${{ matrix.version }}
         working-directory: ./packages/sdk-core/previous-versions-testing
 
       - name: "Test Schemas and Attempt Query Execution"

--- a/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+++ b/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
@@ -43,6 +43,31 @@ jobs:
           ./tasks/startHardhatNode.sh start
         working-directory: ${{ env.sdk-core-working-directory }}
 
+      # duplicated in call.check-query-schema-against-subgraph, call.setup-deploy-and-test-local-subgraph
+      - name: "Checkout graph node repo and set up local graph node"
+        uses: actions/checkout@v3
+        with:
+          repository: graphprotocol/graph-node
+          path: graph-node
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Run setup because linux and docker-compose"
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          chmod +x setup.sh
+          ./setup.sh
+        working-directory: ./graph-node/docker
+
+      - name: "Docker compose"
+        run: docker-compose up &
+        working-directory: ./graph-node/docker
+
+      - name: "Prepare and Deploy Local Subgraph"
+        run: yarn testenv:start
+        working-directory: ./packages/subgraph
+      #
+
       - name: "Install @superfluid-finance/sdk-core@${{ matrix.version}}"
         run: |
           yarn add -D @superfluid-finance/sdk-core@${{ matrix.version }}

--- a/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+++ b/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: "Test Schemas and Attempt Query Execution"
         run: |
+          yarn install
+          ./tasks/setupTestEnvironment.sh
           ./tasks/testSchemasAndQueries.sh
         working-directory: ./packages/sdk-core
         env:

--- a/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+++ b/.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
@@ -46,7 +46,7 @@ jobs:
       - name: "Install @superfluid-finance/sdk-core@${{ matrix.version}} and test subgraph queries"
         run: |
           yarn add -D @superfluid-finance/sdk-core@v${{ matrix.version }}
-          yarn run-query-tests
+          ../tasks/testSchemasAndQueries.sh
         working-directory: ./packages/sdk-core/previous-versions-testing
         env:
           SUBGRAPH_RELEASE_TAG: ${{ inputs.subgraph-release }}

--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -70,7 +70,13 @@ jobs:
     name: Build and Test Current Subgraph Implementation with Previous SDK-Core Versions
     with:
       subgraph-release: dev
-      run-sdk-core-tests: true
+
+  # test query and subgraph schemas are in sync and query works
+  test-query-schema-against-deployed-dev-subgraphs:
+    uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
+    name: "Test Query Schema and Queries Against Deployed Dev Subgraphs"
+    with:
+      subgraph-release: dev
 
   ethereum-contracts-coverage:
     name: Run coverage test of ethereum-contracts of dev branch

--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -65,16 +65,16 @@ jobs:
       subgraph-release: ''
       run-sdk-core-tests: false
 
-  test-subraph-on-previous-sdk-core-versions:
+  test-subgraph-on-previous-sdk-core-versions:
     uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
-    name: Build and Test Current Subgraph Implementation with Previous SDK-Core Versions
+    name: Test Query Schema and Queries Against Local and Deployed Dev Subgraphs with Previous SDK-Core Versions
     with:
       subgraph-release: dev
 
   # test query and subgraph schemas are in sync and query works
   test-query-schema-against-deployed-dev-subgraphs:
     uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
-    name: "Test Query Schema and Queries Against Deployed Dev Subgraphs"
+    name: "Test Query Schema and Queries Against Local and Deployed Dev Subgraphs"
     with:
       subgraph-release: dev
 

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -167,7 +167,7 @@ jobs:
 
   # test sdk-core and subgraph schemas in sync and query works
   test-sdk-core-schema-against-deployed-feature-subgraphs:
-    uses: ./.github/workflows/call.check-sdk-core-schema-against-subgraph.yml
+    uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
     name: "Test Query Schema and Queries Against Deployed Feature Subgraphs"
     with:
       subgraph-release: feature

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -139,6 +139,7 @@ jobs:
         env:
           POLYGON_MAINNET_PROVIDER_URL: ${{ secrets.POLYGON_MAINNET_PROVIDER_URL }}
 
+  # subgraph integration test
   test-subgraph:
     uses: ./.github/workflows/call.setup-deploy-and-test-local-subgraph.yml
     name: Build and Test Subgraph (Feature Branch)
@@ -148,11 +149,26 @@ jobs:
       subgraph-release: ''
       run-sdk-core-tests: false
 
+  # sdk-core integration test + feature subgraph w/ feature sdk-core
   test-sdk-core:
     uses: ./.github/workflows/call.test-sdk-core.yml
     name: Build and Test SDK-Core (Feature Branch)
     needs: [check]
     if: needs.check.outputs.build_sdk_core
+    with:
+      subgraph-release: feature
+
+  # test latest and previous version of sdk-core with current subgraph
+  test-subraph-on-previous-sdk-core-versions:
+    uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
+    name: Build and Test Current Subgraph Implementation with Latest and Previous SDK-Core Versions
+    with:
+      subgraph-release: feature
+
+  # test sdk-core and subgraph schemas in sync and query works
+  test-sdk-core-schema-against-deployed-feature-subgraphs:
+    uses: ./.github/workflows/call.check-sdk-core-schema-against-subgraph.yml
+    name: "Test Query Schema and Queries Against Deployed Feature Subgraphs"
     with:
       subgraph-release: feature
 

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -159,16 +159,16 @@ jobs:
       subgraph-release: feature
 
   # test latest and previous version of sdk-core with current subgraph
-  test-subraph-on-previous-sdk-core-versions:
+  test-subgraph-on-previous-sdk-core-versions:
     uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
-    name: Build and Test Current Subgraph Implementation with Latest and Previous SDK-Core Versions
+    name: Test Query Schema and Queries Against Local and Deployed Feature Subgraphs with Previous SDK-Core Versions
     with:
       subgraph-release: feature
 
-  # test sdk-core and subgraph schemas in sync and query works
-  test-sdk-core-schema-against-deployed-feature-subgraphs:
+  # test query and local/deployed subgraph schemas in sync and query works
+  test-query-schema-against-deployed-feature-subgraphs:
     uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
-    name: "Test Query Schema and Queries Against Deployed Feature Subgraphs"
+    name: Test Query Schema and Queries Against Local and Deployed Feature Subgraphs
     with:
       subgraph-release: feature
 

--- a/.github/workflows/ci.pre-release-sdk-core.yml
+++ b/.github/workflows/ci.pre-release-sdk-core.yml
@@ -8,7 +8,6 @@ on:
       - "packages/sdk-core/**"
       - "packages/subgraph/**"
       - ".github/workflows/ci.pre-release-sdk-core.yml"
-      - ".github/workflows/call.check-subgraph-indexing-statuses.yml"
       - ".github/workflows/call.test-sdk-core.yml"
 
 jobs:
@@ -27,38 +26,17 @@ jobs:
           echo github.head_ref: ${{ github.head_ref }}
           echo github.base_ref: ${{ github.base_ref }}
 
-  # A. ensure subgraph indexing is complete on all v1 endpoints before allowing sdk-core release
-  # purpose: ensure the new sdk-core version can be released, it will ALWAYS fail if v1 is
-  #          still indexing on any network
-  # assumption: releasing sdk-core before v1 is indexed on all networks may lead to a broken release
-  #             and we usually release subgraph before sdk-core so we assume subgraph is properly deployed
-  # result: this should work once the v1 endpoints are fully indexed, otherwise it will ALWAYS fail and is NG for release
-  check-subgraph-indexing-completeness:
-    uses: ./.github/workflows/call.check-subgraph-indexing-statuses.yml
-    name: Check Subgraph Indexing Status for v1 Endpoints
-    if: github.base_ref == 'release-sdk-core-stable'
+  # test query and subgraph schemas are in sync and query works (safe to deploy w/o breaking changes)
+  test-query-schema-against-deployed-v1-subgraphs:
+    uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
+    name: "Test Query Schema and Queries Against Deployed V1 Subgraphs"
     with:
       subgraph-release: v1
 
-  # B. build and test v1 endpoint subgraph with release sdk-core
-  # purpose: ensure the new sdk-core version works with the currently deployed v1 matic endpoint
-  # assumption: matic is the indexing blocker and if this passes, it will pass on all other networks
-  # result: this should work once matic v1 endpoint is indexed and thus A should be passing as well
-  #         otherwise it's NG for release (we run A just in case another endpoint is lagging)
+  # tests non-query sdk-core functionality
   build-and-test-live-v1-subgraph-current-release:
     uses: ./.github/workflows/call.test-sdk-core.yml
     name: Build and Test SDK-Core (Release branch)
     if: github.base_ref == 'release-sdk-core-stable'
     with:
       subgraph-release: v1
-
-  # C. build and test dev endpoint subgraph with release sdk-core
-  # purpose: ensure the new sdk-core version works with the currently deployed dev goerli endpoint
-  # assumption: we assume that dev endpoint is synced (do a manual check here to see this is true)
-  # result: this should work as ci.canary should've passed otherwise we need to go back and complete the previous release
-  build-and-test-live-dev-subgraph-current-release:
-    uses: ./.github/workflows/call.test-sdk-core.yml
-    name: Build and Test SDK-Core (Release branch)
-    if: github.base_ref == 'release-sdk-core-stable'
-    with:
-      subgraph-release: dev

--- a/.github/workflows/ci.pre-release-sdk-core.yml
+++ b/.github/workflows/ci.pre-release-sdk-core.yml
@@ -29,7 +29,7 @@ jobs:
   # test query and subgraph schemas are in sync and query works (safe to deploy w/o breaking changes)
   test-query-schema-against-deployed-v1-subgraphs:
     uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
-    name: "Test Query Schema and Queries Against Deployed V1 Subgraphs"
+    name: Test Query Schema and Queries Against Local and Deployed V1 Subgraphs
     with:
       subgraph-release: v1
 

--- a/.github/workflows/ci.pre-release-subgraph.yml
+++ b/.github/workflows/ci.pre-release-subgraph.yml
@@ -64,4 +64,3 @@ jobs:
       # we want to check here if the subgraph implementation in dev is safe to use
       # for v1 endpoints (backwards compatible)
       subgraph-release: dev
-      run-sdk-core-tests: false

--- a/.github/workflows/ci.pre-release-subgraph.yml
+++ b/.github/workflows/ci.pre-release-subgraph.yml
@@ -57,7 +57,7 @@ jobs:
   #         otherwise it should ALWAYS work
   build-and-test-live-subgraph-previous-releases:
     uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
-    name: Build and test current subgraph release with previous sdk-core versions
+    name: Test Query Schema and Queries Against Local and Deployed Dev Subgraphs with Previous SDK-Core Versions
     if: github.base_ref == 'release-subgraph-v1'
     with:
       # we check with dev endpoint here because v1 endpoints are to be deployed

--- a/.github/workflows/daily-query-check.yml
+++ b/.github/workflows/daily-query-check.yml
@@ -7,12 +7,12 @@ on:
 jobs:
   test-query-schema-against-deployed-v1-subgraphs:
     uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
-    name: "Test Query Schema and Queries Against Deployed V1 Subgraphs"
+    name: "Test Query Schema and Queries Against Local and Deployed V1 Subgraphs"
     with:
       subgraph-release: v1
 
   test-query-schema-against-deployed-dev-subgraphs:
     uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
-    name: "Test Query Schema and Queries Against Deployed Dev Subgraphs"
+    name: "Test Query Schema and Queries Against Local and Deployed Dev Subgraphs"
     with:
       subgraph-release: dev

--- a/.github/workflows/daily-query-check.yml
+++ b/.github/workflows/daily-query-check.yml
@@ -1,0 +1,18 @@
+name: Daily Subgraph and Query Sync Check
+
+on:
+  schedule:
+    - cron: 0 11 * * *
+
+jobs:
+  test-query-schema-against-deployed-v1-subgraphs:
+    uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
+    name: "Test Query Schema and Queries Against Deployed V1 Subgraphs"
+    with:
+      subgraph-release: v1
+
+  test-query-schema-against-deployed-dev-subgraphs:
+    uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
+    name: "Test Query Schema and Queries Against Deployed Dev Subgraphs"
+    with:
+      subgraph-release: dev

--- a/packages/sdk-core/previous-versions-testing/queryTests.ts
+++ b/packages/sdk-core/previous-versions-testing/queryTests.ts
@@ -17,22 +17,11 @@ export const getChainId = () => {
 };
 
 export const testQueryClassFunctions = async (query: Query) => {
-    const tokens = await query.listAllSuperTokens({}, { take: 10 });
-    const indexes = await query.listIndexes({}, { take: 10 });
-    const indexSubscriptions = await query.listIndexSubscriptions(
-        {},
-        { take: 10 }
-    );
-    const streams = await query.listStreams({}, { take: 10 });
-    const userInteractedSuperTokens = await query.listUserInteractedSuperTokens(
-        {},
-        { take: 10 }
-    );
-    expect(tokens.data.length).to.be.greaterThan(0);
-    expect(indexes.data.length).to.be.greaterThan(0);
-    expect(indexSubscriptions.data.length).to.be.greaterThan(0);
-    expect(streams.data.length).to.be.greaterThan(0);
-    expect(userInteractedSuperTokens.data.length).to.be.greaterThan(0);
+    await query.listAllSuperTokens({}, { take: 10 });
+    await query.listIndexes({}, { take: 10 });
+    await query.listIndexSubscriptions({}, { take: 10 });
+    await query.listStreams({}, { take: 10 });
+    await query.listUserInteractedSuperTokens({}, { take: 10 });
 };
 
 export const testGetAllEventsQuery = async (query: Query) => {
@@ -40,8 +29,7 @@ export const testGetAllEventsQuery = async (query: Query) => {
     // this version of SDK-Core will be able to handle the deployed subgraph endpoint
     // However, when we test the locally deployed endpoint, we want to test
     // as many of the mapGetAllEventsQueryEvents cases.
-    const events = await query.listEvents({}, { take: 100 });
-    expect(events.data.length).to.be.greaterThan(0);
+    await query.listEvents({}, { take: 100 });
 };
 
 export const testExpectListenerThrow = async (query: Query) => {

--- a/packages/sdk-core/previous-versions-testing/runQueryTests.ts
+++ b/packages/sdk-core/previous-versions-testing/runQueryTests.ts
@@ -27,6 +27,11 @@ describe("Query Tests", () => {
                     process.env.SUBGRAPH_RELEASE_TAG
                 );
         }
+
+        customSubgraphQueriesEndpoint = process.env.SUBGRAPH_ENDPOINT
+            ? process.env.SUBGRAPH_ENDPOINT
+            : customSubgraphQueriesEndpoint;
+
         query = new Query({
             customSubgraphQueriesEndpoint,
         });

--- a/packages/sdk-core/tasks/testSchemasAndQueries.sh
+++ b/packages/sdk-core/tasks/testSchemasAndQueries.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+JQ="../../node_modules/node-jq/bin/jq"
+
+# make sure that if any step fails, the script fails
+set -xe
+
+if [ "$SUBGRAPH_RELEASE_TAG" == "feature" ];then
+    # we only support matic and goerli feature endpoints
+    NETWORKS=("matic" "goerli")
+fi
+
+if [ "$SUBGRAPH_RELEASE_TAG" == "dev" ] || [ "$SUBGRAPH_RELEASE_TAG" == "v1" ];then
+    NETWORKS=( $($JQ -r .[] ../subgraph/networks.json) )
+fi
+
+for i in "${NETWORKS[@]}";do
+    SUBGRAPH_ENDPOINT=https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-$SUBGRAPH_RELEASE_TAG-$i
+
+    # generate schema.graphql with desired endpoint
+    npx get-graphql-schema $SUBGRAPH_ENDPOINT > src/subgraph/schema.graphql
+    # attempt to generate types with schema.graphql generated in previous step and .graphql files in entities folders
+    yarn generate:graphql-types
+    # attempt to run queries with desired endpoint
+    export SUBGRAPH_ENDPOINT=$SUBGRAPH_ENDPOINT && npx hardhat test previous-versions-testing/runQueryTests.ts
+done


### PR DESCRIPTION
* Workflow simplified
* Testing the issue in a more direct way
* Removed redundant/unhelpful tests
* testSchemasAndQueries task created to test schemas are in sync and queries work in respective networks and versions

## Subgraph
For Feature, Dev, V1:
- We are always running the integration tests to ensure that everything is working as expected (non-sdk-core (query) related).
  - if this fails, it is a clear no-go (for release)
- We are testing the latest and previous sdk-core (query) versions against the local subgraph AND all networks for currently deployed subgraphs on desired network (feature: feature, canary: canary, release: canary)
  - if this fails, it is likely a no-go (for release) as it fails the backwards compatibility test (unless this is **explicit**)

## SDK-Core (Query)
For Feature, Dev, V1:
- We are always running the integration tests to ensure that everything is working as expected (non-sdk-core (query) related + current sdk-core version)
  - if this fails, it is a clear no-go (for release)
- We also generate the schema off the desired version (feature/dev/v1) endpoints for all networks, compare and try running the queries
  - if this fails, it is a clear no-go (for release) because this means either:
    - the required subgraph version is not indexed on a specific network or not deployed yet
    - a property name in one of the queries is renamed or added which doesn't exist on the subgraph
  - nonetheless, it means this is a no-go for release
- We also run a cronjob (`daily-query-check.yml`) which ensures that the current sdk-core (query) in production/dev build is in sync with the deployed subgraphs: it will break if we have pushed some subgraph changes, but have not pushed the necessary sdk-core (query) changes