### PR TITLE
[Github Actions] Fixes

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -77,12 +77,27 @@ jobs:
     with:
       subgraph-release: dev
 
+  check:
+    name: Checking what packages need to be built
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      build_subgraph: ${{ env.BUILD_SUBGRAPH }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check changeset
+        run: tasks/check-changeset.sh ${{ github.sha }} dev
+
   # deploy subgraph if changes are made, we can call this every time, but we won't actually do any deployments
   # if the IPFS hash generated stays the same (no mapping logic changes)
   deploy-subgraph-changes:
     uses: ./.github/workflows/call.deploy-subgraph.yml
     name: "Deploy Subgraph to all dev endpoints"
-    needs: [test-subgraph, test-subgraph-on-previous-sdk-core-versions, test-query-schema-against-deployed-dev-subgraphs]
+    needs: [check, test-subgraph, test-subgraph-on-previous-sdk-core-versions, test-query-schema-against-deployed-dev-subgraphs]
+    if: needs.check.outputs.build_subgraph
     with: 
       release_branch: dev
       deploy_to_satsuma_endpoint: false

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -58,9 +58,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Check changeset
-        run: tasks/check-changeset.sh ${{ github.sha }} dev
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
- remove duplicate check-changeset in ci.feature
- add check for subgraph changes in canary for deployment
  - I was incorrect about the subgraph not deploying on each merge to dev-this deploys because the commit hash is changed and this gets placed in a file which is part of the mapping
  - Solution: use check-changeset to only deploy if the subgraph files/folders in check-changeset have changed