### PR TITLE
[SDK-core] Map `indexId` to `IndexSubscription` when querying from Subgraph

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+- Map `indexId` to `IndexSubscription` when querying from Subgraph
+
 ## [0.5.2] - 2022-07-26
 
 ### Added

--- a/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscription.ts
+++ b/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscription.ts
@@ -34,6 +34,7 @@ export interface IndexSubscription {
     units: BigNumber;
     indexTotalUnits: BigNumber;
     index: SubgraphId;
+    indexId: string;
     token: Address;
     tokenSymbol: string;
     subscriber: Address;
@@ -77,6 +78,7 @@ export class IndexSubscriptionQueryHandler extends SubgraphQueryHandler<
             updatedAtTimestamp: Number(x.updatedAtTimestamp),
             updatedAtBlockNumber: Number(x.updatedAtBlockNumber),
             index: x.index.id,
+            indexId: x.index.indexId,
             indexValueCurrent: x.index.indexValue,
             indexTotalUnits: x.index.totalUnits,
             token: x.index.token.id,

--- a/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscriptions.graphql
+++ b/packages/sdk-core/src/subgraph/entities/indexSubscription/indexSubscriptions.graphql
@@ -13,6 +13,7 @@ query indexSubscriptions($first: Int = 10, $orderBy: IndexSubscription_orderBy =
         id
         index {
             id
+            indexId,
             indexValue
             totalUnits
             token {


### PR DESCRIPTION
Why?
`indexId` is required when doing index subscription related operations.