### PR TITLE
[SDK-core] Use `serialize-error`

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - `SFError` refactor to be more conventional. It inherits `Error` and uses `cause` to wrap internal errors.
+- Use `serialize-error` for serializing error object inside the message.
 
 ### Breaking
 - `SFError.errorObject` renamed to `SFError.cause`

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -59,6 +59,7 @@
         "browserify": "^17.0.0",
         "graphql-request": "^4.3.0",
         "lodash": "^4.17.21",
+        "serialize-error": "^11.0.0",
         "tsify": "^5.0.4"
     },
     "devDependencies": {

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -59,7 +59,7 @@
         "browserify": "^17.0.0",
         "graphql-request": "^4.3.0",
         "lodash": "^4.17.21",
-        "serialize-error": "^11.0.0",
+        "serialize-error": "8.1.0",
         "tsify": "^5.0.4"
     },
     "devDependencies": {

--- a/packages/sdk-core/src/SFError.ts
+++ b/packages/sdk-core/src/SFError.ts
@@ -1,3 +1,5 @@
+import { serializeError } from "serialize-error";
+
 export type ErrorType =
     | "FRAMEWORK_INITIALIZATION"
     | "SUPERTOKEN_INITIALIZATION"
@@ -55,7 +57,7 @@ export class SFError extends Error {
         )} Error: ${message}${
             cause
                 ? `
-Caused by: ${JSON.stringify(cause, null, 2)}`
+Caused by: ${serializeError(cause)}`
                 : ""
         }`;
         super(


### PR DESCRIPTION
Why?
`JSON.stringify` is not sufficient for serializing errors:
![image](https://user-images.githubusercontent.com/10894666/179945620-37362adf-e025-4b80-aaa9-712556343f5d.png)

`serialize-error` is a popular small library that handles error serialization: https://www.npmjs.com/package/serialize-error