### PR TITLE
[SUBGRAPH] `flowRateAtLiquidation` field for [DATA]

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -974,6 +974,11 @@ type AgreementLiquidatedByEvent implements Event @entity {
     The full deposit amount of the stream that was liquidated.
     """
     deposit: BigInt!
+
+    """
+    The flow rate of the stream at the time of liquidation.
+    """
+    flowRateAtLiquidation: BigInt!
 }
 
 type AgreementLiquidatedV2Event implements Event @entity {
@@ -1010,6 +1015,11 @@ type AgreementLiquidatedV2Event implements Event @entity {
     The full deposit amount of the stream that was liquidated.
     """
     deposit: BigInt!
+
+    """
+    The flow rate of the stream at the time of liquidation.
+    """
+    flowRateAtLiquidation: BigInt!
 
     """
     TO BE DEPRECATED in v2 endpoint - use rewardAmountReceiver instead

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -311,6 +311,7 @@ function _createAgreementLiquidatedByEventEntity(
     ev.rewardAmount = event.params.rewardAmount;
     ev.bailoutAmount = event.params.bailoutAmount;
     ev.deposit = stream ? stream.deposit : BIG_INT_ZERO;
+    ev.flowRateAtLiquidation = stream ? stream.currentFlowRate : BIG_INT_ZERO;
     ev.save();
 }
 
@@ -341,6 +342,7 @@ function _createAgreementLiquidatedV2EventEntity(
     ev.rewardAmount = event.params.rewardAmount;
     ev.targetAccountBalanceDelta = event.params.targetAccountBalanceDelta;
     ev.deposit = stream ? stream.deposit : BIG_INT_ZERO;
+    ev.flowRateAtLiquidation = stream ? stream.currentFlowRate : BIG_INT_ZERO;
 
     let decoded = ethereum.decode(
         "(uint256,uint256)",

--- a/packages/subgraph/tests/superToken/event/superToken.event.test.ts
+++ b/packages/subgraph/tests/superToken/event/superToken.event.test.ts
@@ -55,6 +55,7 @@ describe("SuperToken Mapper Unit Tests", () => {
             ];
             const agreementId = crypto.keccak256(encode(values)); // flowId keccak256(abi.encode(sender, receiver))
             const rewardAmount = BigInt.fromI32(100);
+            const currentFlowRate = BigInt.fromI32(42069);
             const revisionIndex = 0;
             const bailoutAmount = BIG_INT_ZERO;
             const deposit = BigInt.fromI32(420);
@@ -77,7 +78,7 @@ describe("SuperToken Mapper Unit Tests", () => {
                 agreementLiquidatedByEvent.address,
                 revisionIndex,
                 agreementLiquidatedByEvent.block,
-                BigInt.fromI32(42069),
+                currentFlowRate,
                 deposit,
                 BIG_INT_ZERO
             );
@@ -147,6 +148,7 @@ describe("SuperToken Mapper Unit Tests", () => {
             assert.fieldEquals(entityName, id, "rewardAmount", rewardAmount.toString());
             assert.fieldEquals(entityName, id, "bailoutAmount", bailoutAmount.toString());
             assert.fieldEquals(entityName, id, "deposit", deposit.toString());
+            assert.fieldEquals(entityName, id, "flowRateAtLiquidation", currentFlowRate.toString());
         });
 
         test("handleAgreementLiquidatedV2() - Should create a new AgreementLiquidatedV2Event entity", () => {
@@ -170,6 +172,7 @@ describe("SuperToken Mapper Unit Tests", () => {
             const rewardAmount = BigInt.fromI32(100);
             const revisionIndex = 0;
             const targetAccountBalanceDelta = rewardAmount.neg();
+            const currentFlowRate = BigInt.fromI32(42069);
             const deposit = BigInt.fromI32(420);
 
             const agreementLiquidatedV2Event = createAgreementLiquidatedV2Event(
@@ -188,7 +191,7 @@ describe("SuperToken Mapper Unit Tests", () => {
                 agreementLiquidatedV2Event.address,
                 revisionIndex,
                 agreementLiquidatedV2Event.block,
-                BigInt.fromI32(42069),
+                currentFlowRate,
                 deposit,
                 BIG_INT_ZERO
             );
@@ -261,6 +264,7 @@ describe("SuperToken Mapper Unit Tests", () => {
             assert.fieldEquals(entityName, id, "version", version.toString());
             assert.fieldEquals(entityName, id, "liquidationType", liquidationType.toString());
             assert.fieldEquals(entityName, id, "deposit", deposit.toString());
+            assert.fieldEquals(entityName, id, "flowRateAtLiquidation", currentFlowRate.toString());
         });
 
         test("handleTokenUpgraded() - Should create a new TokenUpgradedEvent entity", () => {


### PR DESCRIPTION
@leopk-code requested a field to be added to the `AgreementLiqudatedBy` events to finish up the solvency dashboard. This field was added to calculate the deposit duration (we cannot assume it is 4h).