### PR TITLE
[SDK-CORE/SDK-REDUX] Fix reference docs Cloudfront bucket ID & use single "@dev" for latest dev-build

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -245,7 +245,7 @@ jobs:
           aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
           s3_uri: ${{ format('{0}sdk-core@{1}', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI, steps.sdk-versions.outputs.SDK_CORE_VERSION) }}
-          cloudfront_distribution_id: E3SV855CTC9UJO
+          cloudfront_distribution_id: E3JEO5R14CT8IH
 
       - name: Upload sdk-redux HTML documentation
         uses: ./build-scripts/s3cloudfront-hosting/actions/sync
@@ -255,7 +255,7 @@ jobs:
           aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
           s3_uri: ${{ format('{0}sdk-redux@{1}', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI, steps.sdk-versions.outputs.SDK_REDUX_VERSION) }}
-          cloudfront_distribution_id: E3SV855CTC9UJO
+          cloudfront_distribution_id: E3JEO5R14CT8IH
 
   upgrade-contracts:
     name: Upgrade ethereum-contracts on goerli testnet (protocol release version "test")

--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -244,7 +244,7 @@ jobs:
           aws_region: eu-west-2
           aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
-          s3_uri: ${{ format('{0}sdk-core@{1}', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI, steps.sdk-versions.outputs.SDK_CORE_VERSION) }}
+          s3_uri: ${{ format('{0}sdk-core@dev', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI) }}
           cloudfront_distribution_id: E3JEO5R14CT8IH
 
       - name: Upload sdk-redux HTML documentation
@@ -254,7 +254,7 @@ jobs:
           aws_region: eu-west-2
           aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
-          s3_uri: ${{ format('{0}sdk-redux@{1}', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI, steps.sdk-versions.outputs.SDK_REDUX_VERSION) }}
+          s3_uri: ${{ format('{0}sdk-redux@dev', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI) }}
           cloudfront_distribution_id: E3JEO5R14CT8IH
 
   upgrade-contracts:

--- a/.github/workflows/handler.deploy-to-mainnet.yml
+++ b/.github/workflows/handler.deploy-to-mainnet.yml
@@ -71,4 +71,4 @@ jobs:
           aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
           s3_uri: ${{ format('{0}{1}-contract-addrs@{2}', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI, github.event.inputs.network, github.run_id) }}
-          cloudfront_distribution_id: E3SV855CTC9UJO
+          cloudfront_distribution_id: E3JEO5R14CT8IH

--- a/.github/workflows/handler.publish-release-packages.yml
+++ b/.github/workflows/handler.publish-release-packages.yml
@@ -79,7 +79,7 @@ jobs:
           aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
           s3_uri: ${{ format('{0}sdk-core@{1}', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI, steps.publish-sdk-core.outputs.PUBLISHED_VERSION) }}
-          cloudfront_distribution_id: E3SV855CTC9UJO
+          cloudfront_distribution_id: E3JEO5R14CT8IH
 
       - name: Upload sdk-core latest documentation redirect
         if: env.PUBLISH_SDK_CORE == 1
@@ -90,7 +90,7 @@ jobs:
           aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
           s3_uri: ${{ format('{0}sdk-core', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI) }}
-          cloudfront_distribution_id: E3SV855CTC9UJO
+          cloudfront_distribution_id: E3JEO5R14CT8IH
 
       - name: Publish sdk-redux package
         id: publish-sdk-redux
@@ -120,7 +120,7 @@ jobs:
           aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
           s3_uri: ${{ format('{0}sdk-redux@{1}', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI, steps.publish-sdk-redux.outputs.PUBLISHED_VERSION) }}
-          cloudfront_distribution_id: E3SV855CTC9UJO
+          cloudfront_distribution_id: E3JEO5R14CT8IH
 
       - name: Upload sdk-redux latest documentation redirect
         if: env.PUBLISH_SDK_REDUX == 1
@@ -131,4 +131,4 @@ jobs:
           aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
           s3_uri: ${{ format('{0}sdk-redux', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI) }}
-          cloudfront_distribution_id: E3SV855CTC9UJO
+          cloudfront_distribution_id: E3JEO5R14CT8IH

--- a/.github/workflows/handler.update-evm-contracts-docs.yml
+++ b/.github/workflows/handler.update-evm-contracts-docs.yml
@@ -54,7 +54,7 @@ jobs:
       #     aws_access_key_id: ${{ secrets.SITE_DEPLOYER_AWS_ACCESS_KEY_ID }}
       #     aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
       #     s3_uri: ${{ format('{0}ethereum-contracts@{1}', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI, steps.sdk-versions.outputs.CONTRACTS_VERSION) }}
-      #     cloudfront_distribution_id: E3SV855CTC9UJO
+      #     cloudfront_distribution_id: E3JEO5R14CT8IH
 
       - name: Update the docs repo
         uses: dmnemec/copy_file_to_another_repo_action@main


### PR DESCRIPTION
Why?
Bit of a mishap from infra. All the previous reference docs got deleted unfortunately. 

Using the chance to unify dev-build reference documentation to a single `@dev`. 