### PR TITLE
[SDK-core] Include "DOM" lib for ESModule build

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,10 +79,7 @@
         ],
         "nohoist": [
             "**/webpack",
-            "**/webpack/**",
-            "**/react",
-            "**/react-redux",
-            "**/@reduxjs/toolkit"
+            "**/webpack/**"
         ]
     },
     "version": "0.0.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,10 @@
         ],
         "nohoist": [
             "**/webpack",
-            "**/webpack/**"
+            "**/webpack/**",
+            "**/react",
+            "**/react-redux",
+            "**/@reduxjs/toolkit"
         ]
     },
     "version": "0.0.0"

--- a/packages/sdk-core/tsconfig.module.json
+++ b/packages/sdk-core/tsconfig.module.json
@@ -6,7 +6,8 @@
         "module": "esnext",
         "declaration": true,
         "declarationMap": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "lib": ["DOM", "ESNext"]
     },
     "exclude": [
         "node_modules/**"


### PR DESCRIPTION
I'm not exactly sure what this error is about: https://github.com/superfluid-finance/protocol-monorepo/actions/runs/3469242783/jobs/5795997631

It seems that Browserify tries to bundle everything from the root `node_modules`, even if it's not specified in SDK-core's `package.json`.

As a simple fix (hopefully), let's just not hoist React/Redux packages that only SDK-redux uses anyways.

EDIT: Turns out, setting "DOM" lib for ESModule build fixes the issue. This doesn't actually change the output, it just gives TypeScript the expectation that when using ESModule then DOM API-s are present. I'm not sure if it's ideal but it can't be too bad.