### PR TITLE
[SDK-redux] Don't stop transaction tracking when transaction serialization fails

### DIFF
--- a/packages/sdk-redux/CHANGELOG.md
+++ b/packages/sdk-redux/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the SDK-redux will be documented in this file.
 ### Breaking
 - Pass in `signer` through mutation payload
 - Remove `setSignerForSdkRedux`
+- Serialized `transactionResponse` is now possibly undefined on `TrackedTransaction` when serialization fails
 
 ### Added
 - Query for transfer events

--- a/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/thunks/initiateNewTransactionTrackingThunk.ts
+++ b/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/thunks/initiateNewTransactionTrackingThunk.ts
@@ -4,6 +4,7 @@ import {ethers} from 'ethers';
 import {getTransactionTrackerSlice} from '../../../sdkReduxConfig';
 import {TransactionTitle} from '../transactionTitle';
 import {transactionTrackerSlicePrefix} from '../transactionTrackerSlice';
+import {trySerializeTransaction} from '../trySerializeTransaction';
 
 import {trackPendingTransactionThunk} from './trackPendingTransactionThunk';
 
@@ -31,7 +32,7 @@ export const initiateNewTransactionTrackingThunk = createAsyncThunk<
             signer: ethers.utils.getAddress(arg.signer),
             timestampMs: new Date().getTime(),
             status: 'Pending',
-            transactionResponse: ethers.utils.serializeTransaction(arg.transactionResponse),
+            transactionResponse: trySerializeTransaction(arg.transactionResponse),
             title: arg.title,
             extraData: arg.extraData,
         })

--- a/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/thunks/trackPendingTransactionThunk.ts
+++ b/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/thunks/trackPendingTransactionThunk.ts
@@ -11,6 +11,7 @@ import {createGeneralTags} from '../../rtkQuery/cacheTags/CacheTagTypes';
 import {EthersError} from '../ethersError';
 import {transactionTrackerSelectors} from '../transactionTrackerAdapter';
 import {TransactionTrackerReducer, transactionTrackerSlicePrefix} from '../transactionTrackerSlice';
+import {trySerializeTransaction} from '../trySerializeTransaction';
 import {waitForOneConfirmation} from '../waitForOneConfirmation';
 
 /**
@@ -43,7 +44,7 @@ export const trackPendingTransactionThunk = createAsyncThunk<
                     id: transactionHash,
                     changes: {
                         status: 'Succeeded',
-                        transactionReceipt: ethers.utils.serializeTransaction(transactionReceipt),
+                        transactionReceipt: trySerializeTransaction(transactionReceipt),
                     },
                 })
             );

--- a/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/trackedTransaction.ts
+++ b/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/trackedTransaction.ts
@@ -17,7 +17,7 @@ export interface TrackedTransaction {
      */
     timestampMs: number;
     status: TransactionStatus;
-    transactionResponse: string;
+    transactionResponse?: string;
     transactionReceipt?: string;
     ethersErrorCode?: ethers.errors;
     ethersErrorMessage?: string;

--- a/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/trySerializeTransaction.ts
+++ b/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/trySerializeTransaction.ts
@@ -13,4 +13,5 @@ export const trySerializeTransaction = (
     } catch (error) {
         console.error(error);
     }
+    return undefined;
 };

--- a/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/trySerializeTransaction.ts
+++ b/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/trySerializeTransaction.ts
@@ -1,0 +1,16 @@
+import {SignatureLike} from '@ethersproject/bytes';
+import {ethers, UnsignedTransaction} from 'ethers';
+
+/**
+ * The use-case arose from Gnosis Safe transaction serialization failing.
+ */
+export const trySerializeTransaction = (
+    transaction: UnsignedTransaction,
+    signature?: SignatureLike
+): string | undefined => {
+    try {
+        return ethers.utils.serializeTransaction(transaction, signature);
+    } catch (error) {
+        console.error(error);
+    }
+};


### PR DESCRIPTION
Why?
Gnosis Safe transaction serialization failed and stopped the tracking initialization.

TODO:
Create issue for Gnosis/Ethers guys