### PR TITLE
[SDK-CORE] Fix Batch Call Expect

### DIFF
--- a/packages/sdk-core/test/3_batch_call.test.ts
+++ b/packages/sdk-core/test/3_batch_call.test.ts
@@ -57,7 +57,7 @@ describe("Batch Call Tests", () => {
                 .exec(alpha);
         } catch (err: any) {
             expect(err.message).to.contain(
-                "Cannot read properties of undefined"
+                "undefined"
             );
         }
     });


### PR DESCRIPTION
This test keeps failing in Canary and is not always caught in `ci.feature` as sdk-core tests aren't always run.

* this test just needs to know something is undefined
* in the workflow it lets us know which property is undefined, but locally it gives the original message: "Cannot read properties of undefined"