### PR TITLE
Add resolver and loader to deployer, add tests

### DIFF
--- a/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeployer.sol
+++ b/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeployer.sol
@@ -16,6 +16,8 @@ import {
     ERC20WithTokenInfo
 } from "../superfluid/SuperTokenFactory.sol";
 import {SuperToken} from "../superfluid/SuperToken.sol";
+import {Resolver} from "./Resolver.sol";
+import {SuperfluidLoader} from "./SuperfluidLoader.sol";
 import "../apps/CFAv1Library.sol";
 import "../apps/IDAv1Library.sol";
 
@@ -32,6 +34,8 @@ contract SuperfluidFrameworkDeployer {
         InstantDistributionAgreementV1 ida;
         IDAv1Library.InitData idaLib;
         SuperTokenFactory superTokenFactory;
+        Resolver resolver;
+        SuperfluidLoader superfluidLoader;
     }
 
     TestGovernance internal governance;
@@ -39,6 +43,8 @@ contract SuperfluidFrameworkDeployer {
     ConstantFlowAgreementV1 internal cfa;
     InstantDistributionAgreementV1 internal ida;
     SuperTokenFactory internal superTokenFactory;
+    Resolver internal resolver;
+    SuperfluidLoader internal superfluidLoader;
 
     /// @notice Deploys everything... probably
     constructor() {
@@ -99,6 +105,21 @@ contract SuperfluidFrameworkDeployer {
             new address[](0),
             address(superTokenFactory)
         );
+
+        // Deploy Resolver
+        resolver = new Resolver();
+
+        // Deploy SuperfluidLoader
+        superfluidLoader = new SuperfluidLoader(resolver);
+
+        // Register Governance with Resolver
+        resolver.set("TestGovernance.test", address(governance));
+
+        // Register Superfluid with Resolver
+        resolver.set("Superfluid.test", address(host));
+
+        // Register SuperfluidLoader with Resolver
+        resolver.set("SuperfluidLoader-v1", address(superfluidLoader));
     }
 
     /// @notice Fetches the framework contracts
@@ -113,7 +134,9 @@ contract SuperfluidFrameworkDeployer {
             cfaLib: CFAv1Library.InitData(host, cfa),
             ida: ida,
             idaLib: IDAv1Library.InitData(host, ida),
-            superTokenFactory: superTokenFactory
+            superTokenFactory: superTokenFactory,
+            resolver: resolver,
+            superfluidLoader: superfluidLoader
         });
         return sf;
     }

--- a/packages/ethereum-contracts/test/foundry/SuperfluidFrameworkDeployer.t.sol
+++ b/packages/ethereum-contracts/test/foundry/SuperfluidFrameworkDeployer.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity 0.8.14;
+
+import "forge-std/Test.sol";
+import {
+    SuperfluidFrameworkDeployer,
+    Resolver,
+    SuperfluidLoader
+} from "@superfluid-finance/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeployer.sol";
+import {
+    ERC1820RegistryCompiled
+} from "@superfluid-finance/ethereum-contracts/contracts/libs/ERC1820RegistryCompiled.sol";
+
+contract SuperfluidFrameworkDeployerTest is Test {
+    SuperfluidFrameworkDeployer internal sfDeployer;
+    SuperfluidFrameworkDeployer.Framework internal sf;
+    Resolver internal resolver;
+    SuperfluidLoader internal superfluidLoader; 
+
+    address internal constant admin = address(0x420);
+
+    function setUp() public {
+        vm.etch(ERC1820RegistryCompiled.at, ERC1820RegistryCompiled.bin);
+
+        sfDeployer = new SuperfluidFrameworkDeployer();
+
+        sf = sfDeployer.getFramework();
+
+        resolver = sf.resolver;
+
+        superfluidLoader = sf.superfluidLoader;
+    }
+
+    function testAllContractsDeployed() public {
+        assertTrue(address(sf.governance) != address(0));
+        assertTrue(address(sf.host) != address(0));
+        assertTrue(address(sf.cfa) != address(0));
+        assertTrue(address(sf.ida) != address(0));
+        assertTrue(address(sf.superTokenFactory) != address(0));
+        assertTrue(address(sf.resolver) != address(0));
+        assertTrue(address(sf.superfluidLoader) != address(0));
+    }
+
+    function testResolverGetsGovernance() public {
+        assertEq(
+            resolver.get("TestGovernance.test"),
+            address(sf.governance)
+        );
+    }
+
+    function testResolverGetsHost() public {
+        assertEq(
+            resolver.get("Superfluid.test"),
+            address(sf.host)
+        );
+    }
+
+    function testResolverGetsLoader() public {
+        assertEq(
+            resolver.get("SuperfluidLoader-v1"),
+            address(superfluidLoader)
+        );
+    }
+
+    function testLoaderGetsFramework() public {
+        SuperfluidLoader.Framework memory loadedSf = superfluidLoader.loadFramework("test");
+
+        assertEq(address(loadedSf.superfluid), address(sf.host));
+        assertEq(address(loadedSf.superTokenFactory), address(sf.superTokenFactory));
+        assertEq(address(loadedSf.agreementCFAv1), address(sf.cfa));
+        assertEq(address(loadedSf.agreementIDAv1), address(sf.ida));
+    }
+}


### PR DESCRIPTION
This PR adds the Resolver and SuperfluidLoader contracts to the SuperfluidFrameworkDeployer deployment.

It also adds unit tests for the SuperfluidFrameworkDeployer using Foundry tests.