### PR TITLE
[SUBGRAPH] Add `deposit` field to `AgreementLiquidatedByEvent`/`AgreementLiquidatedV2Event`

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -1518,8 +1518,9 @@ type StreamRevision @entity {
 
     """
     The "most recently alive" stream between a sender and receiver.
+    Note: The `revisionIndex` property may not be the same as the `revisionIndex` of `mostRecentStream`. Which means `mostRecentStream` has been closed and no new stream has been opened.
     """
-    stream: Stream!
+    mostRecentStream: Stream!
 }
 
 """

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -969,6 +969,11 @@ type AgreementLiquidatedByEvent implements Event @entity {
     bondAccount: Bytes!
     rewardAmount: BigInt!
     bailoutAmount: BigInt!
+
+    """
+    The full deposit amount of the stream that was liquidated.
+    """
+    deposit: BigInt!
 }
 
 type AgreementLiquidatedV2Event implements Event @entity {
@@ -1000,6 +1005,11 @@ type AgreementLiquidatedV2Event implements Event @entity {
     targetAccountBalanceDelta: BigInt!
     version: BigInt!
     liquidationType: Int!
+
+    """
+    The full deposit amount of the stream that was liquidated.
+    """
+    deposit: BigInt!
 
     """
     TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead
@@ -1499,9 +1509,17 @@ type StreamPeriod @entity {
 #  Helper Entities #
 ####################
 type StreamRevision @entity {
+    """
+    ID composed of: keccak256(abi.encode(sender,receiver))-tokenAddress
+    """
     id: ID!
     revisionIndex: Int!
     periodRevisionIndex: Int!
+
+    """
+    The "most recent" deposit of a stream between a sender and receiver.
+    """
+    deposit: BigInt!
 }
 
 """

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -1517,9 +1517,9 @@ type StreamRevision @entity {
     periodRevisionIndex: Int!
 
     """
-    The "most recent" deposit of a stream between a sender and receiver.
+    The "most recently alive" stream between a sender and receiver.
     """
-    deposit: BigInt!
+    stream: Stream!
 }
 
 """

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -201,6 +201,7 @@ export function getOrInitStreamRevision(
         streamRevision = new StreamRevision(streamRevisionId);
         streamRevision.revisionIndex = 0;
         streamRevision.periodRevisionIndex = 0;
+        streamRevision.deposit = BIG_INT_ZERO;
     }
     return streamRevision as StreamRevision;
 }

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -229,7 +229,7 @@ export function getOrInitStream(event: FlowUpdated): Stream {
     );
 
     // set stream id
-    streamRevision.stream = id;
+    streamRevision.mostRecentStream = id;
     streamRevision.save();
 
     let stream = Stream.load(id);

