### PR TITLE
Gov: Convenience method for app registration keys and some cleanup

### DIFF
--- a/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceBase.sol
+++ b/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceBase.sol
@@ -365,7 +365,7 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
     )
         public
     {
-        return _clearConfig(host, superToken, SuperfluidGovernanceConfigs.SUPERTOKEN_MINIMUM_DEPOSIT_KEY);
+        _clearConfig(host, superToken, SuperfluidGovernanceConfigs.SUPERTOKEN_MINIMUM_DEPOSIT_KEY);
         emit SuperTokenMinimumDepositChanged(host, superToken, false, 0);
     }
 

--- a/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceBase.sol
+++ b/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceBase.sol
@@ -218,7 +218,7 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
     }
 
     /**************************************************************************
-    /* Known Configurations
+    /* Convenience methods for known Configurations
     /*************************************************************************/
 
     // Superfluid rewardAddress
@@ -232,7 +232,8 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
         ISuperfluid host,
         ISuperfluidToken superToken
     )
-        public view returns (address)
+        public view
+        returns (address)
     {
         return getConfigAsAddress(
             host, superToken,
@@ -246,11 +247,11 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
     )
         public
     {
-        emit RewardAddressChanged(host, superToken, true, rewardAddress);
-        return _setConfig(
+        _setConfig(
             host, superToken,
             SuperfluidGovernanceConfigs.SUPERFLUID_REWARD_ADDRESS_CONFIG_KEY,
             rewardAddress);
+        emit RewardAddressChanged(host, superToken, true, rewardAddress);
     }
 
     function clearRewardAddress(
@@ -259,10 +260,10 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
     )
         public
     {
-        emit RewardAddressChanged(host, superToken, false, address(0));
         _clearConfig(
             host, superToken,
             SuperfluidGovernanceConfigs.SUPERFLUID_REWARD_ADDRESS_CONFIG_KEY);
+        emit RewardAddressChanged(host, superToken, false, address(0));
     }
 
     // CFAv1 liquidationPeriod (DEPRECATED BY PPPConfigurationChanged)
@@ -283,16 +284,17 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
     function getPPPConfig(
         ISuperfluid host,
         ISuperfluidToken superToken
-    ) public view
+    )
+        public view
         returns (uint256 liquidationPeriod, uint256 patricianPeriod)
-        {
-            uint256 pppConfig = getConfigAsUint256(
-                host,
-                superToken,
-                SuperfluidGovernanceConfigs.CFAV1_PPP_CONFIG_KEY
-            );
-            (liquidationPeriod, patricianPeriod) = SuperfluidGovernanceConfigs.decodePPPConfig(pppConfig);
-        }
+    {
+        uint256 pppConfig = getConfigAsUint256(
+            host,
+            superToken,
+            SuperfluidGovernanceConfigs.CFAV1_PPP_CONFIG_KEY
+        );
+        (liquidationPeriod, patricianPeriod) = SuperfluidGovernanceConfigs.decodePPPConfig(pppConfig);
+    }
 
     function setPPPConfig(
         ISuperfluid host,
@@ -307,23 +309,27 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
             && patricianPeriod < type(uint32).max,
             "SFGov: Invalid liquidationPeriod or patricianPeriod"
         );
-        emit PPPConfigurationChanged(host, superToken, true, liquidationPeriod, patricianPeriod);
         uint256 value = (uint256(liquidationPeriod) << 32) | uint256(patricianPeriod);
-        return _setConfig(
+        _setConfig(
             host,
             superToken,
             SuperfluidGovernanceConfigs.CFAV1_PPP_CONFIG_KEY,
             value
         );
+        emit PPPConfigurationChanged(host, superToken, true, liquidationPeriod, patricianPeriod);
     }
 
     function clearPPPConfig(
         ISuperfluid host,
         ISuperfluidToken superToken
-    ) public {
+    )
+        public
+    {
+        _clearConfig(host, superToken, SuperfluidGovernanceConfigs.CFAV1_PPP_CONFIG_KEY);
         emit PPPConfigurationChanged(host, superToken, false, 0, 0);
-        return _clearConfig(host, superToken, SuperfluidGovernanceConfigs.CFAV1_PPP_CONFIG_KEY);
     }
+
+    // CFAv1 minimum deposit
     event SuperTokenMinimumDepositChanged(
         ISuperfluid indexed host,
         ISuperfluidToken indexed superToken,
@@ -334,8 +340,9 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
     function getSuperTokenMinimumDeposit(
         ISuperfluid host,
         ISuperfluidToken superToken
-    ) public view
-    returns (uint256 value)
+    )
+        public view
+        returns (uint256 value)
     {
         return getConfigAsUint256(host, superToken,
             SuperfluidGovernanceConfigs.SUPERTOKEN_MINIMUM_DEPOSIT_KEY);
@@ -345,18 +352,21 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
         ISuperfluid host,
         ISuperfluidToken superToken,
         uint256 value
-    ) public {
+    )
+        public
+    {
+        _setConfig(host, superToken, SuperfluidGovernanceConfigs.SUPERTOKEN_MINIMUM_DEPOSIT_KEY, value);
         emit SuperTokenMinimumDepositChanged(host, superToken, true, value);
-        return _setConfig(host, superToken, SuperfluidGovernanceConfigs.SUPERTOKEN_MINIMUM_DEPOSIT_KEY, value);
     }
 
     function clearSuperTokenMinimumDeposit(
         ISuperfluid host,
         ISuperToken superToken
-    ) public
+    )
+        public
     {
-        emit SuperTokenMinimumDepositChanged(host, superToken, false, 0);
         return _clearConfig(host, superToken, SuperfluidGovernanceConfigs.SUPERTOKEN_MINIMUM_DEPOSIT_KEY);
+        emit SuperTokenMinimumDepositChanged(host, superToken, false, 0);
     }
 
     // trustedForwarder
