### PR TITLE
[WORKFLOWS] Make Subgraph deployment more explicit

### DIFF
--- a/.github/workflows/call.deploy-hosted-service-subgraph.yml
+++ b/.github/workflows/call.deploy-hosted-service-subgraph.yml
@@ -10,7 +10,7 @@ on:
       network:
         required: true
         type: string
-        description: 'The network you want to deploy to (matic, xdai, eth-mainnet, etc.) or "" for all networks.'
+        description: 'The network you want to deploy to (matic, xdai, eth-mainnet, etc.) or `all` for all networks.'
     secrets:
       THE_GRAPH_ACCESS_TOKEN:
         description: 'The Graph access token for deploying subgraphs'
@@ -88,14 +88,14 @@ jobs:
           fi
 
       - name: "Deploy to All Hosted Subgraph Superfluid endpoints"
-        if: inputs.network == ''
+        if: inputs.network == 'all'
         run: ./tasks/deploy-all-hosted-service-networks.sh ${{ inputs.release_branch }}
         working-directory: ${{ env.subgraph-working-directory }}
         env:
           THE_GRAPH_ACCESS_TOKEN: ${{ secrets.THE_GRAPH_ACCESS_TOKEN }}
 
       - name: "Deploy to Hosted Subgraph Superfluid endpoint"
-        if: inputs.network != ''
+        if: inputs.network != 'all'
         run: ./tasks/deploy-to-hosted-service-network.sh ${{ inputs.release_branch }} ${{ inputs.network }}
         working-directory: ${{ env.subgraph-working-directory }}
         env:

--- a/.github/workflows/call.deploy-satsuma-subgraph.yml
+++ b/.github/workflows/call.deploy-satsuma-subgraph.yml
@@ -6,7 +6,7 @@ on:
       network:
         required: true
         type: string
-        description: 'The network you want to deploy to (matic, xdai, eth-mainnet, etc.) or "" for all networks.'
+        description: 'The network you want to deploy to (matic, xdai, eth-mainnet, etc.) or `all` for all networks.'
       satsuma_version_label:
         required: true
         type: string
@@ -82,7 +82,7 @@ jobs:
         working-directory: ${{ env.subgraph-working-directory }}
 
       - name: "Deploy to All Satsuma endpoints"
-        if: inputs.network == ''
+        if: inputs.network == 'all'
         run: |
           shortRev=$(git rev-parse --short ${{ github.sha }})
           versionLabel=${{ inputs.satsuma_version_label }}-${shortRev}
@@ -92,7 +92,7 @@ jobs:
           SATSUMA_DEPLOY_KEY: ${{ secrets.SATSUMA_DEPLOY_KEY }}
 
       - name: "Deploy to Satsuma endpoint"
-        if: inputs.network != ''
+        if: inputs.network != 'all'
         run: |
           shortRev=$(git rev-parse --short ${{ github.sha }})
           versionLabel=${{ inputs.satsuma_version_label }}-${shortRev}

--- a/.github/workflows/handler.deploy-hosted-service-subgraph.yml
+++ b/.github/workflows/handler.deploy-hosted-service-subgraph.yml
@@ -19,7 +19,7 @@ on:
       network:
         required: true
         type: string
-        description: 'The network you want to deploy to (matic, xdai, eth-mainnet, etc.) or "" for all networks.'
+        description: 'The network you want to deploy to (matic, xdai, eth-mainnet, etc.) or `all` for all networks.'
 jobs:
   build-and-test-local-subgraph:
     uses: ./.github/workflows/call.test-local-subgraph.yml

--- a/.github/workflows/handler.deploy-production-subgraphs.yml
+++ b/.github/workflows/handler.deploy-production-subgraphs.yml
@@ -37,7 +37,7 @@ jobs:
     name: Deploy Hosted Service Subgraph
     with:
       release_branch: "v1"
-      network: ""
+      network: "all"
     secrets:
       THE_GRAPH_ACCESS_TOKEN: ${{ secrets.THE_GRAPH_ACCESS_TOKEN }}
 
@@ -50,6 +50,6 @@ jobs:
     name: Deploy Satsuma Subgraph
     with:
       satsuma_version_label: ${{ github.event.inputs.satsuma_version_label }}
-      network: ""
+      network: "all"
     secrets:
       SATSUMA_DEPLOY_KEY: ${{ secrets.SATSUMA_DEPLOY_KEY }}

--- a/.github/workflows/handler.deploy-satsuma-subgraph.yml
+++ b/.github/workflows/handler.deploy-satsuma-subgraph.yml
@@ -18,7 +18,7 @@ on:
       network:
         required: true
         type: string
-        description: 'The network you want to deploy to (matic, xdai, eth-mainnet, etc.) or "" for all networks.'
+        description: 'The network you want to deploy to (matic, xdai, eth-mainnet, etc.) or `all` for all networks.'
 jobs:
   build-and-test-local-subgraph:
     uses: ./.github/workflows/call.test-local-subgraph.yml

