### PR TITLE
Issue #256 | Try/Catch FlowNFT Hooks

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -135,15 +135,15 @@ jobs:
           yarn build
           yarn workspace @superfluid-finance/ethereum-contracts test-coverage
 
-      # - name: Install lcov
-      #   run: sudo apt-get -y install lcov
+      - name: Install lcov
+        run: sudo apt-get -y install lcov
 
-      # - name: Clean up and merge coverage artifacts
-      #   run: |
-      #     # extract coverage for NFT contracts from forge coverage
-      #     lcov -e lcov.info -o lcov.info 'packages/ethereum-contracts/contracts/superfluid/*NFT*.sol'
-      #     # merge hardhat and forge coverage files
-      #     lcov -a lcov.info -a packages/ethereum-contracts/coverage/lcov.info -o packages/ethereum-contracts/coverage/lcov.info
+      - name: Clean up and merge coverage artifacts
+        run: |
+          # extract coverage for NFT contracts from forge coverage
+          lcov -e lcov.info -o lcov.info 'packages/ethereum-contracts/contracts/superfluid/*NFT*.sol'
+          # merge hardhat and forge coverage files
+          lcov -a lcov.info -a packages/ethereum-contracts/coverage/lcov.info -o packages/ethereum-contracts/coverage/lcov.info
 
       - name: Create coverage artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -87,48 +87,6 @@ jobs:
           # NOTE: This is currently unset and fork tests are not being run
           POLYGON_MAINNET_ARCHIVE_PROVIDER_URL: ${{ secrets.POLYGON_MAINNET_ARCHIVE_PROVIDER_URL }}
 
-  test-canary-coverage-ethereum-contracts:
-    name: Run coverage test of ethereum-contracts of dev branch
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-          cache: "yarn"
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
-
-      - name: Run coverage test
-        run: |
-          yarn install --frozen-lockfile
-          yarn build
-          yarn workspace @superfluid-finance/ethereum-contracts test-coverage
-
-      - name: Install lcov
-        run: sudo apt-get -y install lcov
-
-      - name: Clean up and merge coverage artifacts
-        run: |
-          # extract coverage for NFT contracts from forge coverage
-          lcov -e lcov.info -o lcov.info 'packages/ethereum-contracts/contracts/superfluid/*NFT*.sol'
-          # merge hardhat and forge coverage files
-          lcov -a lcov.info -a packages/ethereum-contracts/coverage/lcov.info -o packages/ethereum-contracts/coverage/lcov.info
-
-      - name: Create coverage artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ethereum-contracts-coverage
-          path: |
-            packages/ethereum-contracts/coverage/
-
   coverage-ethereum-contracts:
     name: Build and test coverage of ethereum-contracts (Feature Branch)
 

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -87,6 +87,48 @@ jobs:
           # NOTE: This is currently unset and fork tests are not being run
           POLYGON_MAINNET_ARCHIVE_PROVIDER_URL: ${{ secrets.POLYGON_MAINNET_ARCHIVE_PROVIDER_URL }}
 
+  test-canary-coverage-ethereum-contracts:
+    name: Run coverage test of ethereum-contracts of dev branch
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "yarn"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run coverage test
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+          yarn workspace @superfluid-finance/ethereum-contracts test-coverage
+
+      - name: Install lcov
+        run: sudo apt-get -y install lcov
+
+      - name: Clean up and merge coverage artifacts
+        run: |
+          # extract coverage for NFT contracts from forge coverage
+          lcov -e lcov.info -o lcov.info 'packages/ethereum-contracts/contracts/superfluid/*NFT*.sol'
+          # merge hardhat and forge coverage files
+          lcov -a lcov.info -a packages/ethereum-contracts/coverage/lcov.info -o packages/ethereum-contracts/coverage/lcov.info
+
+      - name: Create coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ethereum-contracts-coverage
+          path: |
+            packages/ethereum-contracts/coverage/
+
   coverage-ethereum-contracts:
     name: Build and test coverage of ethereum-contracts (Feature Branch)
 