@@ -401,25 +411,77 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
     )
         public
     {
-        _setConfig(
+        _clearConfig(
             host, superToken,
-            SuperfluidGovernanceConfigs.getTrustedForwarderConfigKey(forwarder),
-            0);
+            SuperfluidGovernanceConfigs.getTrustedForwarderConfigKey(forwarder));
         emit TrustedForwarderChanged(host, superToken, true, forwarder, false);
     }
 
-    function clearTrustedForwarder(
+    // Superfluid registrationKey
+    event AppRegistrationKeyChanged(
+        ISuperfluid indexed host,
+        address indexed deployer,
+        string appRegistrationKey,
+        uint256 expirationTs
+    );
+
+    function verifyAppRegistrationKey(
         ISuperfluid host,
-        ISuperfluidToken superToken,
-        address forwarder
+        address deployer,
+        string memory registrationKey
+    )
+        public view
+        returns(bool validNow, uint256 expirationTs)
+    {
+        bytes32 configKey = SuperfluidGovernanceConfigs.getAppRegistrationConfigKey(
+            deployer,
+            registrationKey
+        );
+        uint256 expirationTs = getConfigAsUint256(host, ISuperfluidToken(address(0)), configKey);
+        return (
+            // solhint-disable-next-line not-rely-on-time
+            expirationTs >= block.timestamp,
+            expirationTs
+        );
+    }
+
+    function setAppRegistrationKey(
+        ISuperfluid host,
+        address deployer,
+        string memory registrationKey,
+        uint256 expirationTs
     )
         public
     {
-        emit TrustedForwarderChanged(host, superToken, false, forwarder, false);
-        return _clearConfig(
-            host, superToken,
-            SuperfluidGovernanceConfigs.getTrustedForwarderConfigKey(forwarder));
+        bytes32 configKey = SuperfluidGovernanceConfigs.getAppRegistrationConfigKey(
+            deployer,
+            registrationKey
+        );
+        _setConfig(host, ISuperfluidToken(address(0)), configKey, expirationTs);
+        emit AppRegistrationKeyChanged(host, deployer, registrationKey, expirationTs);
     }
+
+    function clearAppRegistrationKey(
+        ISuperfluid host,
+        address deployer,
+        string memory registrationKey
+    )
+        public
+    {
+        bytes32 configKey = SuperfluidGovernanceConfigs.getAppRegistrationConfigKey(
+            deployer,
+            registrationKey
+        );
+        _clearConfig(host, ISuperfluidToken(address(0)), configKey);
+        emit AppRegistrationKeyChanged(host, deployer, registrationKey, 0);
+    }
+
+    // Superfluid App factory
+    event AppFactoryAuthorizationChanged(
+        ISuperfluid indexed host,
+        address indexed factory,
+        bool authorized
+    );
 
     /**
      * @dev tells if the given factory is authorized to register apps
@@ -453,11 +515,11 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
             assembly { cs := extcodesize(factory) }
             require(cs > 0, "SFGov: factory must be a contract");
         }
-
         _setConfig(
             host, ISuperfluidToken(address(0)),
             SuperfluidGovernanceConfigs.getAppFactoryConfigKey(factory),
             1);
+        emit AppFactoryAuthorizationChanged(host, factory, true);
     }
 
     /**
@@ -473,6 +535,7 @@ abstract contract SuperfluidGovernanceBase is ISuperfluidGovernance
         _clearConfig(
             host, ISuperfluidToken(address(0)),
             SuperfluidGovernanceConfigs.getAppFactoryConfigKey(factory));
+        emit AppFactoryAuthorizationChanged(host, factory, false);
     }
 
     // TODO: would like to use virtual modifier, but solhint doesn't like it atm

--- a/packages/ethereum-contracts/scripts/gov-create-new-app-registration-key.js
+++ b/packages/ethereum-contracts/scripts/gov-create-new-app-registration-key.js
@@ -6,8 +6,6 @@ const {
     sendGovernanceAction,
 } = require("./libs/common");
 
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
-
 /**
  * @dev Create a new super app registration key.
  * @param {Array} argv Overriding command line arguments
@@ -43,11 +41,12 @@ module.exports = eval(`(${S.toString()})({
             throw new Error("EXPIRATON_TS not an integer");
         }
         expirationTs = parsedExpTs;
-        console.log("Expiration timestamp", expirationTs);
     }
-    const registrationkey = args.pop();
+    const registrationKey = args.pop();
     const deployer = args.pop();
     console.log("Deployer", deployer);
+    console.log("Registration key", registrationKey);
+    console.log("Expiration timestamp", expirationTs);
 
     console.log("protocol release version:", protocolReleaseVersion);
 
@@ -63,23 +62,14 @@ module.exports = eval(`(${S.toString()})({
     });
     await sf.initialize();
 
-    const appKey = web3.utils.sha3(
-        web3.eth.abi.encodeParameters(
-            ["string", "address", "string"],
-            [
-                "org.superfluid-finance.superfluid.appWhiteListing.registrationKey",
-                deployer,
-                registrationkey,
-            ]
-        )
-    );
-    console.log("App key", appKey);
     console.log("Expiration date", new Date(expirationTs * 1000)); // print human readable
 
-    // Note that we are NOT using gov.whiteListNewApp here, because it doesn't support setting
-    // an expiration date and will eventually be deprecated.
-    // Instead we use the lower level setConfig directly.
     await sendGovernanceAction(sf, (gov) =>
-        gov.setConfig(sf.host.address, ZERO_ADDRESS, appKey, expirationTs)
+        gov.setAppRegistrationKey(
+            sf.host.address,
+            deployer,
+            registrationKey,
+            expirationTs
+        )
     );
 });

--- a/packages/ethereum-contracts/test/contracts/superfluid/Superfluid.test.js
+++ b/packages/ethereum-contracts/test/contracts/superfluid/Superfluid.test.js
@@ -2577,19 +2577,6 @@ describe("Superfluid Host Contract", function () {
             await t.popEvmSnapshot();
         });
 
-        function createAppKey(deployer, registrationKey) {
-            return web3.utils.sha3(
-                web3.eth.abi.encodeParameters(
-                    ["string", "address", "string"],
-                    [
-                        "org.superfluid-finance.superfluid.appWhiteListing.registrationKey",
-                        deployer,
-                        registrationKey,
-                    ]
-                )
-            );
-        }
-
         context("#40.x register app with key", () => {
             it("#40.1 app registration without key should fail", async () => {
                 await expectRevertedWith(
@@ -2614,13 +2601,13 @@ describe("Superfluid Host Contract", function () {
             });
 
             it("#40.3 app can register with a correct key", async () => {
-                const appKey = createAppKey(bob, "hello world");
+                const regKey = "hello world";
                 const expirationTs =
                     Math.floor(Date.now() / 1000) + 3600 * 24 * 90; // 90 days from now
-                await governance.setConfig(
+                await governance.setAppRegistrationKey(
                     superfluid.address,
-                    ZERO_ADDRESS,
-                    appKey,
+                    bob,
+                    regKey,
                     expirationTs
                 );
                 const app = await SuperAppMockWithRegistrationkey.new(
@@ -2635,13 +2622,13 @@ describe("Superfluid Host Contract", function () {
             });
 
             it("#40.4 app registration with key for different deployer should fail", async () => {
-                const appKey = createAppKey(bob, "hello world");
+                const regKey = "hello world";
                 const expirationTs =
                     Math.floor(Date.now() / 1000) + 3600 * 24 * 90; // 90 days from now
-                await governance.setConfig(
+                await governance.setAppRegistrationKey(
                     superfluid.address,
-                    ZERO_ADDRESS,
-                    appKey,
+                    bob,
+                    regKey,
                     expirationTs
                 );
                 await expectRevertedWith(
@@ -2658,12 +2645,12 @@ describe("Superfluid Host Contract", function () {
             });
 
             it("#40.5 app can register with an expired key should fail", async () => {
-                const appKey = createAppKey(bob, "hello world again");
+                const regKey = "hello world again";
                 const expirationTs = Math.floor(Date.now() / 1000) - 3600 * 24; // expired yesterday
-                await governance.setConfig(
+                await governance.setAppRegistrationKey(
                     superfluid.address,
-                    ZERO_ADDRESS,
-                    appKey,
+                    bob,
+                    regKey,
                     expirationTs
                 );
                 await expectRevertedWith(


### PR DESCRIPTION
We wanted to (re-)introduce (context: https://github.com/superfluid-finance/protocol-monorepo/pull/769) convenience methods for governing app registration keys, see https://github.com/superfluid-finance/protocol-monorepo/issues/1039.

After an incident with key handout (by mistake communicated "app keys" instead of the needed "registration keys", I simplified the code to not expose the "app key" aka "config key" (that's what it basically was: the config key for the gov module KV store) to the public gov interface.

Piggy-backed:
* emit event when changing app factory authorizations
* removed `clearTrustedForwarder` and changed `disableTrustedForwarder` to use `_clearConfig` internally. (assuming there's no good reason to do it otherwise, or is there?)
* more consistent syntax and code in other convenience methods (no functional change), e.g. don't use `return` for `_setConfig` and `_clearConfig` which don't return anything.