### PR TITLE
[ETHEREUM-CONTRACTS] bump solc to 0.8.19

### DIFF
--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+- bump solc to 0.8.19
+
 ### Breaking
 - `BatchLiquidator.deleteFlows` doesn't take host and CFA address as argument anymore. This makes L2 solvency operations considerably cheaper.
 

--- a/packages/ethereum-contracts/contracts/agreements/AgreementBase.sol
+++ b/packages/ethereum-contracts/contracts/agreements/AgreementBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { UUPSProxiable } from "../upgradability/UUPSProxiable.sol";
 import { ISuperAgreement } from "../interfaces/superfluid/ISuperAgreement.sol";

--- a/packages/ethereum-contracts/contracts/agreements/AgreementLibrary.sol
+++ b/packages/ethereum-contracts/contracts/agreements/AgreementLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluidGovernance,

--- a/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { IConstantFlowAgreementHook } from "../interfaces/agreements/IConstantFlowAgreementHook.sol";
 import {

--- a/packages/ethereum-contracts/contracts/agreements/InstantDistributionAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/InstantDistributionAgreementV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceBase.sol
+++ b/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceII.sol
+++ b/packages/ethereum-contracts/contracts/gov/SuperfluidGovernanceII.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { UUPSProxy } from "../upgradability/UUPSProxy.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/ethereum-contracts/contracts/libs/BaseRelayRecipient.sol
+++ b/packages/ethereum-contracts/contracts/libs/BaseRelayRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "../interfaces/utils/IRelayRecipient.sol";
 

--- a/packages/ethereum-contracts/contracts/libs/CallUtils.sol
+++ b/packages/ethereum-contracts/contracts/libs/CallUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 /**
  * @title Call utilities library that is absent from the OpenZeppelin

--- a/packages/ethereum-contracts/contracts/libs/ERC1820RegistryCompiled.sol
+++ b/packages/ethereum-contracts/contracts/libs/ERC1820RegistryCompiled.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPLv3
 // solhint-disable const-name-snakecase
 // solhint-disable max-line-length
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 /// @dev This is meant to be used by test framework to get the raw bytecode without compiling the origin contract
 library ERC1820RegistryCompiled {

--- a/packages/ethereum-contracts/contracts/libs/ERC777Helper.sol
+++ b/packages/ethereum-contracts/contracts/libs/ERC777Helper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { IERC1820Registry } from "@openzeppelin/contracts/utils/introspection/IERC1820Registry.sol";
 

--- a/packages/ethereum-contracts/contracts/libs/EventsEmitter.sol
+++ b/packages/ethereum-contracts/contracts/libs/EventsEmitter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 /**
  * @title Events Emitter Library

--- a/packages/ethereum-contracts/contracts/libs/FixedSizeData.sol
+++ b/packages/ethereum-contracts/contracts/libs/FixedSizeData.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 /**
  * @title Utilities for fixed size data in storage

--- a/packages/ethereum-contracts/contracts/libs/SlotsBitmapLibrary.sol
+++ b/packages/ethereum-contracts/contracts/libs/SlotsBitmapLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {ISuperfluidToken} from "../interfaces/superfluid/ISuperfluidToken.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/AgreementMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/AgreementMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/CFAAppMocks.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFAAppMocks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/CFALibraryMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFALibraryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {ISuperfluid, ISuperfluidToken, ISuperToken} from "../interfaces/superfluid/ISuperfluid.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/CallUtilsMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CallUtilsMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { CallUtils } from "../libs/CallUtils.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/CallUtilsTester.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CallUtilsTester.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { CallUtils } from "../libs/CallUtils.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/CustomSuperTokenMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CustomSuperTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     CustomSuperTokenBase,

--- a/packages/ethereum-contracts/contracts/mocks/ERC777SenderRecipientMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/ERC777SenderRecipientMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/packages/ethereum-contracts/contracts/mocks/FakeSuperfluidMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/FakeSuperfluidMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { CallUtils } from "../libs/CallUtils.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/ForwarderMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/ForwarderMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { CallUtils } from "../libs/CallUtils.sol";
 import { IRelayRecipient } from "../interfaces/utils/IRelayRecipient.sol";

--- a/packages/ethereum-contracts/contracts/mocks/IDASuperAppTester.sol
+++ b/packages/ethereum-contracts/contracts/mocks/IDASuperAppTester.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/IDAv1LibraryMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/IDAv1LibraryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 pragma experimental ABIEncoderV2;
 
 import {ISuperfluid, ISuperfluidToken, ISuperToken} from "../interfaces/superfluid/ISuperfluid.sol";

--- a/packages/ethereum-contracts/contracts/mocks/MockSmartWallet.sol
+++ b/packages/ethereum-contracts/contracts/mocks/MockSmartWallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { ISuperToken, IERC20 } from "../superfluid/Superfluid.sol";
 

--- a/packages/ethereum-contracts/contracts/mocks/MultiFlowTesterApp.sol
+++ b/packages/ethereum-contracts/contracts/mocks/MultiFlowTesterApp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/StreamRedirector.sol
+++ b/packages/ethereum-contracts/contracts/mocks/StreamRedirector.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { ISuperfluid, ISuperToken, SuperAppBase, ISuperApp, SuperAppDefinitions } from "../apps/SuperAppBase.sol";
 import { CFAv1Library } from "../apps/CFAv1Library.sol";

--- a/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/SuperTokenFactoryMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperTokenFactoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { SuperTokenMock } from "./SuperTokenMock.sol";
 import {

--- a/packages/ethereum-contracts/contracts/mocks/SuperTokenLibraryV1Mock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperTokenLibraryV1Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/SuperTokenMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/mocks/SuperfluidDestructorMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperfluidDestructorMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPLv3
 // solhint-disable
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 contract SuperfluidDestructorMock {
 

--- a/packages/ethereum-contracts/contracts/mocks/SuperfluidGovernanceIIMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperfluidGovernanceIIMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { ISuperfluid } from "../interfaces/superfluid/ISuperfluid.sol";
 import { SuperfluidGovernanceII } from "../gov/SuperfluidGovernanceII.sol";

--- a/packages/ethereum-contracts/contracts/mocks/SuperfluidMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperfluidMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     Superfluid,

--- a/packages/ethereum-contracts/contracts/mocks/UUPSProxiableMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/UUPSProxiableMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { UUPSProxiable } from "../upgradability/UUPSProxiable.sol";
 

--- a/packages/ethereum-contracts/contracts/superfluid/FullUpgradableSuperTokenProxy.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/FullUpgradableSuperTokenProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { ISuperTokenFactory } from "../interfaces/superfluid/ISuperTokenFactory.sol";
 import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";

--- a/packages/ethereum-contracts/contracts/superfluid/SuperToken.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { UUPSProxiable } from "../upgradability/UUPSProxiable.sol";
 

--- a/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import {

--- a/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/packages/ethereum-contracts/contracts/superfluid/SuperfluidToken.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperfluidToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { ISuperfluid } from "../interfaces/superfluid/ISuperfluid.sol";
 import { ISuperAgreement } from "../interfaces/superfluid/ISuperAgreement.sol";

--- a/packages/ethereum-contracts/contracts/tokens/PureSuperToken.sol
+++ b/packages/ethereum-contracts/contracts/tokens/PureSuperToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperToken,

--- a/packages/ethereum-contracts/contracts/tokens/SETH.sol
+++ b/packages/ethereum-contracts/contracts/tokens/SETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperToken,

--- a/packages/ethereum-contracts/contracts/upgradability/UUPSProxiable.sol
+++ b/packages/ethereum-contracts/contracts/upgradability/UUPSProxiable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { UUPSUtils } from "./UUPSUtils.sol";
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/packages/ethereum-contracts/contracts/upgradability/UUPSProxy.sol
+++ b/packages/ethereum-contracts/contracts/upgradability/UUPSProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { UUPSUtils } from "./UUPSUtils.sol";
 import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";

--- a/packages/ethereum-contracts/contracts/upgradability/UUPSUtils.sol
+++ b/packages/ethereum-contracts/contracts/upgradability/UUPSUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 /**
  * @title UUPS (Universal Upgradeable Proxy Standard) Shared Library

--- a/packages/ethereum-contracts/contracts/utils/BatchLiquidator.sol
+++ b/packages/ethereum-contracts/contracts/utils/BatchLiquidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { ISuperfluid, ISuperAgreement, ISuperToken } from "../interfaces/superfluid/ISuperfluid.sol";
 import { IConstantFlowAgreementV1 } from "../interfaces/agreements/IConstantFlowAgreementV1.sol";

--- a/packages/ethereum-contracts/contracts/utils/Resolver.sol
+++ b/packages/ethereum-contracts/contracts/utils/Resolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { AccessControlEnumerable } from "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import { IResolver } from "../interfaces/utils/IResolver.sol";

--- a/packages/ethereum-contracts/contracts/utils/SuperUpgrader.sol
+++ b/packages/ethereum-contracts/contracts/utils/SuperUpgrader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/packages/ethereum-contracts/contracts/utils/SuperfluidLoader.sol
+++ b/packages/ethereum-contracts/contracts/utils/SuperfluidLoader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { IResolver } from "../interfaces/utils/IResolver.sol";
 import {

--- a/packages/ethereum-contracts/contracts/utils/TOGA.sol
+++ b/packages/ethereum-contracts/contracts/utils/TOGA.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/packages/ethereum-contracts/contracts/utils/TestGovernance.sol
+++ b/packages/ethereum-contracts/contracts/utils/TestGovernance.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluid,

--- a/packages/ethereum-contracts/contracts/utils/TestResolver.sol
+++ b/packages/ethereum-contracts/contracts/utils/TestResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { Resolver } from "./Resolver.sol";
 

--- a/packages/ethereum-contracts/contracts/utils/TestToken.sol
+++ b/packages/ethereum-contracts/contracts/utils/TestToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/packages/ethereum-contracts/hardhat.config.ts
+++ b/packages/ethereum-contracts/hardhat.config.ts
@@ -68,7 +68,7 @@ function createNetworkConfig(
 
 const config: HardhatUserConfig = {
     solidity: {
-        version: "0.8.18",
+        version: "0.8.19",
         settings: {
             optimizer: {
                 enabled: true,

--- a/packages/ethereum-contracts/test/foundry/FoundrySuperfluidTester.sol
+++ b/packages/ethereum-contracts/test/foundry/FoundrySuperfluidTester.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 

--- a/packages/ethereum-contracts/test/foundry/SuperfluidFrameworkDeployer.t.sol
+++ b/packages/ethereum-contracts/test/foundry/SuperfluidFrameworkDeployer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 import {

--- a/packages/ethereum-contracts/test/foundry/agreements/ConstantFlowAgreementV1.prop.sol
+++ b/packages/ethereum-contracts/test/foundry/agreements/ConstantFlowAgreementV1.prop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 

--- a/packages/ethereum-contracts/test/foundry/agreements/ConstantFlowAgreementV1.t.sol
+++ b/packages/ethereum-contracts/test/foundry/agreements/ConstantFlowAgreementV1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "../FoundrySuperfluidTester.sol";
 

--- a/packages/ethereum-contracts/test/foundry/agreements/InstantDistributionAgreementV1.t.sol
+++ b/packages/ethereum-contracts/test/foundry/agreements/InstantDistributionAgreementV1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "../FoundrySuperfluidTester.sol";
 

--- a/packages/ethereum-contracts/test/foundry/deployments/ForkPolygonSuperTokenFactoryUpgrade.t.sol
+++ b/packages/ethereum-contracts/test/foundry/deployments/ForkPolygonSuperTokenFactoryUpgrade.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { console, Test } from "forge-std/Test.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/ethereum-contracts/test/foundry/deployments/ForkSmoke.t.sol
+++ b/packages/ethereum-contracts/test/foundry/deployments/ForkSmoke.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { console, Test } from "forge-std/Test.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/packages/ethereum-contracts/test/foundry/libs/AgreementLibrary.prop.sol
+++ b/packages/ethereum-contracts/test/foundry/libs/AgreementLibrary.prop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import { AgreementLibrary } from "@superfluid-finance/ethereum-contracts/contracts/agreements/AgreementLibrary.sol";
 

--- a/packages/ethereum-contracts/test/foundry/libs/CallUtils.t.sol
+++ b/packages/ethereum-contracts/test/foundry/libs/CallUtils.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 

--- a/packages/ethereum-contracts/test/foundry/libs/SlotsBitmapLibrary.prop.sol
+++ b/packages/ethereum-contracts/test/foundry/libs/SlotsBitmapLibrary.prop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "forge-std/Test.sol";
 

--- a/packages/ethereum-contracts/test/foundry/utils/BatchLiquidator.t.sol
+++ b/packages/ethereum-contracts/test/foundry/utils/BatchLiquidator.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPLv3
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 import "../FoundrySuperfluidTester.sol";
 import { BatchLiquidator } from "@superfluid-finance/ethereum-contracts/contracts/utils/BatchLiquidator.sol";

--- a/packages/ethereum-contracts/truffle-config.js
+++ b/packages/ethereum-contracts/truffle-config.js
@@ -389,7 +389,7 @@ const E = (module.exports = {
     // Configure your compilers
     compilers: {
         solc: {
-            version: "0.8.18", // Fetch exact version from solc-bin (default: truffle's version)
+            version: "0.8.19", // Fetch exact version from solc-bin (default: truffle's version)
             settings: {
                 // See the solidity docs for advice about optimization and evmVersion
                 optimizer: {


### PR DESCRIPTION
Bumping solc version to 0.8.19 as this is required by the SemanticMoney library.