### PR TITLE
[ETHEREUM-CONTRACTS] Patrician Period Patch

### DIFF
--- a/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
@@ -1432,6 +1432,10 @@ contract ConstantFlowAgreementV1 is
         internal pure
         returns (bool)
     {
+        if (signedTotalCFADeposit == 0) {
+            return false;
+        }
+
         int256 totalRewardLeft = availableBalance + signedTotalCFADeposit;
         int256 totalCFAOutFlowrate = signedTotalCFADeposit / int256(liquidationPeriod);
         // divisor cannot be zero with existing outflow

--- a/packages/ethereum-contracts/nodemon.json
+++ b/packages/ethereum-contracts/nodemon.json
@@ -1,0 +1,3 @@
+{
+    "ignore": ["typechain-types", "artifacts", "cache", "build"]
+}

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -27,7 +27,7 @@
         "run-hardhat": "IS_HARDHAT=true hardhat",
         "run-truffle": "IS_TRUFFLE=true truffle",
         "run-forge": "IS_FOUNDRY=true forge",
-        "run-nodemon": "nodemon -e sol,js,ts -i build -x",
+        "run-nodemon": "nodemon -e sol,js,ts -x",
         "build": "run-s build:*",
         "build:contracts": "rm -f build/contracts/*;yarn run-truffle compile",
         "build:hardhat": "yarn run-hardhat compile",

--- a/packages/ethereum-contracts/test/contracts/agreements/ConstantFlowAgreementV1-Non-Callback.test.ts
+++ b/packages/ethereum-contracts/test/contracts/agreements/ConstantFlowAgreementV1-Non-Callback.test.ts
@@ -1388,7 +1388,7 @@ describe("CFAv1 | Non-Callback Tests", function () {
 
         it("#1.4.17 Patrician period updates when user is not solvent", async () => {
             shouldCreateSolventLiquidationTest({
-                titlePrefix: "#1.4.10",
+                titlePrefix: "#1.4.17",
                 sender,
                 receiver,
                 by: agent,
@@ -1410,6 +1410,52 @@ describe("CFAv1 | Non-Callback Tests", function () {
             );
 
             assert.isFalse(period[0]);
+        });
+
+        it("#1.4.18 isPatricianPeriod should handle case when user deposit is 0 (no flow)", async () => {
+            // @note comment out the `if (signedTotalCFADeposit == 0)` check in
+            // _isPatricianPeriod to see this revert.
+
+            // set Alice as the reward address
+            await governance.setRewardAddress(
+                superfluid.address,
+                ZERO_ADDRESS,
+                t.aliases[sender]
+            );
+
+            // create a flow from sender -> receiver
+            shouldCreateSolventLiquidationTest({
+                titlePrefix: "#1.4.18",
+                sender,
+                receiver,
+                by: agent,
+                seconds: t.configs.PATRICIAN_PERIOD.add(toBN(1)),
+            });
+
+            // drain account
+            await t.timeTravelOnce(t.configs.INIT_BALANCE.div(FLOW_RATE1));
+
+            // liquidate flow (receiver)
+            await agreementHelper.modifyFlow({
+                type: FLOW_TYPE_DELETE,
+                superToken: superToken.address,
+                sender: t.aliases[sender],
+                receiver: t.aliases[receiver],
+                signer: await ethers.getSigner(t.aliases[receiver]),
+            });
+
+            // user balance is less than 0 to skip the first check
+            const balance = await superToken.realtimeBalanceOfNow(
+                t.aliases[sender]
+            );
+            expect(balance.availableBalance).to.be.lessThan(toBN(0));
+
+            // expect the patrician period to be false (new logic)
+            const period = await cfa.isPatricianPeriodNow(
+                superToken.address,
+                t.aliases[sender]
+            );
+            expect(period.isCurrentlyPatricianPeriod).to.be.false;
         });
     });
 


### PR DESCRIPTION
This fixes an issue where if `cfa._isPatricianPeriod` is run with `signedTotalCFADeposit = 0`, this view function will revert with: `Panic(uint256)` because of division by 0.

This happens because of the following formulas:
```
int256 totalCFAOutFlowrate = signedTotalCFADeposit / int256(liquidationPeriod);
// totalCFAOutFlowrate = 0 / something arbitrary non-zero number = 0

return totalRewardLeft / totalCFAOutFlowrate > int256(liquidationPeriod - patricianPeriod);
// return: some arbitrary number / 0
```