### PR TITLE
[CI/SUBGRAPH] Auto deploy subgraph

### DIFF
--- a/.github/workflows/call.deploy-subgraph.yml
+++ b/.github/workflows/call.deploy-subgraph.yml
@@ -1,0 +1,75 @@
+name: Reusable Workflow | Deploy Subgraph
+
+on:
+  workflow_call:
+    inputs:
+      release_branch:
+        required: true
+        type: string
+      deploy_to_satsuma_endpoint:
+        required: true
+        type: boolean
+      network:
+        required: true
+        type: string
+      satsuma_version_label:
+        required: false
+        type: string
+
+jobs:
+  deploy-subgraph:
+    name: Deploy Subgraph
+
+    runs-on: ubuntu-latest
+
+    env:
+      subgraph-working-directory: ./packages/subgraph
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Install node"
+        uses: "actions/setup-node@v3"
+        with:
+          node-version: "16"
+          cache: "yarn"
+
+      - name: "Install dependencies"
+        run: yarn install --frozen-lockfile
+
+      - name: "Build contracts"
+        run: yarn build
+        working-directory: ./packages/ethereum-contracts
+
+      - name: "Get ABI"
+        run: node scripts/getAbi.js
+        working-directory: ${{ env.subgraph-working-directory }}
+
+      - name: "Generate subgraph manifest"
+        run: "yarn prepare-manifest-local" # NOTE: A hack to make codegen work
+        working-directory: ${{ env.subgraph-working-directory }}
+
+      - name: "Generate meta.ignore.ts file"
+        run: "yarn generate-sf-meta"
+        working-directory: ${{ env.subgraph-working-directory }}
+        env:
+          COMMIT_HASH: ${{ github.sha }}
+          CONFIGURATION: ${{ inputs.release_branch }}
+
+      - name: "Generate AssemblyScript types"
+        run: "yarn codegen"
+        working-directory: ${{ env.subgraph-working-directory }}
+
+      - name: "Deploy to Satsuma endpoint"
+        if: inputs.deploy_to_satsuma_endpoint == true
+        run: "yarn deploy:to-satsuma ${{ inputs.satsuma_version_label }} ${{ inputs.network }}"
+        working-directory: ${{ env.subgraph-working-directory }}
+        env:
+          SATSUMA_DEPLOY_KEY: ${{ secrets.SATSUMA_DEPLOY_KEY }}
+
+      - name: "Deploy to Hosted Subgraph Superfluid endpoint"
+        if: inputs.deploy_to_satsuma_endpoint == false
+        run: "yarn deploy ${{ inputs.release_branch }} ${{ inputs.network }}"
+        working-directory: ${{ env.subgraph-working-directory }}
+        env:
+          THE_GRAPH_ACCESS_TOKEN: ${{ secrets.THE_GRAPH_ACCESS_TOKEN }}

--- a/.github/workflows/call.deploy-subgraph.yml
+++ b/.github/workflows/call.deploy-subgraph.yml
@@ -46,7 +46,7 @@ jobs:
         working-directory: ${{ env.subgraph-working-directory }}
 
       - name: "Generate subgraph manifest"
-        run: "yarn prepare-manifest-local" # NOTE: A hack to make codegen work
+        run: "yarn prepare-manifest-local"
         working-directory: ${{ env.subgraph-working-directory }}
 
       - name: "Generate meta.ignore.ts file"

--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -86,6 +86,8 @@ jobs:
     with: 
       release_branch: dev
       deploy_to_satsuma_endpoint: false
+      # empty network deploys to all networks
+      network: "" 
 
   test-spec-haskell:
     uses: ./.github/workflows/call.test-spec-haskell.yml

--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -77,6 +77,16 @@ jobs:
     with:
       subgraph-release: dev
 
+  # deploy subgraph if changes are made, we can call this every time, but we won't actually do any deployments
+  # if the IPFS hash generated stays the same (no mapping logic changes)
+  deploy-subgraph-changes:
+    uses: ./.github/workflows/call.deploy-subgraph.yml
+    name: "Deploy Subgraph to all dev endpoints"
+    needs: [test-subgraph, test-subgraph-on-previous-sdk-core-versions, test-query-schema-against-deployed-dev-subgraphs]
+    with: 
+      release_branch: dev
+      deploy_to_satsuma_endpoint: false
+
   test-spec-haskell:
     uses: ./.github/workflows/call.test-spec-haskell.yml
     name: Build and Test Spec Haskell (Canary Branch)

--- a/.github/workflows/handler.deploy-subgraph.yml
+++ b/.github/workflows/handler.deploy-subgraph.yml
@@ -25,59 +25,10 @@ on:
 
 jobs:
   deploy-subgraph:
+    uses: ./.github/workflows/call.deploy-subgraph.yml
     name: Deploy Subgraph
-
-    runs-on: ubuntu-latest
-
-    env:
-      subgraph-working-directory: ./packages/subgraph
-      contracts-working-directory: ./packages/ethereum-contracts
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: "Install node"
-        uses: "actions/setup-node@v3"
-        with:
-          node-version: "16"
-          cache: "yarn"
-
-      - name: "Install dependencies"
-        run: yarn install --frozen-lockfile
-
-      - name: "Build contracts"
-        run: yarn build
-        working-directory: ${{ env.contracts-working-directory }}
-
-      - name: "Get ABI"
-        run: node scripts/getAbi.js
-        working-directory: ${{ env.subgraph-working-directory }}
-
-      - name: "Generate subgraph manifest"
-        run: "yarn prepare-manifest-local" # NOTE: A hack to make codegen work
-        working-directory: ${{ env.subgraph-working-directory }}
-
-      - name: "Generate meta.ignore.ts file"
-        run: "yarn generate-sf-meta"
-        working-directory: ${{ env.subgraph-working-directory }}
-        env:
-          COMMIT_HASH: ${{ github.sha }}
-          CONFIGURATION: ${{ github.event.inputs.release_branch }}
-
-      - name: "Generate AssemblyScript types"
-        run: "yarn codegen"
-        working-directory: ${{ env.subgraph-working-directory }}
-
-      - name: "Deploy to Satsuma endpoint"
-        if: inputs.deploy_to_satsuma_endpoint == true
-        run: "yarn deploy:to-satsuma ${{ github.event.inputs.satsuma_version_label }} ${{ github.event.inputs.network }}"
-        working-directory: ${{ env.subgraph-working-directory }}
-        env:
-          SATSUMA_DEPLOY_KEY: ${{ secrets.SATSUMA_DEPLOY_KEY }}
-
-      - name: "Deploy to Hosted Subgraph Superfluid endpoint"
-        if: inputs.deploy_to_satsuma_endpoint == false
-        run: "yarn deploy ${{ github.event.inputs.release_branch }} ${{ github.event.inputs.network }}"
-        working-directory: ${{ env.subgraph-working-directory }}
-        env:
-          THE_GRAPH_ACCESS_TOKEN: ${{ secrets.THE_GRAPH_ACCESS_TOKEN }}
+    with:
+      release_branch: ${{ github.event.inputs.release_branch }}
+      deploy_to_satsuma_endpoint: ${{ github.event.inputs.deploy_to_satsuma_endpoint }}
+      network: ${{ github.event.inputs.network }}
+      satsuma_version_label: ${{ github.event.inputs.satsuma_version_label }}


### PR DESCRIPTION
- add subgraph deployment to canary CI
  - This is triggered **EVERY** time, but actually deployment only occurs if changes are made to the mapping logic.
- create reusable workflow for deploying subgraph
- use reusable workflow in ci.canary and handler.deploy-subgraph