### PR TITLE
[SUBGRAPH] fix subgraph function handler naming

### DIFF
--- a/packages/subgraph/src/mappings/toga.ts
+++ b/packages/subgraph/src/mappings/toga.ts
@@ -10,7 +10,7 @@ import {
 } from "../../generated/schema";
 import { createEventID, initializeEventEntity } from "../utils";
 
-export function handleNewPICEvent(event: NewPIC): void {
+export function handleNewPIC(event: NewPIC): void {
     const eventId = createEventID("NewPIC", event);
     const ev = new NewPICEvent(eventId);
     initializeEventEntity(ev, event, [event.params.token, event.params.pic]);
@@ -23,7 +23,7 @@ export function handleNewPICEvent(event: NewPIC): void {
     ev.save();
 }
 
-export function handleExitRateChangedEvent(event: ExitRateChanged): void {
+export function handleExitRateChanged(event: ExitRateChanged): void {
     const eventId = createEventID("ExitRateChanged", event);
     const ev = new ExitRateChangedEvent(eventId);
     initializeEventEntity(ev, event, [event.params.token]);
@@ -34,7 +34,7 @@ export function handleExitRateChangedEvent(event: ExitRateChanged): void {
     ev.save();
 }
 
-export function handleBondIncreasedEvent(event: BondIncreased): void {
+export function handleBondIncreased(event: BondIncreased): void {
     const eventId = createEventID("BondIncreased", event);
     const ev = new BondIncreasedEvent(eventId);
     initializeEventEntity(ev, event, [event.params.token]);

--- a/packages/subgraph/tests/toga/event/toga.event.test.ts
+++ b/packages/subgraph/tests/toga/event/toga.event.test.ts
@@ -1,6 +1,6 @@
 import { BigInt } from "@graphprotocol/graph-ts";
 import { assert, beforeEach, clearStore, describe, test } from "matchstick-as";
-import { handleBondIncreasedEvent, handleExitRateChangedEvent, handleNewPICEvent } from "../../../src/mappings/toga";
+import { handleBondIncreased, handleExitRateChanged, handleNewPIC } from "../../../src/mappings/toga";
 import { assertEventBaseProperties } from "../../assertionHelpers";
 import { alice, maticXAddress } from "../../constants";
 import {
@@ -21,10 +21,10 @@ describe("TOGA Event Entity Unit Tests", () => {
         clearStore();
     });
 
-    test("handleNewPICEvent() - Should create a new NewPICEvent entity", () => {
+    test("handleNewPIC() - Should create a new NewPICEvent entity", () => {
         const newPICEvent = createNewPICEvent(token, pic, bond, exitRate);
 
-        handleNewPICEvent(newPICEvent);
+        handleNewPIC(newPICEvent);
 
         const id = assertEventBaseProperties(newPICEvent, "NewPIC");
         assert.fieldEquals("NewPICEvent", id, "token", token);
@@ -33,20 +33,20 @@ describe("TOGA Event Entity Unit Tests", () => {
         assert.fieldEquals("NewPICEvent", id, "exitRate", exitRate.toString());
     });
 
-    test("handleExitRateChangedEvent() - Should create a new ExitRateChangedEvent entity", () => {
+    test("handleExitRateChanged() - Should create a new ExitRateChangedEvent entity", () => {
         const exitRateChangedEvent = createExitRateChangedEvent(token, exitRate);
 
-        handleExitRateChangedEvent(exitRateChangedEvent);
+        handleExitRateChanged(exitRateChangedEvent);
 
         const id = assertEventBaseProperties(exitRateChangedEvent, "ExitRateChanged");
         assert.fieldEquals("ExitRateChangedEvent", id, "token", token);
         assert.fieldEquals("ExitRateChangedEvent", id, "exitRate", exitRate.toString());
     });
 
-    test("handleBondIncreasedEvent() - Should create a new BondIncreasedEvent entity", () => {
+    test("handleBondIncreased() - Should create a new BondIncreasedEvent entity", () => {
         const bondIncreasedEvent = createBondIncreasedEvent(token, additionalBond);
         
-        handleBondIncreasedEvent(bondIncreasedEvent);
+        handleBondIncreased(bondIncreasedEvent);
 
         const id = assertEventBaseProperties(bondIncreasedEvent, "BondIncreased");
         assert.fieldEquals("BondIncreasedEvent", id, "token", token);


### PR DESCRIPTION
- yaml and handler naming inconsistency

Note to self: this PR highlighted the downside of the unit tests, it doesn't catch if the naming of the handler was wrong (doesn't exist) whereas the integration test would've caught it.