### PR TITLE
[WORKFLOWS] fix canary

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -62,15 +62,16 @@ jobs:
     uses: ./.github/workflows/call.test-hot-fuzz.yml
 
   test-subgraph:
-    uses: superfluid-finance/protocol-monorepo/.github/workflows/call.test-local-subgraph.yml@dev
+    uses: ./.github/workflows/call.test-local-subgraph.yml
     name: Build and Test Subgraph (Development Branch)
 
   test-sdk-core:
-    uses: superfluid-finance/protocol-monorepo/.github/workflows/call.test-sdk-core.yml@dev
+    uses: ./.github/workflows/call.test-sdk-core.yml
     name: Build and Test SDK-Core (Development Branch)
     with:
       subgraph-release: local
       subgraph-endpoint: http://localhost:8000/subgraphs/name/superfluid-test
+      run-coverage-tests: false
 
   check:
     name: Checking what packages need to be built
@@ -149,7 +150,7 @@ jobs:
             packages/ethereum-contracts/coverage/
 
   coverage-sdk-core:
-    uses: superfluid-finance/protocol-monorepo/.github/workflows/call.test-sdk-core.yml@dev
+    uses: ./.github/workflows/call.test-sdk-core.yml
     name: Build and Test SDK-Core Coverage (Canary Branch)
     with: 
       subgraph-release: local

--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -135,6 +135,9 @@ jobs:
           yarn build
           yarn workspace @superfluid-finance/ethereum-contracts test-coverage
 
+      - name: Install lcov
+        run: sudo apt-get -y install lcov
+
       - name: Clean up and merge coverage artifacts
         run: |
           # extract coverage for NFT contracts from forge coverage

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -87,13 +87,13 @@ jobs:
           # NOTE: This is currently unset and fork tests are not being run
           POLYGON_MAINNET_ARCHIVE_PROVIDER_URL: ${{ secrets.POLYGON_MAINNET_ARCHIVE_PROVIDER_URL }}
 
-  coverage-ethereum-contracts:
+  temp-coverage-ethereum-contracts:
     name: Build and test coverage of ethereum-contracts (Feature Branch)
 
     runs-on: ubuntu-latest
 
-    needs: [check]
-    if: needs.check.outputs.build_ethereum_contracts
+    # needs: [check]
+    # if: needs.check.outputs.build_ethereum_contracts
 
     steps:
       - uses: actions/checkout@v3
@@ -104,35 +104,30 @@ jobs:
           node-version: 16.x
           cache: "yarn"
 
-      - name: Install and build
-        run: |
-          yarn install --frozen-lockfile
-          yarn build
+      # - name: Install and build
+      #   run: |
+      #     yarn install --frozen-lockfile
+      #     yarn build
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+      # - name: Install Foundry
+      #   uses: foundry-rs/foundry-toolchain@v1
+      #   with:
+      #     version: nightly
 
-      - name: Run coverage test
-        run: |
-          yarn workspace @superfluid-finance/ethereum-contracts test-coverage
+      # - name: Run coverage test
+      #   run: |
+      #     yarn workspace @superfluid-finance/ethereum-contracts test-coverage
       
       - name: Install lcov
-        run: |
-          # https://github.com/actions/runner-images/issues/560
-          sudo apt install libperlio-gzip-perl libjson-perl
-          wget "https://github.com/linux-test-project/lcov/archive/master.zip"
-          unzip "master.zip"
-          cd "lcov-master"
-          sudo make install
+        run: sudo apt-get -y install lcov
 
       - name: Clean up and merge coverage artifacts
         run: |
+          lcov --help
           # extract coverage for NFT contracts from forge coverage
-          lcov -e lcov.info -o lcov.info 'packages/ethereum-contracts/contracts/superfluid/*NFT*.sol'
-          # merge hardhat and forge coverage files
-          lcov -a lcov.info -a packages/ethereum-contracts/coverage/lcov.info -o lcov.info
+          # lcov -e lcov.info -o lcov.info 'packages/ethereum-contracts/contracts/superfluid/*NFT*.sol'
+          # # merge hardhat and forge coverage files
+          # lcov -a lcov.info -a packages/ethereum-contracts/coverage/lcov.info -o lcov.info
 
   test-hot-fuzz:
     uses: ./.github/workflows/call.test-hot-fuzz.yml

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -87,7 +87,7 @@ jobs:
           # NOTE: This is currently unset and fork tests are not being run
           POLYGON_MAINNET_ARCHIVE_PROVIDER_URL: ${{ secrets.POLYGON_MAINNET_ARCHIVE_PROVIDER_URL }}
 
-  temp-coverage-ethereum-contracts:
+  coverage-ethereum-contracts:
     name: Build and test coverage of ethereum-contracts (Feature Branch)
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -117,6 +117,22 @@ jobs:
       - name: Run coverage test
         run: |
           yarn workspace @superfluid-finance/ethereum-contracts test-coverage
+      
+      - name: Install lcov
+        run: |
+          # https://github.com/actions/runner-images/issues/560
+          sudo apt install libperlio-gzip-perl libjson-perl
+          wget "https://github.com/linux-test-project/lcov/archive/master.zip"
+          unzip "master.zip"
+          cd "lcov-master"
+          sudo make install
+
+      - name: Clean up and merge coverage artifacts
+        run: |
+          # extract coverage for NFT contracts from forge coverage
+          lcov -e lcov.info -o lcov.info 'packages/ethereum-contracts/contracts/superfluid/*NFT*.sol'
+          # merge hardhat and forge coverage files
+          lcov -a lcov.info -a packages/ethereum-contracts/coverage/lcov.info -o lcov.info
 
   test-hot-fuzz:
     uses: ./.github/workflows/call.test-hot-fuzz.yml

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -92,8 +92,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # needs: [check]
-    # if: needs.check.outputs.build_ethereum_contracts
+    needs: [check]
+    if: needs.check.outputs.build_ethereum_contracts
 
     steps:
       - uses: actions/checkout@v3
@@ -104,30 +104,19 @@ jobs:
           node-version: 16.x
           cache: "yarn"
 
-      # - name: Install and build
-      #   run: |
-      #     yarn install --frozen-lockfile
-      #     yarn build
-
-      # - name: Install Foundry
-      #   uses: foundry-rs/foundry-toolchain@v1
-      #   with:
-      #     version: nightly
-
-      # - name: Run coverage test
-      #   run: |
-      #     yarn workspace @superfluid-finance/ethereum-contracts test-coverage
-      
-      - name: Install lcov
-        run: sudo apt-get -y install lcov
-
-      - name: Clean up and merge coverage artifacts
+      - name: Install and build
         run: |
-          lcov --help
-          # extract coverage for NFT contracts from forge coverage
-          # lcov -e lcov.info -o lcov.info 'packages/ethereum-contracts/contracts/superfluid/*NFT*.sol'
-          # # merge hardhat and forge coverage files
-          # lcov -a lcov.info -a packages/ethereum-contracts/coverage/lcov.info -o lcov.info
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run coverage test
+        run: |
+          yarn workspace @superfluid-finance/ethereum-contracts test-coverage
 
   test-hot-fuzz:
     uses: ./.github/workflows/call.test-hot-fuzz.yml


### PR DESCRIPTION
- add missing run-coverage-tests
- favor ./ syntax over @dev otherwise actionlint won't catch missing inputs