### PR TITLE
[WORKFLOWS] Fix deploy subgraph workflow

### DIFF
--- a/packages/subgraph/tasks/deploy-to-hosted-service.sh
+++ b/packages/subgraph/tasks/deploy-to-hosted-service.sh
@@ -14,5 +14,6 @@ if [ "$2" == "" ];then
     ./tasks/deploy-all-networks.sh $1
 else
     # else we deploy to the specified network ($1 = release, $2 = network)
+    ./tasks/prepare-manifest.sh $2
     ./tasks/deploy-to-hosted-service-network.sh $1 $2
 fi

--- a/packages/subgraph/tasks/deploy-to-hosted-service.sh
+++ b/packages/subgraph/tasks/deploy-to-hosted-service.sh
@@ -14,5 +14,6 @@ if [ "$2" == "" ];then
     ./tasks/deploy-all-networks.sh $1
 else
     # else we deploy to the specified network ($1 = release, $2 = network)
+    ./tasks/prepare-manifest.sh $i
     ./tasks/deploy-to-hosted-service-network.sh $1 $2
 fi

--- a/packages/subgraph/tasks/deploy-to-hosted-service.sh
+++ b/packages/subgraph/tasks/deploy-to-hosted-service.sh
@@ -14,6 +14,6 @@ if [ "$2" == "" ];then
     ./tasks/deploy-all-networks.sh $1
 else
     # else we deploy to the specified network ($1 = release, $2 = network)
-    ./tasks/prepare-manifest.sh $i
+    ./tasks/prepare-manifest.sh $1
     ./tasks/deploy-to-hosted-service-network.sh $1 $2
 fi

--- a/packages/subgraph/tasks/deploy-to-hosted-service.sh
+++ b/packages/subgraph/tasks/deploy-to-hosted-service.sh
@@ -14,6 +14,6 @@ if [ "$2" == "" ];then
     ./tasks/deploy-all-networks.sh $1
 else
     # else we deploy to the specified network ($1 = release, $2 = network)
-    ./tasks/prepare-manifest.sh $1
+    ./tasks/prepare-manifest.sh $2
     ./tasks/deploy-to-hosted-service-network.sh $1 $2
 fi


### PR DESCRIPTION
## Context
Recently, I did a deploy to [v1 goerli](https://github.com/superfluid-finance/protocol-monorepo/actions/runs/4426937045).
However, it deployed the matic endpoint data to the network because the `call.deploy-subgraph.yml` file prepares the manifest file for matic, but inside of `deploy-to-hosted-service.sh`, there is no `prepare-manifest.sh` call to prepare it again for the correct network.

## Immediate Fix
The immediate fix is to just call deploy all because this calls prepare-manifest already.

## Long-term Fix
I added the `./tasks/prepare-manifest.sh $2` call to `deploy-to-hosted-service.sh` so that it properly prepares the 