### PR TITLE
[SDK-core] Don't wrap SubgraphClient's errors with SFError

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Breaking
+- Don't wrap `SubgraphClient` with `SFError`
+
 ## [0.5.5] - 2022-08-31
 ### Added
 - Support for: `optimism-goerli` and `arbitrum-goerli` added

--- a/packages/sdk-core/src/subgraph/SubgraphClient.ts
+++ b/packages/sdk-core/src/subgraph/SubgraphClient.ts
@@ -1,9 +1,6 @@
 import { TypedDocumentNode } from "@graphql-typed-document-node/core";
-import { DocumentNode, print } from "graphql";
+import { DocumentNode } from "graphql";
 import { request } from "graphql-request";
-import { isString } from "lodash";
-
-import { SFError } from "../SFError";
 
 type RequestDocument = string | DocumentNode;
 
@@ -23,23 +20,11 @@ export class SubgraphClient {
         document: RequestDocument | TypedDocumentNode<T, V>,
         variables?: V
     ): Promise<T> {
-        try {
-            return await request<T, V>(
-                this.subgraphUrl,
-                document,
-                cleanVariables(variables)
-            );
-        } catch (err) {
-            const queryString: string = isString(document)
-                ? document
-                : print(document);
-            throw new SFError({
-                type: "SUBGRAPH_ERROR",
-                message: `Failed call to subgraph with: 
-${queryString}`,
-                cause: err,
-            });
-        }
+        return await request<T, V>(
+            this.subgraphUrl,
+            document,
+            cleanVariables(variables)
+        );
     }
 }
 


### PR DESCRIPTION
Why?
Pretty useless wrapping which again just creates obfuscation.