--- a/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
@@ -18,9 +18,9 @@ import {
 } from "../interfaces/superfluid/ISuperfluid.sol";
 import { IConstantOutflowNFT } from "../interfaces/superfluid/IConstantOutflowNFT.sol";
 import { AgreementBase } from "./AgreementBase.sol";
-
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { AgreementLibrary } from "./AgreementLibrary.sol";
+import { SafeGasLibrary } from "../libs/SafeGasLibrary.sol";
 
 /**
  * @title ConstantFlowAgreementV1 contract
@@ -75,6 +75,7 @@ contract ConstantFlowAgreementV1 is
     bytes32 private constant SUPERTOKEN_MINIMUM_DEPOSIT_KEY =
         keccak256("org.superfluid-finance.superfluid.superTokenMinimumDeposit");
 
+    // @note this variable is deprecated and no longer used
     IConstantFlowAgreementHook public immutable constantFlowAgreementHook;
 
     // An arbitrarily chosen safety limit for the external calls to protect against out-of-gas grief exploits.
@@ -478,12 +479,7 @@ contract ConstantFlowAgreementV1 is
             }(flowVars.sender, flowVars.receiver)
         // solhint-disable-next-line no-empty-blocks
         {} catch {
-// If the CFA hook actually runs out of gas, not just hitting the safety gas limit, we revert the whole transaction.
-// This solves an issue where the gas estimaton didn't provide enough gas by default for the CFA hook to succeed.
-// See https://medium.com/@wighawag/ethereum-the-concept-of-gas-and-its-dangers-28d0eb809bb2
-            if (gasleft() <= gasLeftBefore / 63) {
-                revert CFA_HOOK_OUT_OF_GAS();
-            }
+            SafeGasLibrary._revertWhenOutOfGas(gasLeftBefore);
         }
     }
 
@@ -522,12 +518,7 @@ contract ConstantFlowAgreementV1 is
             }(flowVars.sender, flowVars.receiver)
         // solhint-disable-next-line no-empty-blocks
         {} catch {
-// If the CFA hook actually runs out of gas, not just hitting the safety gas limit, we revert the whole transaction.
-// This solves an issue where the gas estimaton didn't provide enough gas by default for the CFA hook to succeed.
-// See https://medium.com/@wighawag/ethereum-the-concept-of-gas-and-its-dangers-28d0eb809bb2
-            if (gasleft() <= gasLeftBefore / 63) {
-                revert CFA_HOOK_OUT_OF_GAS();
-            }
+            SafeGasLibrary._revertWhenOutOfGas(gasLeftBefore);
         }
     }
 
@@ -648,12 +639,7 @@ contract ConstantFlowAgreementV1 is
             }(flowVars.sender, flowVars.receiver)
         // solhint-disable-next-line no-empty-blocks
         {} catch {
-// If the CFA hook actually runs out of gas, not just hitting the safety gas limit, we revert the whole transaction.
-// This solves an issue where the gas estimaton didn't provide enough gas by default for the CFA hook to succeed.
-// See https://medium.com/@wighawag/ethereum-the-concept-of-gas-and-its-dangers-28d0eb809bb2
-            if (gasleft() <= gasLeftBefore / 63) {
-                revert CFA_HOOK_OUT_OF_GAS();
-            }
+            SafeGasLibrary._revertWhenOutOfGas(gasLeftBefore);
         }
     }
 

--- a/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
+++ b/packages/ethereum-contracts/contracts/agreements/ConstantFlowAgreementV1.sol
@@ -470,12 +470,21 @@ contract ConstantFlowAgreementV1 is
 
         _requireAvailableBalance(flowVars.token, flowVars.sender, currentContext);
 
-        // for now, we are aware that this will break super tokens with custom super token logic
-        // which choose not to upgrade, in order to fix this, we must use the old try/catch logic
-        // which was previously in place for the previous marketing NFT
-        ISuperToken(
-            address(flowVars.token)
-        ).constantOutflowNFT().onCreate(flowVars.sender, flowVars.receiver);
+        uint256 gasLeftBefore = gasleft();
+    
+        try
+            ISuperToken(address(flowVars.token)).constantOutflowNFT().onCreate{
+                gas: CFA_HOOK_GAS_LIMIT
+            }(flowVars.sender, flowVars.receiver)
+        // solhint-disable-next-line no-empty-blocks
+        {} catch {
+// If the CFA hook actually runs out of gas, not just hitting the safety gas limit, we revert the whole transaction.
+// This solves an issue where the gas estimaton didn't provide enough gas by default for the CFA hook to succeed.
+// See https://medium.com/@wighawag/ethereum-the-concept-of-gas-and-its-dangers-28d0eb809bb2
+            if (gasleft() <= gasLeftBefore / 63) {
+                revert CFA_HOOK_OUT_OF_GAS();
+            }
+        }
     }
 
     function _updateFlow(
@@ -505,13 +514,21 @@ contract ConstantFlowAgreementV1 is
 
         _requireAvailableBalance(flowVars.token, flowVars.sender, currentContext);
 
-        // for now, we are aware that this will break super tokens with custom super token logic
-        // which choose not to upgrade, in order to fix this, we must use the old try/catch logic
-        // which was previously in place for the previous marketing NFT
-        ISuperToken(address(flowVars.token)).constantOutflowNFT().onUpdate(
-            flowVars.sender,
-            flowVars.receiver
-        );
+        uint256 gasLeftBefore = gasleft();
+    
+        try
+            ISuperToken(address(flowVars.token)).constantOutflowNFT().onUpdate{
+                gas: CFA_HOOK_GAS_LIMIT
+            }(flowVars.sender, flowVars.receiver)
+        // solhint-disable-next-line no-empty-blocks
+        {} catch {
+// If the CFA hook actually runs out of gas, not just hitting the safety gas limit, we revert the whole transaction.
+// This solves an issue where the gas estimaton didn't provide enough gas by default for the CFA hook to succeed.
+// See https://medium.com/@wighawag/ethereum-the-concept-of-gas-and-its-dangers-28d0eb809bb2
+            if (gasleft() <= gasLeftBefore / 63) {
+                revert CFA_HOOK_OUT_OF_GAS();
+            }
+        }
     }
 
     function _deleteFlow(
@@ -623,14 +640,21 @@ contract ConstantFlowAgreementV1 is
             }
         }
 
-        // for now, we are aware that this will break super tokens with custom super token logic
-        // which choose not to upgrade, in order to fix this, we must use the old try/catch logic
-        // which was previously in place for the previous marketing NFT
-        
-        ISuperToken(address(flowVars.token)).constantOutflowNFT().onDelete(
-            flowVars.sender,
-            flowVars.receiver
-        );
+        uint256 gasLeftBefore = gasleft();
+    
+        try
+            ISuperToken(address(flowVars.token)).constantOutflowNFT().onDelete{
+                gas: CFA_HOOK_GAS_LIMIT
+            }(flowVars.sender, flowVars.receiver)
+        // solhint-disable-next-line no-empty-blocks
+        {} catch {
+// If the CFA hook actually runs out of gas, not just hitting the safety gas limit, we revert the whole transaction.
+// This solves an issue where the gas estimaton didn't provide enough gas by default for the CFA hook to succeed.
+// See https://medium.com/@wighawag/ethereum-the-concept-of-gas-and-its-dangers-28d0eb809bb2
+            if (gasleft() <= gasLeftBefore / 63) {
+                revert CFA_HOOK_OUT_OF_GAS();
+            }
+        }
     }
 
     /**************************************************************************

--- a/packages/ethereum-contracts/contracts/libs/SafeGasLibrary.sol
+++ b/packages/ethereum-contracts/contracts/libs/SafeGasLibrary.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity 0.8.19;
+
+/// @title SafeGasLibrary
+/// @author Superfluid
+/// @notice An internal library used to handle out of gas errors
+library SafeGasLibrary {
+    error OUT_OF_GAS();
+
+    /// @dev A function used in the catch block to handle true out of gas errors
+    /// @param gasLeftBefore the gas left before the try/catch block
+    function _revertWhenOutOfGas(uint256 gasLeftBefore) internal {
+// If the function actually runs out of gas, not just hitting the safety gas limit, we revert the whole transaction.
+// This solves an issue where the gas estimaton didn't provide enough gas by default for the function to succeed.
+// See https://medium.com/@wighawag/ethereum-the-concept-of-gas-and-its-dangers-28d0eb809bb2
+        if (gasleft() <= gasLeftBefore / 63) {
+            revert OUT_OF_GAS();
+        }
+    }
+}

--- a/packages/ethereum-contracts/test/foundry/superfluid/FlowNFTBase.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/FlowNFTBase.t.sol
@@ -256,8 +256,8 @@ abstract contract FlowNFTBaseTest is FoundrySuperfluidTester {
     function helper_Get_NFT_ID(
         address _flowSender,
         address _flowReceiver
-    ) public pure returns (uint256) {
-        return uint256(keccak256(abi.encode(_flowSender, _flowReceiver)));
+    ) public view returns (uint256) {
+        return constantOutflowNFTLogic.getTokenId(_flowSender, _flowReceiver);
     }
 
     function helper_Create_Flow_And_Assert_NFT_Invariants(

--- a/packages/ethereum-contracts/test/foundry/superfluid/nftUpgradability/CFAv1NFTUpgradability.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/nftUpgradability/CFAv1NFTUpgradability.t.sol
@@ -11,6 +11,9 @@ import {
     ConstantInflowNFT
 } from "../../../../contracts/superfluid/ConstantInflowNFT.sol";
 import {
+    IFlowNFTBase
+} from "../../../../contracts/interfaces/superfluid/IFlowNFTBase.sol";
+import {
     ConstantOutflowNFT
 } from "../../../../contracts/superfluid/ConstantOutflowNFT.sol";
 import { FlowNFTBaseTest } from "../FlowNFTBase.t.sol";
@@ -61,6 +64,24 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
                 sf.cfa
             );
         constantOutflowNFTBaseStorageLayoutMock.validateStorageLayout();
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    Revert Tests
+    //////////////////////////////////////////////////////////////////////////*/
+    function test_Revert_NFT_Contracts_Cannot_Be_Upgraded_By_Non_Host(
+        address notHost
+    ) public {
+        vm.assume(notHost != address(sf.host));
+        ConstantOutflowNFT newOutflowLogic = new ConstantOutflowNFT(sf.cfa);
+        vm.expectRevert(IFlowNFTBase.CFA_NFT_ONLY_HOST.selector);
+        vm.prank(notHost);
+        constantOutflowNFTProxy.updateCode(address(newOutflowLogic));
+
+        ConstantInflowNFT newInflowLogic = new ConstantInflowNFT(sf.cfa);
+        vm.expectRevert(IFlowNFTBase.CFA_NFT_ONLY_HOST.selector);
+        vm.prank(notHost);
+        constantInflowNFTProxy.updateCode(address(newInflowLogic));
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
See the issue here: https://github.com/superfluid-finance/superfluid-stories/issues/256

## Summary of Changes
- This adds the try/catch back to the flow nft hooks in the CFA.
- Create a new internal library to encapsulate some of the logic when reverting out of gas in the catch block
- Uncomment foundry coverage sections in ci.canary to prevent breaking changes
- Add test to check if `updateCode` reverts when called by non-host for FlowNFTBase
- Use `getTokenId` instead of repeating token id logic in test code: `helper_Get_NFT_ID` (also for coverage)