### PR TITLE
[SDK-CORE] 0.6.1 Release

### DIFF
--- a/packages/automation-contracts/autowrap/package.json
+++ b/packages/automation-contracts/autowrap/package.json
@@ -17,12 +17,12 @@
     "devDependencies": {
         "@nomiclabs/hardhat-etherscan": "^3.1.3",
         "@openzeppelin/contracts": "^4.8.0",
-        "@superfluid-finance/ethereum-contracts": "1.4.3",
+        "@superfluid-finance/ethereum-contracts": "1.5.0",
         "dotenv": "^16.0.3"
     },
     "dependencies": {
+        "@superfluid-finance/metadata": "git+https://github.com/superfluid-finance/metadata.git",
         "hardhat": "^2.12.4",
-        "hardhat-deploy": "^0.11.22",
-        "@superfluid-finance/metadata": "git+https://github.com/superfluid-finance/metadata.git"
+        "hardhat-deploy": "^0.11.22"
     }
 }

--- a/packages/automation-contracts/scheduler/package.json
+++ b/packages/automation-contracts/scheduler/package.json
@@ -17,12 +17,12 @@
     "devDependencies": {
         "@nomiclabs/hardhat-etherscan": "^3.1.3",
         "@openzeppelin/contracts": "^4.8.0",
-        "@superfluid-finance/ethereum-contracts": "1.4.3",
+        "@superfluid-finance/ethereum-contracts": "1.5.0",
         "dotenv": "^16.0.3"
     },
     "dependencies": {
+        "@superfluid-finance/metadata": "git+https://github.com/superfluid-finance/metadata.git",
         "hardhat": "^2.12.4",
-        "hardhat-deploy": "^0.11.22",
-        "@superfluid-finance/metadata": "git+https://github.com/superfluid-finance/metadata.git"
+        "hardhat-deploy": "^0.11.22"
     }
 }

--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the SDK-core will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2022-12-20
+
+### Changed
+- Subgraph endpoints all use hosted service endpoints by default
+
 ## [0.6.0] - 2022-12-19
 
 ### Added
@@ -261,8 +266,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - New `SuperToken` class with `SuperToken` CRUD functionality and an underlying `Token` class with basic `ERC20` functionality
   - New `BatchCall` class for creating and executing batch calls with supported `Operation's`
 
-[Unreleased]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.6.0...HEAD
-[0.5.9]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.5.9...sdk-core%40v0.6.0
+[Unreleased]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.6.1...HEAD
+[0.6.1]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.6.0...sdk-core%40v0.6.1
+[0.6.0]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.5.9...sdk-core%40v0.6.0
 [0.5.9]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.5.8...sdk-core%40v0.5.9
 [0.5.8]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.5.7...sdk-core%40v0.5.8
 [0.5.7]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.5.6...sdk-core%40v0.5.7

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-core",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "SDK Core for building with Superfluid Protocol",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/sdk-core#readme",
     "repository": {

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -52,7 +52,7 @@
     "dependencies": {
         "@graphprotocol/graph-cli": "0.37.0",
         "@graphprotocol/graph-ts": "0.29.0",
-        "@superfluid-finance/sdk-core": "0.6.0",
+        "@superfluid-finance/sdk-core": "0.6.1",
         "mustache": "^4.2.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3470,7 +3470,7 @@
 
 "@superfluid-finance/metadata@git+https://github.com/superfluid-finance/metadata.git":
   version "1.1.0"
-  resolved "git+https://github.com/superfluid-finance/metadata.git#680a8020da870e28853182de5ae7f297992ac498"
+  resolved "git+https://github.com/superfluid-finance/metadata.git#69f9e0dc756f5e55164e9a270b8c0c61c0284aae"
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
## [0.6.1] - 2022-12-20

### Changed
- Subgraph endpoints all use hosted service endpoints by default