### PR TITLE
[SDK-core] Use serialize-error (vol. 2)

### DIFF
--- a/packages/sdk-core/src/SFError.ts
+++ b/packages/sdk-core/src/SFError.ts
@@ -57,7 +57,7 @@ export class SFError extends Error {
         )} Error: ${message}${
             cause
                 ? `
-Caused by: ${serializeError(cause)}`
+Caused by: ${JSON.stringify(serializeError(cause), null, 2)}`
                 : ""
         }`;
         super(


### PR DESCRIPTION
Follow-up to this: https://github.com/superfluid-finance/protocol-monorepo/pull/983 Now it's good to go. 

Sorry, didn't set the previous one as _draft_ because wanted a PR build. I'll comment "do not merge" or use GitHub's "request changes" to block merging next time.