### PR TITLE
[SUBGRAPH] Fix resolver breaking logic

### DIFF
--- a/packages/subgraph/src/addresses.template.ts
+++ b/packages/subgraph/src/addresses.template.ts
@@ -16,6 +16,6 @@ export function getNativeAssetSuperTokenAddress(): Address {
     return Address.fromString("{{nativeAssetSuperTokenAddress}}");
 }
 
-export function getIsTestNetwork(): boolean {
+export function getIsLocalIntegrationTesting(): boolean {
     return "{{testNetwork}}".length > 0;
 }

--- a/packages/subgraph/src/addresses.template.ts
+++ b/packages/subgraph/src/addresses.template.ts
@@ -15,3 +15,7 @@ export function getResolverAddress(): Address {
 export function getNativeAssetSuperTokenAddress(): Address {
     return Address.fromString("{{nativeAssetSuperTokenAddress}}");
 }
+
+export function getIsTestNetwork(): boolean {
+    return "{{testNetwork}}".length > 0;
+}

--- a/packages/subgraph/src/utils.ts
+++ b/packages/subgraph/src/utils.ts
@@ -7,7 +7,7 @@ import {
     Token,
     TokenStatistic,
 } from "../generated/schema";
-import { getResolverAddress } from "./addresses";
+import { getIsTestNetwork } from "./addresses";
 
 /**************************************************************************
  * Constants
@@ -111,8 +111,8 @@ export function getIsListedToken(
     resolverAddress: Address
 ): Token {
     const resolverContract = Resolver.bind(resolverAddress);
-    const RESOLVER_ADDRESS = getResolverAddress();
-    const version = resolverAddress.equals(RESOLVER_ADDRESS) ? "test" : "v1";
+    const isLocalIntegrationTesting = getIsTestNetwork();
+    const version = isLocalIntegrationTesting ? "test" : "v1";
     const result = resolverContract.try_get(
         "supertokens." + version + "." + token.symbol
     );

--- a/packages/subgraph/src/utils.ts
+++ b/packages/subgraph/src/utils.ts
@@ -7,7 +7,7 @@ import {
     Token,
     TokenStatistic,
 } from "../generated/schema";
-import { getIsTestNetwork } from "./addresses";
+import { getIsLocalIntegrationTesting } from "./addresses";
 
 /**************************************************************************
  * Constants
@@ -111,7 +111,7 @@ export function getIsListedToken(
     resolverAddress: Address
 ): Token {
     const resolverContract = Resolver.bind(resolverAddress);
-    const isLocalIntegrationTesting = getIsTestNetwork();
+    const isLocalIntegrationTesting = getIsLocalIntegrationTesting();
     const version = isLocalIntegrationTesting ? "test" : "v1";
     const result = resolverContract.try_get(
         "supertokens." + version + "." + token.symbol

--- a/packages/subgraph/tests/mockedFunctions.ts
+++ b/packages/subgraph/tests/mockedFunctions.ts
@@ -52,7 +52,7 @@ export function mockedHandleSuperTokenInitRPCCalls(
     // getIsListedToken(token, resolver) => resolver.try_get(key)
     mockedResolverGet(
         resolverAddress,
-        "supertokens.test." + tokenSymbol,
+        "supertokens.v1." + tokenSymbol,
         isListed ? superToken : ZERO_ADDRESS.toHexString()
     );
 


### PR DESCRIPTION
Issue: After a deployment to all endpoint today, we started receiving a lot of errors. This was due to none of the tokens being listed.

The initial thought was that some logic changes in the recent PR with matchstick broke it, but in fact it was an earlier [PR](https://github.com/superfluid-finance/protocol-monorepo/commit/810e42362259ba6bd242a09857c154d280617469) which broke this.

`let version = resolverAddress.equals(RESOLVER_ADDRESS) ? "test" : "v1";` this will always equal to "test" which led to all tokens being considered not listed: it would return 0 address when trying to do a `.get` on "supertokens.test.USDCx" for example.