### PR TITLE
[SDK-redux] `skipLibCheck=true` again

### DIFF
--- a/packages/sdk-redux/tsconfig.json
+++ b/packages/sdk-redux/tsconfig.json
@@ -15,7 +15,7 @@
         "esModuleInterop": true,
         /* Include modules imported with .json extension. */
         "resolveJsonModule": true,
-        "skipLibCheck": false,
+        "skipLibCheck": true,
         "strict": true
         /* Enable all strict type-checking options. */,
         /* Strict Type-Checking Options */


### PR DESCRIPTION
Apparently opens up a can of worms and dependency issues with the monorepo: https://github.com/superfluid-finance/protocol-monorepo/issues/1174