### PR TITLE
Add gnosisscan support

### DIFF
--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -75,6 +75,6 @@
         "solidity-coverage": "0.7.21",
         "solidity-docgen": "^0.6.0-beta.17",
         "truffle-flattener": "^1.6.0",
-        "truffle-plugin-verify": "d10r/truffle-plugin-verify#verifyProxyFixed"
+        "truffle-plugin-verify": "0.5.28"
     }
 }

--- a/packages/ethereum-contracts/scripts/info-print-contract-addresses.js
+++ b/packages/ethereum-contracts/scripts/info-print-contract-addresses.js
@@ -38,17 +38,14 @@ module.exports = eval(`(${S.toString()})()`)(async function (
     console.log("chain ID: ", chainId);
     const config = getConfig(chainId);
 
-    config.tokenList = [];
-
     const sf = new SuperfluidSDK.Framework({
         ...extractWeb3Options(options),
         version: protocolReleaseVersion,
-        tokens: [], //config.tokenList,
-        loadSuperNativeToken: false, //true,
+        tokens: config.tokenList,
+        loadSuperNativeToken: true,
         additionalContracts: ["UUPSProxiable"],
     });
     await sf.initialize();
-    sf.config.nativeTokenSymbol = undefined;
 
     const {UUPSProxiable, ISuperTokenFactory} = sf.contracts;
 

--- a/packages/ethereum-contracts/scripts/info-print-contract-addresses.js
+++ b/packages/ethereum-contracts/scripts/info-print-contract-addresses.js
@@ -38,14 +38,17 @@ module.exports = eval(`(${S.toString()})()`)(async function (
     console.log("chain ID: ", chainId);
     const config = getConfig(chainId);
 
+    config.tokenList = [];
+
     const sf = new SuperfluidSDK.Framework({
         ...extractWeb3Options(options),
         version: protocolReleaseVersion,
-        tokens: config.tokenList,
-        loadSuperNativeToken: true,
+        tokens: [], //config.tokenList,
+        loadSuperNativeToken: false, //true,
         additionalContracts: ["UUPSProxiable"],
     });
     await sf.initialize();
+    sf.config.nativeTokenSymbol = undefined;
 
     const {UUPSProxiable, ISuperTokenFactory} = sf.contracts;
 

--- a/packages/ethereum-contracts/tasks/etherscan-verify-framework.sh
+++ b/packages/ethereum-contracts/tasks/etherscan-verify-framework.sh
@@ -47,29 +47,29 @@ function try_verify() {
 }
 
 echo SUPERFLUID_HOST
-try_verify UUPSProxy@${SUPERFLUID_HOST_PROXY} --implementation Superfluid
+try_verify Superfluid@${SUPERFLUID_HOST_PROXY} --custom-proxy UUPSProxy
 
 echo SUPERFLUID_GOVERNANCE
 if [ ! -z "$IS_TESTNET" ];then
 try_verify TestGovernance@${SUPERFLUID_GOVERNANCE}
 else
-try_verify SuperfluidGovernanceIIProxy@${SUPERFLUID_GOVERNANCE} --implementation SuperfluidGovernanceII
+try_verify SuperfluidGovernanceII@${SUPERFLUID_GOVERNANCE} --custom-proxy SuperfluidGovernanceIIProxy
 fi
 
 echo SUPERFLUID_SUPER_TOKEN_FACTORY
-try_verify UUPSProxy@${SUPERFLUID_SUPER_TOKEN_FACTORY_PROXY} --implementation SuperTokenFactory
+try_verify SuperTokenFactory@${SUPERFLUID_SUPER_TOKEN_FACTORY_PROXY} --custom-proxy UUPSProxy
 
 echo SUPERFLUID_SUPER_TOKEN_LOGIC
 if [ -z "$NO_FORCE_CONSTRUCTOR_ARGS" ];then
     # it is required to provide the constructor arguments manually, because the super token logic is created through a contract not an EOA
     SUPERFLUID_SUPER_TOKEN_LOGIC_CONSTRUCTOR_ARGS=$(node -e 'console.log("'${SUPERFLUID_HOST_PROXY}'".toLowerCase().slice(2).padStart(64, "0"))')
-    try_verify UUPSProxy@${SUPERFLUID_SUPER_TOKEN_LOGIC} --implementation SuperToken --forceConstructorArgs string:${SUPERFLUID_SUPER_TOKEN_LOGIC_CONSTRUCTOR_ARGS}
+    try_verify SuperToken@${SUPERFLUID_SUPER_TOKEN_LOGIC} --forceConstructorArgs string:${SUPERFLUID_SUPER_TOKEN_LOGIC_CONSTRUCTOR_ARGS} --custom-proxy UUPSProxy
 else
     echo "!!! WARNING !!! Cannot verify super token logic due to forceConstructorArgs not supported."
 fi
 
 echo CFA
-try_verify UUPSProxy@${CFA_PROXY} --implementation ConstantFlowAgreementV1
+try_verify ConstantFlowAgreementV1@${CFA_PROXY} --custom-proxy UUPSProxy
 
 echo SlotsBitmapLibrary
 try_verify SlotsBitmapLibrary@${SLOTS_BITMAP_LIBRARY_ADDRESS}
@@ -91,12 +91,12 @@ jq -s '.[0] * .[1]' \
 }
 EOF
     ) > build/contracts/InstantDistributionAgreementV1.json
-try_verify UUPSProxy@${IDA_PROXY} --implementation InstantDistributionAgreementV1
+try_verify InstantDistributionAgreementV1@${IDA_PROXY} --custom-proxy UUPSProxy
 mv -f build/contracts/InstantDistributionAgreementV1.json.bak build/contracts/InstantDistributionAgreementV1.json
 
 if [ ! -z "$SUPER_TOKEN_NATIVE_COIN" ];then
     echo SUPER_TOKEN_NATIVE_COIN
-    try_verify SETHProxy@${SUPER_TOKEN_NATIVE_COIN} --implementation SuperToken
+    try_verify SuperToken@${SUPER_TOKEN_NATIVE_COIN} --custom-proxy SETHProxy
 fi
 
 set +x

--- a/packages/ethereum-contracts/truffle-config.js
+++ b/packages/ethereum-contracts/truffle-config.js
@@ -284,7 +284,7 @@ const E = (module.exports = {
 
         "arbitrum-rinkeby": {
             ...createNetworkDefaultConfiguration("arbitrum-rinkeby"),
-            network_id: 42162,
+            network_id: 421611,
             gas: 250e6, // arbgas is different and estimation fails for expensive txs
             timeoutBlocks: 50, // # of blocks before a deployment times out  (minimum/default: 50)
             skipDryRun: false, // Skip dry run before migrations? (default: false for public nets )

--- a/packages/ethereum-contracts/truffle-config.js
+++ b/packages/ethereum-contracts/truffle-config.js
@@ -406,6 +406,7 @@ const E = (module.exports = {
         optimistic_etherscan: process.env.OPTIMISTIC_API_KEY,
         bscscan: process.env.BSCSCAN_API_KEY,
         arbiscan: process.env.ARBISCAN_API_KEY,
+        gnosisscan: process.env.GNOSISSCAN_API_KEY,
     },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18891,9 +18891,10 @@ truffle-flattener@^1.6.0:
     mkdirp "^1.0.4"
     tsort "0.0.1"
 
-truffle-plugin-verify@d10r/truffle-plugin-verify#verifyProxyFixed:
-  version "0.5.26"
-  resolved "https://codeload.github.com/d10r/truffle-plugin-verify/tar.gz/e913c3db14f37c9c8c858e707cf550b3ab56aa16"
+truffle-plugin-verify@0.5.28:
+  version "0.5.28"
+  resolved "https://registry.yarnpkg.com/truffle-plugin-verify/-/truffle-plugin-verify-0.5.28.tgz#e0d3811c366e0625656ea97f7443ef897f004332"
+  integrity sha512-wmWJsJPq9Zj/FaJVXISwnL0mOGGKLgSCbOnwXzxmuv+0iRcUuccFAianYP4Ru/QjzsD2T6pQ7TUjVGLEcCkMtg==
   dependencies:
     axios "^0.26.1"
     cli-logger "^0.5.40"


### PR DESCRIPTION
There's now https://gnosisscan.io/
I created an account for user superfluidit, see 1Password.

* updated truffle-plugin-verify to [v0.5.28](https://github.com/rkalis/truffle-plugin-verify/releases/tag/v0.5.28) and changed the [syntax for proxied contracts](https://github.com/rkalis/truffle-plugin-verify#usage-with-proxy-contracts) to the syntax introduced in v0.5.27
* fixed the chainId of arbitrum-rinkeby (was by mistake incorrectly changed in a recent PR)