--- a/packages/subgraph/src/mappings/cfav1.ts
+++ b/packages/subgraph/src/mappings/cfav1.ts
@@ -92,18 +92,23 @@ export function handleFlowUpdated(event: FlowUpdated): void {
     stream.deposit = newDeposit;
     stream.save();
 
+    const streamRevision = getOrInitStreamRevision(
+        senderAddress,
+        receiverAddress,
+        tokenAddress
+    );
+
     const flowRateDelta = flowRate.minus(oldFlowRate);
     const isCreate = oldFlowRate.equals(BIG_INT_ZERO);
     const isDelete = flowRate.equals(BIG_INT_ZERO);
+
+    streamRevision.deposit = newDeposit;
+
     if (isDelete) {
-        const streamRevision = getOrInitStreamRevision(
-            senderAddress,
-            receiverAddress,
-            tokenAddress
-        );
         streamRevision.revisionIndex = streamRevision.revisionIndex + 1;
-        streamRevision.save();
     }
+
+    streamRevision.save();
 
     // create event entity
     const flowUpdateEvent = _createFlowUpdatedEntity(

--- a/packages/subgraph/src/mappings/cfav1.ts
+++ b/packages/subgraph/src/mappings/cfav1.ts
@@ -92,23 +92,20 @@ export function handleFlowUpdated(event: FlowUpdated): void {
     stream.deposit = newDeposit;
     stream.save();
 
-    const streamRevision = getOrInitStreamRevision(
-        senderAddress,
-        receiverAddress,
-        tokenAddress
-    );
-
     const flowRateDelta = flowRate.minus(oldFlowRate);
     const isCreate = oldFlowRate.equals(BIG_INT_ZERO);
     const isDelete = flowRate.equals(BIG_INT_ZERO);
 
-    streamRevision.deposit = newDeposit;
-
     if (isDelete) {
+        const streamRevision = getOrInitStreamRevision(
+            senderAddress,
+            receiverAddress,
+            tokenAddress
+        );
         streamRevision.revisionIndex = streamRevision.revisionIndex + 1;
-    }
 
-    streamRevision.save();
+        streamRevision.save();
+    }
 
     // create event entity
     const flowUpdateEvent = _createFlowUpdatedEntity(

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -300,7 +300,7 @@ function _createAgreementLiquidatedByEventEntity(
     const streamRevisionId =
         event.params.id.toHex() + "-" + event.address.toHexString();
     const streamRevision = StreamRevision.load(streamRevisionId);
-    const stream = streamRevision ? Stream.load(streamRevision.stream) : null;
+    const stream = streamRevision ? Stream.load(streamRevision.mostRecentStream) : null;
 
     ev.token = event.address;
     ev.liquidatorAccount = event.params.liquidatorAccount;
@@ -329,7 +329,7 @@ function _createAgreementLiquidatedV2EventEntity(
     const streamRevisionId =
         event.params.id.toHex() + "-" + event.address.toHexString();
     const streamRevision = StreamRevision.load(streamRevisionId);
-    const stream = streamRevision ? Stream.load(streamRevision.stream) : null;
+    const stream = streamRevision ? Stream.load(streamRevision.mostRecentStream) : null;
 
     ev.token = event.address;
     ev.liquidatorAccount = event.params.liquidatorAccount;

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -14,11 +14,13 @@ import {
     BurnedEvent,
     MintedEvent,
     SentEvent,
+    StreamRevision,
     TokenDowngradedEvent,
     TokenUpgradedEvent,
     TransferEvent,
 } from "../../generated/schema";
 import {
+    BIG_INT_ZERO,
     createEventID,
     initializeEventEntity,
     tokenHasValidHost,
@@ -294,6 +296,10 @@ function _createAgreementLiquidatedByEventEntity(
         event.params.bondAccount,
     ]) as AgreementLiquidatedByEvent;
 
+    const streamRevisionId =
+        event.params.id.toHex() + "-" + event.address.toHexString();
+    const streamRevision = StreamRevision.load(streamRevisionId);
+
     ev.token = event.address;
     ev.liquidatorAccount = event.params.liquidatorAccount;
     ev.agreementClass = event.params.agreementClass;
@@ -302,6 +308,7 @@ function _createAgreementLiquidatedByEventEntity(
     ev.bondAccount = event.params.bondAccount;
     ev.rewardAmount = event.params.rewardAmount;
     ev.bailoutAmount = event.params.bailoutAmount;
+    ev.deposit = streamRevision ? streamRevision.deposit : BIG_INT_ZERO;
     ev.save();
 }
 
@@ -317,6 +324,10 @@ function _createAgreementLiquidatedV2EventEntity(
         event.params.rewardAmountReceiver,
     ]);
 
+    const streamRevisionId =
+        event.params.id.toHex() + "-" + event.address.toHexString();
+    const streamRevision = StreamRevision.load(streamRevisionId);
+
     ev.token = event.address;
     ev.liquidatorAccount = event.params.liquidatorAccount;
     ev.agreementClass = event.params.agreementClass;
@@ -326,6 +337,7 @@ function _createAgreementLiquidatedV2EventEntity(
     ev.rewardAccount = event.params.rewardAmountReceiver;
     ev.rewardAmount = event.params.rewardAmount;
     ev.targetAccountBalanceDelta = event.params.targetAccountBalanceDelta;
+    ev.deposit = streamRevision ? streamRevision.deposit : BIG_INT_ZERO;
 
     let decoded = ethereum.decode(
         "(uint256,uint256)",

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -14,6 +14,7 @@ import {
     BurnedEvent,
     MintedEvent,
     SentEvent,
+    Stream,
     StreamRevision,
     TokenDowngradedEvent,
     TokenUpgradedEvent,
@@ -299,6 +300,7 @@ function _createAgreementLiquidatedByEventEntity(
     const streamRevisionId =
         event.params.id.toHex() + "-" + event.address.toHexString();
     const streamRevision = StreamRevision.load(streamRevisionId);
+    const stream = streamRevision ? Stream.load(streamRevision.stream) : null;
 
     ev.token = event.address;
     ev.liquidatorAccount = event.params.liquidatorAccount;
@@ -308,7 +310,7 @@ function _createAgreementLiquidatedByEventEntity(
     ev.bondAccount = event.params.bondAccount;
     ev.rewardAmount = event.params.rewardAmount;
     ev.bailoutAmount = event.params.bailoutAmount;
-    ev.deposit = streamRevision ? streamRevision.deposit : BIG_INT_ZERO;
+    ev.deposit = stream ? stream.deposit : BIG_INT_ZERO;
     ev.save();
 }
 
@@ -327,6 +329,7 @@ function _createAgreementLiquidatedV2EventEntity(
     const streamRevisionId =
         event.params.id.toHex() + "-" + event.address.toHexString();
     const streamRevision = StreamRevision.load(streamRevisionId);
+    const stream = streamRevision ? Stream.load(streamRevision.stream) : null;
 
     ev.token = event.address;
     ev.liquidatorAccount = event.params.liquidatorAccount;
@@ -337,7 +340,7 @@ function _createAgreementLiquidatedV2EventEntity(
     ev.rewardAccount = event.params.rewardAmountReceiver;
     ev.rewardAmount = event.params.rewardAmount;
     ev.targetAccountBalanceDelta = event.params.targetAccountBalanceDelta;
-    ev.deposit = streamRevision ? streamRevision.deposit : BIG_INT_ZERO;
+    ev.deposit = stream ? stream.deposit : BIG_INT_ZERO;
 
     let decoded = ethereum.decode(
         "(uint256,uint256)",

--- a/packages/subgraph/src/utils.ts
+++ b/packages/subgraph/src/utils.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes, Entity, ethereum, log, Value } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, crypto, Entity, ethereum, log, Value } from "@graphprotocol/graph-ts";
 import { ISuperToken as SuperToken } from "../generated/templates/SuperToken/ISuperToken";
 import { Resolver } from "../generated/ResolverV1/Resolver";
 import {
@@ -18,11 +18,24 @@ export const ZERO_ADDRESS = Address.zero();
 export const MAX_FLOW_RATE = BigInt.fromI32(2).pow(95).minus(BigInt.fromI32(1));
 export const ORDER_MULTIPLIER = BigInt.fromI32(10000);
 export const MAX_SAFE_SECONDS = BigInt.fromI64(8640000000000); //In seconds, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_ecmascript_epoch_and_timestamps
+
 /**************************************************************************
  * Convenience Conversions
  *************************************************************************/
 export function bytesToAddress(bytes: Bytes): Address {
     return Address.fromBytes(bytes);
+}
+
+/**
+ * Take an array of ethereum values and return the encoded bytes.
+ * @param values
+ * @returns the encoded bytes
+ */
+ export function encode(values: Array<ethereum.Value>): Bytes {
+    return ethereum.encode(
+        // forcefully cast Value[] -> Tuple
+        ethereum.Value.fromTuple(changetype<ethereum.Tuple>(values))
+    )!;
 }
 
 /**************************************************************************
@@ -175,10 +188,13 @@ export function getStreamRevisionID(
     receiverAddress: Address,
     tokenAddress: Address
 ): string {
+    const values: Array<ethereum.Value> = [
+        ethereum.Value.fromAddress(senderAddress),
+        ethereum.Value.fromAddress(receiverAddress),
+    ];
+    const flowId = crypto.keccak256(encode(values));
     return (
-        senderAddress.toHex() +
-        "-" +
-        receiverAddress.toHex() +
+        flowId.toHex() +
         "-" +
         tokenAddress.toHex()
     );
@@ -191,7 +207,11 @@ export function getStreamID(
     revisionIndex: number
 ): string {
     return (
-        getStreamRevisionID(senderAddress, receiverAddress, tokenAddress) +
+        senderAddress.toHex() +
+        "-" +
+        receiverAddress.toHex() +
+        "-" +
+        tokenAddress.toHex() +
         "-" +
         revisionIndex.toString()
     );

--- a/packages/subgraph/src/utils.ts
+++ b/packages/subgraph/src/utils.ts
@@ -280,10 +280,6 @@ export function getAccountTokenSnapshotID(
 
 // Get HOL Exists Functions
 
-export function streamRevisionExists(id: string): boolean {
-    return StreamRevision.load(id) != null;
-}
-
 /**
  * If your units get set to 0, you will still have a subscription
  * entity, but your subscription technically no longer exists.

--- a/packages/subgraph/tests/converters.ts
+++ b/packages/subgraph/tests/converters.ts
@@ -174,14 +174,3 @@ export function getBooleanEventParam(
     return new ethereum.EventParam(name, ethereum.Value.fromBoolean(value));
 }
 
-/**
- * Take an array of ethereum values and return the encoded bytes.
- * @param values
- * @returns the encoded bytes
- */
-export function encode(values: Array<ethereum.Value>): Bytes {
-    return ethereum.encode(
-        // forcefully cast Value[] -> Tuple
-        ethereum.Value.fromTuple(changetype<ethereum.Tuple>(values))
-    )!;
-}

--- a/packages/subgraph/tests/mockedEntities.ts
+++ b/packages/subgraph/tests/mockedEntities.ts
@@ -1,5 +1,5 @@
-import { Address, ethereum } from "@graphprotocol/graph-ts";
-import { Token } from "../generated/schema";
+import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { StreamRevision, Token } from "../generated/schema";
 import { getNativeAssetSuperTokenAddress } from "../src/addresses";
 
 /**
@@ -25,11 +25,9 @@ export function createSuperToken(
     underlyingAddress: Address
 ): Token {
     const tokenId = tokenAddress.toHex();
-    let token = Token.load(tokenId);
-
     let currentTimestamp = block.timestamp;
 
-    token = new Token(tokenId);
+    const token = new Token(tokenId);
     token.createdAtTimestamp = currentTimestamp;
     token.createdAtBlockNumber = block.number;
     token.decimals = decimals;
@@ -48,4 +46,31 @@ export function createSuperToken(
     
     token.save();
     return token as Token;
+}
+
+/**
+ * Creates a StreamRevision entity
+ * @param flowId 
+ * @param tokenAddress 
+ * @param deposit 
+ * @param revisionIndex 
+ * @param periodRevisionIndex 
+ * @returns StreamRevision
+ */
+export function createStreamRevision(
+    flowId: string,
+    tokenAddress: string,
+    deposit: BigInt,
+    revisionIndex: i32,
+    periodRevisionIndex: i32,
+): StreamRevision {
+    const id = flowId + "-" + tokenAddress;
+
+    const streamRevision = new StreamRevision(id);
+    streamRevision.deposit = deposit;
+    streamRevision.revisionIndex = revisionIndex;
+    streamRevision.periodRevisionIndex =  periodRevisionIndex;
+
+    streamRevision.save();
+    return streamRevision;
 }

--- a/packages/subgraph/tests/mockedEntities.ts
+++ b/packages/subgraph/tests/mockedEntities.ts
@@ -1,6 +1,7 @@
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
-import { StreamRevision, Token } from "../generated/schema";
+import { Stream, StreamRevision, Token } from "../generated/schema";
 import { getNativeAssetSuperTokenAddress } from "../src/addresses";
+import { getStreamID } from "../src/utils";
 
 /**
  * Creates a SuperToken entity
@@ -49,10 +50,57 @@ export function createSuperToken(
 }
 
 /**
+ * Creates a Stream entity
+ * Note: this function currently assumes the createdAt/updatedAt is the same.
+ * @param senderAddress 
+ * @param receiverAddress 
+ * @param tokenAddress 
+ * @param revisionIndex 
+ * @param block
+ * @param currentFlowRate 
+ * @param deposit 
+ * @param streamedUntilUpdatedAt 
+ * @returns 
+ */
+export function createStream(
+    senderAddress: Address,
+    receiverAddress: Address,
+    tokenAddress: Address,
+    revisionIndex: i32,
+    block: ethereum.Block,
+    currentFlowRate: BigInt,
+    deposit: BigInt,
+    streamedUntilUpdatedAt: BigInt
+): Stream {
+    const streamId = getStreamID(
+        senderAddress,
+        receiverAddress,
+        tokenAddress,
+        revisionIndex
+    );
+    const timestamp = block.timestamp;
+    const blockNumber = block.number;
+
+    const stream = new Stream(streamId);
+    stream.createdAtTimestamp = timestamp;
+    stream.createdAtBlockNumber = blockNumber;
+    stream.updatedAtTimestamp = timestamp;
+    stream.updatedAtBlockNumber = blockNumber;
+    stream.currentFlowRate = currentFlowRate;
+    stream.deposit = deposit;
+    stream.streamedUntilUpdatedAt = streamedUntilUpdatedAt;
+    stream.token = tokenAddress.toHex();
+    stream.sender = senderAddress.toHex();
+    stream.receiver = receiverAddress.toHex();
+    stream.save();
+    return stream;
+}
+
+/**
  * Creates a StreamRevision entity
  * @param flowId 
  * @param tokenAddress 
- * @param deposit 
+ * @param streamId 
  * @param revisionIndex 
  * @param periodRevisionIndex 
  * @returns StreamRevision
@@ -60,14 +108,14 @@ export function createSuperToken(
 export function createStreamRevision(
     flowId: string,
     tokenAddress: string,
-    deposit: BigInt,
+    streamId: string,
     revisionIndex: i32,
     periodRevisionIndex: i32,
 ): StreamRevision {
     const id = flowId + "-" + tokenAddress;
 
     const streamRevision = new StreamRevision(id);
-    streamRevision.deposit = deposit;
+    streamRevision.stream = streamId;
     streamRevision.revisionIndex = revisionIndex;
     streamRevision.periodRevisionIndex =  periodRevisionIndex;
 

--- a/packages/subgraph/tests/mockedEntities.ts
+++ b/packages/subgraph/tests/mockedEntities.ts
@@ -115,7 +115,7 @@ export function createStreamRevision(
     const id = flowId + "-" + tokenAddress;
 
     const streamRevision = new StreamRevision(id);
-    streamRevision.stream = streamId;
+    streamRevision.mostRecentStream = streamId;
     streamRevision.revisionIndex = revisionIndex;
     streamRevision.periodRevisionIndex =  periodRevisionIndex;
 

--- a/packages/subgraph/tests/superToken/event/superToken.event.test.ts
+++ b/packages/subgraph/tests/superToken/event/superToken.event.test.ts
@@ -1,4 +1,4 @@
-import { BigInt, Bytes, crypto, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, crypto, ethereum } from "@graphprotocol/graph-ts";
 import {
     assert,
     beforeEach,
@@ -23,7 +23,7 @@ import {
 } from "../../assertionHelpers";
 import { alice, bob, cfaV1Address, charlie, DEFAULT_DECIMALS, delta, FAKE_INITIAL_BALANCE, maticXName, maticXSymbol } from "../../constants";
 import { getETHAddress, getETHUnsignedBigInt, stringToBytes } from "../../converters";
-import { createStreamRevision } from "../../mockedEntities";
+import { createStream, createStreamRevision } from "../../mockedEntities";
 import { mockedGetAppManifest, mockedGetHost, mockedHandleSuperTokenInitRPCCalls, mockedRealtimeBalanceOf } from "../../mockedFunctions";
 import {
     createAgreementLiquidatedByEvent,
@@ -55,6 +55,7 @@ describe("SuperToken Mapper Unit Tests", () => {
             ];
             const agreementId = crypto.keccak256(encode(values)); // flowId keccak256(abi.encode(sender, receiver))
             const rewardAmount = BigInt.fromI32(100);
+            const revisionIndex = 0;
             const bailoutAmount = BIG_INT_ZERO;
             const deposit = BigInt.fromI32(420);
 
@@ -70,12 +71,23 @@ describe("SuperToken Mapper Unit Tests", () => {
 
             const tokenAddress = agreementLiquidatedByEvent.address.toHex();
 
+            const stream = createStream(
+                Address.fromString(penaltyAccount),
+                Address.fromString(receiver),
+                agreementLiquidatedByEvent.address,
+                revisionIndex,
+                agreementLiquidatedByEvent.block,
+                BigInt.fromI32(42069),
+                deposit,
+                BIG_INT_ZERO
+            );
+
             createStreamRevision(
                 agreementLiquidatedByEvent.params.id.toHex(),
                 tokenAddress,
-                deposit,
-                0,
-                0
+                stream.id,
+                revisionIndex,
+                0 // periodRevisionIndex
             );
 
             mockedGetHost(tokenAddress);
@@ -156,6 +168,7 @@ describe("SuperToken Mapper Unit Tests", () => {
             const agreementId = encode(agreementIdValues);
             const liquidationTypeData = encode(liquidationTypeDataValues);
             const rewardAmount = BigInt.fromI32(100);
+            const revisionIndex = 0;
             const targetAccountBalanceDelta = rewardAmount.neg();
             const deposit = BigInt.fromI32(420);
 
@@ -169,15 +182,24 @@ describe("SuperToken Mapper Unit Tests", () => {
                 targetAccountBalanceDelta,
                 liquidationTypeData
             );
-
+            const stream = createStream(
+                Address.fromString(targetAccount),
+                Address.fromString(receiver),
+                agreementLiquidatedV2Event.address,
+                revisionIndex,
+                agreementLiquidatedV2Event.block,
+                BigInt.fromI32(42069),
+                deposit,
+                BIG_INT_ZERO
+            );
             const tokenAddress = agreementLiquidatedV2Event.address.toHex();
 
             createStreamRevision(
                 agreementLiquidatedV2Event.params.id.toHex(),
                 tokenAddress,
-                deposit,
-                0,
-                0
+                stream.id,
+                revisionIndex,
+                0 // periodRevisionIndex
             );
 
             mockedGetHost(tokenAddress);


### PR DESCRIPTION
This PR adds the full deposit amount of the stream being liquidated to the liquidation event.

## Changes summary
- `deposit` property added to liquidation events
- `stream` property added to `StreamRevision` entity
- It includes unit tests with mocked variables
- `id` field on `StreamRevision` entity changing `from sender-receiver-token` to `keccak256(abi.encode(sender,receiver))`
    > NOTE: this is **UNLIKELY** to be a breaking change as it is an entity that should be solely used for internal logic, but I will confirm with @kasparkallas before moving on with the deployment