### PR TITLE
[SDK-REDUX] Update sdk-redux dependencies and bump version (0.4.0)

### DIFF
--- a/packages/sdk-redux/CHANGELOG.md
+++ b/packages/sdk-redux/CHANGELOG.md
@@ -3,10 +3,13 @@ All notable changes to the SDK-redux will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2022-10-31
+
 ### Breaking
 - Pass in `signer` through mutation payload
 - Remove `setSignerForSdkRedux`
 - Serialized `transactionResponse` is now possibly undefined on `TrackedTransaction` when serialization fails
+- Update `@reduxjs/toolkit` & `@superfluid-finance/sdk-core` dependencies
 
 ### Added
 - Query for transfer events

--- a/packages/sdk-redux/package.json
+++ b/packages/sdk-redux/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-redux",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "SDK Redux for streamlined front-end application development with Superfluid Protocol",
     "homepage": "https://docs.superfluid.finance/",
     "repository": {
@@ -37,17 +37,17 @@
         "node": ">=12"
     },
     "dependencies": {
-        "@types/promise-retry": "^1.1.3",
         "graphql-request": "^4.3.0",
         "lodash": "^4.17.21",
         "promise-retry": "^2.0.1"
     },
     "devDependencies": {
-        "@reduxjs/toolkit": "^1.8.3"
+        "@types/promise-retry": "^1.1.3",
+        "@reduxjs/toolkit": "^1.8.6"
     },
     "peerDependencies": {
-        "@reduxjs/toolkit": "^1.6.0 || ^1.7.0",
-        "@superfluid-finance/sdk-core": "~0.4.3"
+        "@reduxjs/toolkit": "^1.7.0 || 1.8.0",
+        "@superfluid-finance/sdk-core": "~0.5.6"
     },
     "files": [
         "dist/main",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3517,10 +3517,10 @@
   resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.1.0.tgz#0e81ce56b4883b4b2a3001ebe1ab298b84237204"
   integrity sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg==
 
-"@reduxjs/toolkit@^1.8.3":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.3.tgz#9c6a9c497bde43a67618d37a4175a00ae12efeb2"
-  integrity sha512-lU/LDIfORmjBbyDLaqFN2JB9YmAT1BElET9y0ZszwhSBa5Ef3t6o5CrHupw5J1iOXwd+o92QfQZ8OJpwXvsssg==
+"@reduxjs/toolkit@^1.8.6":
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.6.tgz#147fb7957befcdb75bc9c1230db63628e30e4332"
+  integrity sha512-4Ia/Loc6WLmdSOzi7k5ff7dLK8CgG2b8aqpLsCAJhazAzGdp//YBUSaj0ceW6a3kDBDNRrq5CRwyCS0wBiL1ig==
   dependencies:
     immer "^9.0.7"
     redux "^4.1.2"


### PR DESCRIPTION
Why?
Been using the dev-build without changes for a while now. Let's solidify this version as stable.