### PR TITLE
[SDK-core] Don't wrap transaction errors with `SFError` & don't serialize a massive internal error into `SFError` message

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Breaking
+- Don't throw `SFError` when executing `Operation` or `BatchCall`; let the original error bubble up
+- Serialize a much smaller version of the cause in `SFError` (only `name`, `message`, `code`)
+
 ## [0.5.5] - 2022-08-31
 ### Added
 - Support for: `optimism-goerli` and `arbitrum-goerli` added

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -60,7 +60,6 @@
         "browserify": "^17.0.0",
         "graphql-request": "^4.3.0",
         "lodash": "^4.17.21",
-        "serialize-error": "8.1.0",
         "tsify": "^5.0.4"
     },
     "devDependencies": {

--- a/packages/sdk-core/src/BatchCall.ts
+++ b/packages/sdk-core/src/BatchCall.ts
@@ -140,20 +140,12 @@ export default class BatchCall {
     exec = async (
         signer: ethers.Signer
     ): Promise<ethers.ContractTransaction> => {
-        try {
-            const operationStructArray = await Promise.all(
-                this.getOperationStructArrayPromises
-            );
-            return await this.host.contract
-                .connect(signer)
-                .batchCall(operationStructArray);
-        } catch (err) {
-            throw new SFError({
-                type: "BATCH_CALL_ERROR",
-                message: "There was an error executing your batch call:",
-                cause: err,
-            });
-        }
+        const operationStructArray = await Promise.all(
+            this.getOperationStructArrayPromises
+        );
+        return await this.host.contract
+            .connect(signer)
+            .batchCall(operationStructArray);
     };
 
     /* istanbul ignore next */
@@ -167,19 +159,11 @@ export default class BatchCall {
     execForward = async (
         signer: ethers.Signer
     ): Promise<ethers.ContractTransaction> => {
-        try {
-            const operationStructArray = await Promise.all(
-                this.getOperationStructArrayPromises
-            );
-            return await this.host.contract
-                .connect(signer)
-                .forwardBatchCall(operationStructArray);
-        } catch (err) {
-            throw new SFError({
-                type: "BATCH_CALL_ERROR",
-                message: "There was an error executing your batch call:",
-                cause: err,
-            });
-        }
+        const operationStructArray = await Promise.all(
+            this.getOperationStructArrayPromises
+        );
+        return await this.host.contract
+            .connect(signer)
+            .forwardBatchCall(operationStructArray);
     };
 }

--- a/packages/sdk-core/src/Operation.ts
+++ b/packages/sdk-core/src/Operation.ts
@@ -1,8 +1,6 @@
 import { TransactionRequest } from "@ethersproject/abstract-provider";
 import { ethers } from "ethers";
 
-import { SFError } from "./SFError";
-
 export type OperationType =
     | "UNSUPPORTED" // 0
     | "ERC20_APPROVE" // 1
@@ -37,17 +35,10 @@ export default class Operation {
     exec = async (
         signer: ethers.Signer
     ): Promise<ethers.providers.TransactionResponse> => {
-        try {
-            const populatedTransaction =
-                await this.getPopulatedTransactionRequest(signer);
-            return await signer.sendTransaction(populatedTransaction);
-        } catch (err) {
-            throw new SFError({
-                type: "EXECUTE_TRANSACTION",
-                message: "There was an error executing the transaction",
-                cause: err,
-            });
-        }
+        const populatedTransaction = await this.getPopulatedTransactionRequest(
+            signer
+        );
+        return await signer.sendTransaction(populatedTransaction);
     };
 
     /**
@@ -58,17 +49,8 @@ export default class Operation {
     getPopulatedTransactionRequest = async (
         signer: ethers.Signer
     ): Promise<TransactionRequest> => {
-        try {
-            const prePopulated = await this.populateTransactionPromise;
-            return await signer.populateTransaction(prePopulated);
-        } catch (err) {
-            /* istanbul ignore next */
-            throw new SFError({
-                type: "POPULATE_TRANSACTION",
-                message: "There was an error populating the transaction",
-                cause: err,
-            });
-        }
+        const prePopulated = await this.populateTransactionPromise;
+        return await signer.populateTransaction(prePopulated);
     };
     /**
      * Signs the populated transaction via the provided signer (what you intend on sending to the network).
@@ -76,20 +58,11 @@ export default class Operation {
      * @returns {Promise<string>} Fully serialized, signed transaction
      */
     getSignedTransaction = async (signer: ethers.Signer): Promise<string> => {
-        try {
-            const populatedTransaction =
-                await this.getPopulatedTransactionRequest(signer);
-            const signedTxn = await signer.signTransaction(
-                populatedTransaction
-            );
-            return signedTxn;
-        } catch (err) {
-            throw new SFError({
-                type: "SIGN_TRANSACTION",
-                message: "There was an error signing the transaction",
-                cause: err,
-            });
-        }
+        const populatedTransaction = await this.getPopulatedTransactionRequest(
+            signer
+        );
+        const signedTxn = await signer.signTransaction(populatedTransaction);
+        return signedTxn;
     };
 
     /**

--- a/packages/sdk-core/src/SFError.ts
+++ b/packages/sdk-core/src/SFError.ts
@@ -1,4 +1,4 @@
-import { serializeError } from "serialize-error";
+import { miniSerializeError } from "./miniSerializeError";
 
 export type ErrorType =
     | "FRAMEWORK_INITIALIZATION"
@@ -47,18 +47,12 @@ interface ErrorProps {
     cause?: Error | unknown;
 }
 
-// NOTE: this is a temporary solution to fix serializeError
-// which throws a weird JSON error
-const stringifyCause = (cause?: Error | unknown) => {
+const miniStringifyCause = (cause?: Error | unknown) => {
     try {
-        return JSON.stringify(serializeError(cause), null, 2);
-    } catch (err) {
-        try {
-            return JSON.stringify(cause, null, 2);
-        } catch {
-            console.error("Caused by: ", cause);
-            return "[Couldn't serialize error. Error logged to console.]";
-        }
+        return JSON.stringify(miniSerializeError(cause), null, 2);
+    } catch {
+        console.error("SFError caused by: ", cause);
+        return "[Couldn't serialize error. Error logged to console.]";
     }
 };
 
@@ -72,7 +66,7 @@ export class SFError extends Error {
         )} Error: ${message}${
             cause
                 ? `
-Caused by: ${stringifyCause(cause)}`
+Caused by: ${miniStringifyCause(cause)}`
                 : ""
         }`;
         super(

--- a/packages/sdk-core/src/SFError.ts
+++ b/packages/sdk-core/src/SFError.ts
@@ -12,9 +12,6 @@ export type ErrorType =
     | "INVALID_OBJECT"
     | "UNCLEAN_PERMISSIONS"
     | "NEGATIVE_FLOW_ALLOWANCE"
-    | "EXECUTE_TRANSACTION"
-    | "POPULATE_TRANSACTION"
-    | "SIGN_TRANSACTION"
     | "UNSUPPORTED_OPERATION"
     | "MISSING_TRANSACTION_PROPERTIES"
     | "BATCH_CALL_ERROR"
@@ -30,9 +27,6 @@ const errorTypeToTitleMap = new Map<ErrorType, string>([
     ["IDAV1_READ", "InstantDistributionAgreementV1 Read"],
     ["INVALID_ADDRESS", "Invalid Address"],
     ["INVALID_OBJECT", "Invalid Object"],
-    ["POPULATE_TRANSACTION", "Populate Transaction"],
-    ["EXECUTE_TRANSACTION", "Execute Transaction"],
-    ["SIGN_TRANSACTION", "Sign Transaction"],
     ["UNSUPPORTED_OPERATION", "Unsupported Batch Call Operation"],
     ["MISSING_TRANSACTION_PROPERTIES", "Missing Transaction Properties"],
     ["BATCH_CALL_ERROR", "Batch Call"],
@@ -49,10 +43,13 @@ interface ErrorProps {
 
 const miniStringifyCause = (cause?: Error | unknown) => {
     try {
-        return JSON.stringify(miniSerializeError(cause), null, 2);
+        const serializedError = miniSerializeError(cause);
+        const stringifiedError = JSON.stringify(serializedError, null, 2);
+        return stringifiedError.replace(/\\"/g, '"'); // Get rid of escaping of quotes.
     } catch {
+        // `miniSerializeError` is safe enough that this should never occur.
         console.error("SFError caused by: ", cause);
-        return "[Couldn't serialize error. Error logged to console.]";
+        return "[Couldn't serialize internal error. Error logged to console instead.]";
     }
 };
 

--- a/packages/sdk-core/src/miniSerializeError.ts
+++ b/packages/sdk-core/src/miniSerializeError.ts
@@ -1,0 +1,41 @@
+/**
+ * Credit of everything here goes to Redux Toolkit.
+ */
+
+/**
+ * @public
+ */
+export interface SerializedError {
+    name?: string;
+    message?: string;
+    stack?: string;
+    code?: string;
+}
+
+const commonProperties: Array<keyof SerializedError> = [
+    "name",
+    "message",
+    "stack",
+    "code",
+];
+
+/**
+ * Serializes an error into a plain object.
+ * Reworked from https://github.com/sindresorhus/serialize-error
+ *
+ * @public
+ */
+export const miniSerializeError = (value: any): SerializedError => {
+    if (typeof value === "object" && value !== null) {
+        const simpleError: SerializedError = {};
+        for (const property of commonProperties) {
+            if (typeof value[property] === "string") {
+                simpleError[property] = value[property];
+            }
+        }
+
+        return simpleError;
+    }
+
+    return { message: String(value) };
+};

--- a/packages/sdk-core/src/miniSerializeError.ts
+++ b/packages/sdk-core/src/miniSerializeError.ts
@@ -1,29 +1,22 @@
 /**
- * Credit of everything here goes to Redux Toolkit.
+ * Credit of everything here goes to Redux Toolkit (RTK).
  */
 
-/**
- * @public
- */
 export interface SerializedError {
     name?: string;
     message?: string;
-    stack?: string;
     code?: string;
 }
 
 const commonProperties: Array<keyof SerializedError> = [
     "name",
-    "message",
-    "stack",
     "code",
+    "message",
 ];
 
 /**
  * Serializes an error into a plain object.
  * Reworked from https://github.com/sindresorhus/serialize-error
- *
- * @public
  */
 export const miniSerializeError = (value: any): SerializedError => {
     if (typeof value === "object" && value !== null) {

--- a/packages/sdk-core/test/2_operation.test.ts
+++ b/packages/sdk-core/test/2_operation.test.ts
@@ -157,9 +157,8 @@ describe("Operation Tests", () => {
             await operation.exec(deployer);
         } catch (err: any) {
             expect(err.message).to.contain(
-                "Execute Transaction Error: There was an error executing the transaction"
+                "cannot estimate gas"
             );
-            expect(err.cause).to.be.instanceOf(Error);
         }
     });
 
@@ -173,9 +172,8 @@ describe("Operation Tests", () => {
             await operation.getSignedTransaction(alpha);
         } catch (err: any) {
             expect(err.message).to.contain(
-                "Sign Transaction Error: There was an error signing the transaction"
+                "signing transactions is unsupported"
             );
-            expect(err.cause).to.be.instanceOf(Error);
         }
     });
 

--- a/packages/sdk-core/test/3_batch_call.test.ts
+++ b/packages/sdk-core/test/3_batch_call.test.ts
@@ -67,9 +67,8 @@ describe("Batch Call Tests", () => {
             await framework.batchCall([createFlowOp]).exec(deployer);
         } catch (err: any) {
             expect(err.message).to.contain(
-                "Batch Call Error: There was an error executing your batch call:"
+                "cannot estimate gas;"
             );
-            expect(err.cause).to.be.instanceOf(Error);
         }
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17381,13 +17381,6 @@ sentence-case@^3.0.4:
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
 
-serialize-error@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.1.0.tgz#3a069970c712f78634942ddd50fbbc0eaebe2f67"
-  integrity sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==
-  dependencies:
-    type-fest "^0.20.2"
-
 serialize-javascript@6.0.0, serialize-javascript@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"


### PR DESCRIPTION
Steadily moving towards a more optimal error-handling solution based on feedback and usage.

Ideas:
* There is value to `SFError`, especially on `Framework` initialization.
* There is value to serializing the cause into `SFError` but it should be in much more human-friendly minimal format.
* `SFError` sometimes wraps transaction execution errors multiple times which only obfuscates the actual cause of the error. Even for common situations like "user rejected transaction".

Changes:
* Let original error bubble up when executing `Operation` & `BatchCall`.
* Serialize _a much smaller_ version of the internal error (by using the small `miniSerializeError` snippet from RTK).
* Remove `serialize-error` dependency.
* Remove escaping of the quotes from the serialized internal error.

Example of `SFError` with a cause:
```
SFError: Framework Initialization Error: There was an error initializing the framework
Caused by: {
  "name": "Error",
  "code": "CALL_EXCEPTION",
  "message": "call revert exception [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method="get(string)", data="0x", errorArgs=null, errorName=null, errorSignature=null, reason=null, code=CALL_EXCEPTION, version=abi/5.6.4)"
}
```