### PR TITLE
[SDK-CORE/GITHUB CI] Add celo mainnet support

### DIFF
--- a/.github/workflows/handler.verify-contracts.yml
+++ b/.github/workflows/handler.verify-contracts.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          network: [eth-goerli, polygon-mumbai, optimism-goerli, arbitrum-goerli, avalanche-fuji, polygon-mainnet, optimism-mainnet, arbitrum-one, avalanche-c, bsc-mainnet]
+          network: [eth-goerli, polygon-mumbai, optimism-goerli, arbitrum-goerli, avalanche-fuji, polygon-mainnet, optimism-mainnet, arbitrum-one, avalanche-c, bsc-mainnet, celo-mainnet]
 
     steps:
       - uses: actions/checkout@v3
@@ -59,3 +59,4 @@ jobs:
           OPTIMISTIC_API_KEY: ${{ secrets.OPTIMISTIC_API_KEY }}
           ARBISCAN_API_KEY: ${{ secrets.ARBISCAN_API_KEY }}
           BSCSCAN_API_KEY: ${{ secrets.BSCSCAN_API_KEY }}
+          CELOSCAN_API_KEY: ${{ secrets.CELOSCAN_API_KEY }}}

--- a/packages/ethereum-contracts/tasks/etherscan-verify-framework.sh
+++ b/packages/ethereum-contracts/tasks/etherscan-verify-framework.sh
@@ -30,6 +30,7 @@ case $TRUFFLE_NETWORK in
     arbitrum-one | \
     avalanche-c | \
     bsc-mainnet | \
+    celo-mainnet | \
     xdai-mainnet )
         echo "$TRUFFLE_NETWORK is mainnet"
         IS_TESTNET=

--- a/packages/ethereum-contracts/truffle-config.js
+++ b/packages/ethereum-contracts/truffle-config.js
@@ -408,6 +408,7 @@ const E = (module.exports = {
         bscscan: process.env.BSCSCAN_API_KEY,
         arbiscan: process.env.ARBISCAN_API_KEY,
         gnosisscan: process.env.GNOSISSCAN_API_KEY,
+        celoscan: process.env.CELOSCAN_API_KEY,
     },
 });
 

--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the SDK-core will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2023-01-26
+### Added
+- Support for Celo
+
 ## [0.6.1] - 2022-12-20
 
 ### Changed
@@ -266,7 +270,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - New `SuperToken` class with `SuperToken` CRUD functionality and an underlying `Token` class with basic `ERC20` functionality
   - New `BatchCall` class for creating and executing batch calls with supported `Operation's`
 
-[Unreleased]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.6.1...HEAD
+[Unreleased]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.6.2...HEAD
+[0.6.2]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.6.1...sdk-core%40v0.6.2
 [0.6.1]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.6.0...sdk-core%40v0.6.1
 [0.6.0]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.5.9...sdk-core%40v0.6.0
 [0.5.9]: https://github.com/superfluid-finance/protocol-monorepo/compare/sdk-core%40v0.5.8...sdk-core%40v0.5.9

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-core",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "SDK Core for building with Superfluid Protocol",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/sdk-core#readme",
     "repository": {

--- a/packages/subgraph/config/celo-mainnet.json
+++ b/packages/subgraph/config/celo-mainnet.json
@@ -1,0 +1,10 @@
+{
+    "network": "celo",
+    "hostStartBlock": 15870000,
+    "hostAddress": "0x4E583d9390082B65Bef884b629DFA426114CED6d",
+    "cfaAddress": "0x2844c1BBdA121E9E43105630b9C8310e5c72744b",
+    "idaAddress": "0xbCF9cfA8Da20B591790dF27DE65C1254Bf91563d",
+    "superTokenFactoryAddress": "0x0422689cc4087b6B7280e0a7e7F655200ec86Ae1",
+    "resolverV1Address": "0xeE4cD028f5fdaAdeA99f8fc38e8bA8A57c90Be53",
+    "nativeAssetSuperTokenAddress": "0xc22bea0be9872d8b7b3933cec70ece4d53a900da"
+}

--- a/packages/subgraph/networks.json
+++ b/packages/subgraph/networks.json
@@ -10,5 +10,6 @@
     "arbitrum-goerli",
     "optimism-goerli",
     "avalanche-fuji",
-    "bsc-mainnet"
+    "bsc-mainnet",
+    "celo-mainnet"
 ]

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -52,7 +52,7 @@
     "dependencies": {
         "@graphprotocol/graph-cli": "0.37.0",
         "@graphprotocol/graph-ts": "0.29.0",
-        "@superfluid-finance/sdk-core": "0.6.1",
+        "@superfluid-finance/sdk-core": "0.6.2",
         "mustache": "^4.2.0"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,8 +3469,8 @@
     stack-trace "0.0.10"
 
 "@superfluid-finance/metadata@git+https://github.com/superfluid-finance/metadata.git":
-  version "1.1.0"
-  resolved "git+https://github.com/superfluid-finance/metadata.git#69f9e0dc756f5e55164e9a270b8c0c61c0284aae"
+  version "1.1.1"
+  resolved "git+https://github.com/superfluid-finance/metadata.git#694c4d79159e5aa1f61bf258c2afcc93fed00df2"
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
## Purpose
Add support for Superfluid on Celo in our periphery products.

## Changes
- support in SDK-Core (bump metadata in yarn.lock)
- config added to subgraph
- changelog for sdk-core
- verification workflow and shell script for celo mainnet added