### PR TITLE
[ETHEREUM-CONTRACTS] add forge build to pre commit for contracts

### DIFF
--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -65,6 +65,7 @@
         "fix:eslint": "yarn lint-ts --fix",
         "lint:check-no-focused-tests": "grep -FR .only test || { echo 'No test is focused.';exit 0; } && { echo '✘ You have focused tests.'; exit 1; }",
         "pre-commit": "if [ ! -z \"$(git status -s .)\" ];then run-s pre-commit:*;else true;fi",
+        "pre-commit:build": "forge build",
         "pre-commit:lint": "yarn lint",
         "check-updates": "ncu --target minor --dep prod,dev",
         "cloc": "bash tasks/cloc.sh",


### PR DESCRIPTION
## Purpose
To ensure that compilation passes before commit is allowed. Devs no longer have to remember to build before committing, it is automated.
> Caveat: this doesn't catch things which the solidity compiler allows (doing a return statement leading to unreachable code for example).

## Context
Worst case: **20 seconds** to compile (on fresh compile).
Workflows:
- working on contracts w/ TDD (should add insignificant amount of time to pre-commit)
- working on contracts w/o TDD (will catch any compile errors if any and may take up to 20 seconds if all contracts require compilation)
- working on peripheries (may add 20 seconds on initial commit/build)