### PR TITLE
ci.feature + ci.canary cleanup

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -68,6 +68,7 @@ jobs:
   test-subgraph-on-previous-sdk-core-versions:
     uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
     name: Test Query Schema and Queries Against Local and Deployed Dev Subgraphs with Previous SDK-Core Versions
+    if: github.repository == 'superfluid-finance/protocol-monorepo'
     with:
       subgraph-release: dev
 
@@ -75,6 +76,7 @@ jobs:
   test-query-schema-against-deployed-dev-subgraphs:
     uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
     name: "Test Query Schema and Queries Against Local and Deployed Dev Subgraphs"
+    if: github.repository == 'superfluid-finance/protocol-monorepo'
     with:
       subgraph-release: dev
 

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -8,7 +8,7 @@ on:
   # push:
   #   branches-ignore: ["dev", "release-*"]
   #
-  # NOTE To continue the old behaviour, these code snipeets is needed in the check job
+  # NOTE To continue the old behaviour, these code snippets is needed in the check job
   ## triggered by internal pushes or external PRs
   ## if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'superfluid-finance/protocol-monorepo'
 
@@ -162,6 +162,8 @@ jobs:
   test-subgraph-on-previous-sdk-core-versions:
     uses: ./.github/workflows/call.test-subgraph-on-previous-sdk-core-versions.yml
     name: Test Query Schema and Queries Against Local and Deployed Feature Subgraphs with Previous SDK-Core Versions
+    needs: [check]
+    if: needs.check.outputs.build_subgraph
     with:
       subgraph-release: feature
 
@@ -169,6 +171,8 @@ jobs:
   test-query-schema-against-deployed-feature-subgraphs:
     uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml
     name: Test Query Schema and Queries Against Local and Deployed Feature Subgraphs
+    needs: [check]
+    if: needs.check.outputs.build_subgraph || needs.check.outputs.build_sdk_core
     with:
       subgraph-release: feature
 
@@ -385,7 +389,7 @@ jobs:
     runs-on: ubuntu-latest
 
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'superfluid-finance/protocol-monorepo') && always()
-    needs: [test-ethereum-contracts, coverage-ethereum-contracts, test-js-sdk, test-subgraph, test-sdk-core, test-spec-haskell]
+    needs: [test-ethereum-contracts, coverage-ethereum-contracts, test-js-sdk, test-subgraph, test-sdk-core, test-spec-haskell, test-subgraph-on-previous-sdk-core-versions, test-query-schema-against-deployed-feature-subgraphs]
 
     steps:
       - name: Test Results
@@ -405,4 +409,6 @@ jobs:
           check_result js-sdk ${{ needs.test-js-sdk.result }}
           check_result subgraph ${{ needs.test-subgraph.result }}
           check_result sdk-core ${{ needs.test-sdk-core.result }}
-          check_result sdk-core ${{ needs.test-spec-haskell.result }}
+          check_result spec-haskell ${{ needs.test-spec-haskell.result }}
+          check_result subgraph-on-previous-sdk-core-versions ${{ needs.test-subgraph-on-previous-sdk-core-versions.result }}
+          check_result query-schema-against-deployed-feature-subgraph ${{ needs.test-query-schema-against-deployed-feature-subgraphs.result }}


### PR DESCRIPTION
## ci.feature
* only execute query checks if subgraph/sdk-core has changes
* add the two tests to `all-packages-tested` job

## ci.canary
* add check to only execute if github.repository is monorepo
* explicitly did not add these two tests as requirements to `publish-npm-package` job, did not want subgraph indexing/query issues to block packages from being published