### PR TITLE
[SDK-redux] Small type fix

### DIFF
--- a/packages/sdk-redux/package.json
+++ b/packages/sdk-redux/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-redux",
-    "version": "0.5.1",
+    "version": "0.5.0",
     "description": "SDK Redux for streamlined front-end application development with Superfluid Protocol",
     "homepage": "https://docs.superfluid.finance/",
     "repository": {

--- a/packages/sdk-redux/package.json
+++ b/packages/sdk-redux/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-redux",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "SDK Redux for streamlined front-end application development with Superfluid Protocol",
     "homepage": "https://docs.superfluid.finance/",
     "repository": {

--- a/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/registerNewTransaction.ts
+++ b/packages/sdk-redux/src/reduxSlices/transactionTrackerSlice/registerNewTransaction.ts
@@ -16,7 +16,7 @@ export interface RegisterNewTransactionArg {
      */
     chainId: number;
     signerAddress: string;
-    transactionResponse: ethers.providers.TransactionResponse;
+    transactionResponse: NewTransactionResponse;
     /**
      * For dispatching redux thunks.
      */


### PR DESCRIPTION
It completely overlaps with the previous but is a little less strict on what fields to enforce.

Background: This initially came up with wagmi interop as wagmi prefers to send transactions "unchecked" which means that they skip an ethers.js follow-up RPC call to fill in more data about the transaction: https://docs.ethers.org/v5/api/providers/jsonrpc-provider/#JsonRpcSigner-connectUnchecked