--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -15,7 +15,7 @@ const {
     builtTruffleContractLoader,
     sendGovernanceAction,
 } = require("./libs/common");
-const { ethers } = require("ethers");
+const {ethers} = require("ethers");
 
 let resetSuperfluidFramework;
 let resolver;
@@ -415,6 +415,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
         } else {
             contract.link(externalLibraryName, externalLibrary.address);
         }
+        console.log(externalLibraryName, "address", externalLibrary.address);
         return externalLibrary;
     };
 
@@ -448,7 +449,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
         )(superfluid.address, ida.address);
     } else {
         // NOTE that we are reusing the existing deployed external library
-        // here as an optimization, this assumes that we do not change the 
+        // here as an optimization, this assumes that we do not change the
         // library code.
         // link library in order to avoid spurious code change detections
         let slotsBitmapLibraryAddress = ZERO_ADDRESS;
@@ -564,10 +565,26 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
 
     const SuperTokenLogic = useMocks ? SuperTokenMock : SuperToken;
     const factoryAddress = await superfluid.getSuperTokenFactory.call();
+    let superfluidNFTDeployerLibraryAddress = ZERO_ADDRESS;
 
-    // deploy new SuperfluidNFTDeployerLibrary if factory is not deployed
+    // get factory contract
+    const factoryContract = await SuperTokenFactoryLogic.at(factoryAddress);
+
+    const superTokenContract = await SuperToken.at(
+        await factoryContract.getSuperTokenLogic.call()
+    );
+
+    try {
+        superfluidNFTDeployerLibraryAddress =
+            await superTokenContract.SUPERFLUID_NFT_DEPLOYER_LIBRARY_ADDRESS.call();
+    } catch {
+        console.warn(
+            "SUPERFLUID_NFT_DEPLOYER_LIBRARY_ADDRESS does not exist on SuperToken contract yet - deployment required."
+        );
+    }
+    // deploy new SuperfluidNFTDeployerLibrary if it is not deployed
     // link it to SuperToken logic contract
-    if (factoryAddress === ZERO_ADDRESS) {
+    if (superfluidNFTDeployerLibraryAddress === ZERO_ADDRESS) {
         await deployExternalLibraryAndLink(
             SuperfluidNFTDeployerLibrary,
             "SuperfluidNFTDeployerLibrary",
@@ -581,27 +598,30 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
         // link existing deployed external library to SuperToken logic contract
         let superfluidNFTDeployerLibraryAddress = ZERO_ADDRESS;
         try {
-            // get factory contract
-            const factoryContract = await SuperTokenFactoryLogic.at(
-                factoryAddress
-            );
-            const superTokenContract = await SuperToken.at(
-                await factoryContract.getSuperTokenLogic.call()
-            );
-            superfluidNFTDeployerLibraryAddress =
-                await superTokenContract.SUPERFLUID_NFT_DEPLOYER_LIBRARY_ADDRESS.call();
-            if (process.env.IS_HARDHAT) {
-                if (superfluidNFTDeployerLibraryAddress !== ZERO_ADDRESS) {
+            // if the library is not deployed, deploy it and link it to SuperToken logic contract
+            if (superfluidNFTDeployerLibraryAddress === ZERO_ADDRESS) {
+                const superfluidNFTDeployerLibrary =
+                    await deployExternalLibraryAndLink(
+                        SuperfluidNFTDeployerLibrary,
+                        "SuperfluidNFTDeployerLibrary",
+                        "SUPERFLUID_NFT_DEPLOYER_LIBRARY_ADDRESS",
+                        SuperTokenLogic
+                    );
+                superfluidNFTDeployerLibraryAddress =
+                    superfluidNFTDeployerLibrary.address;
+                // else link the preexisting contract
+            } else {
+                if (process.env.IS_HARDHAT) {
                     const lib = await SuperfluidNFTDeployerLibrary.at(
                         superfluidNFTDeployerLibraryAddress
                     );
                     SuperTokenLogic.link(lib);
+                } else {
+                    SuperTokenLogic.link(
+                        "SuperfluidNFTDeployerLibrary",
+                        superfluidNFTDeployerLibraryAddress
+                    );
                 }
-            } else {
-                SuperTokenLogic.link(
-                    "SuperfluidNFTDeployerLibrary",
-                    superfluidNFTDeployerLibraryAddress
-                );
             }
         } catch (e) {
             console.warn(


### PR DESCRIPTION
## Summary
- Require user to explicitly pass `all` to the deploy subgraph handlers to deploy to all networks

See:
- https://www.notion.so/superfluidhq/Production-Subgraph-Deployment-b0f8aeb6e03b439db67565a3f173ca9c?pvs=4
- https://www.notion.so/superfluidhq/Hosted-Service-Subgraph-Deployment-62b3167f778344bc88304893742b08ef?pvs=4
- https://www.notion.so/superfluidhq/Satsuma-Subgraph-Deployment-42ed9f0bde824a4b9e7e2e952364e24a?pvs=4
For instructions on how to deploy.