### PR TITLE
[SDK-CORE] Remove logic which skipped testing of arb-goerli endpoints

### DIFF
--- a/packages/sdk-core/tasks/testSchemasAndQueries.sh
+++ b/packages/sdk-core/tasks/testSchemasAndQueries.sh
@@ -27,10 +27,7 @@ function testSchemaAndQueries() {
 # for sdk-core releases: test deployed subgraphs
 for i in "${NETWORKS[@]}";do
     SUBGRAPH_ENDPOINT=https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-$SUBGRAPH_RELEASE_TAG-$i
-    
-    # @note temporarily don't run tests for arbitrum-goerli because the subgraph doesn't have a URL for it yet
-    if [ "$i" != "arbitrum-goerli" ]; then
-        testSchemaAndQueries
-    fi
+
+    testSchemaAndQueries
 
 done

--- a/packages/sdk-core/test/5_subgraph.test.ts
+++ b/packages/sdk-core/test/5_subgraph.test.ts
@@ -44,10 +44,6 @@ describe("Subgraph Tests", () => {
             ) as NetworkData[];
             await Promise.all(
                 resolverDataArray.map(async (x) => {
-                    // @note this handles arbitrum-goerli not being ready
-                    if (x.subgraphAPIEndpoint.includes("arbitrum-goerli")) {
-                        return;
-                    }
                     // @note if SUBGRAPH_RELEASE_TAG is feature, we only test goerli
                     const isValidFeatureEndpoint =
                         process.env.SUBGRAPH_RELEASE_TAG === "feature" &&


### PR DESCRIPTION
- a minor refactor leftover from before the break to include arbitrum-goerli in subgraph query tests
- more specifically, we remove the logic which removed arbitrum-goerli as an endpoint to test