### PR TITLE
[ETHEREUM-CONTRACTS] 1.6.0 Release

### DIFF
--- a/packages/automation-contracts/autowrap/package.json
+++ b/packages/automation-contracts/autowrap/package.json
@@ -17,7 +17,7 @@
     "devDependencies": {
         "@nomiclabs/hardhat-etherscan": "^3.1.3",
         "@openzeppelin/contracts": "^4.8.0",
-        "@superfluid-finance/ethereum-contracts": "1.5.2",
+        "@superfluid-finance/ethereum-contracts": "1.6.0",
         "dotenv": "^16.0.3"
     },
     "dependencies": {

--- a/packages/automation-contracts/scheduler/package.json
+++ b/packages/automation-contracts/scheduler/package.json
@@ -17,7 +17,7 @@
     "devDependencies": {
         "@nomiclabs/hardhat-etherscan": "^3.1.3",
         "@openzeppelin/contracts": "^4.8.0",
-        "@superfluid-finance/ethereum-contracts": "1.5.2",
+        "@superfluid-finance/ethereum-contracts": "1.6.0",
         "dotenv": "^16.0.3"
     },
     "dependencies": {

--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -5,6 +5,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+
+## [v1.6.0] - 2023-04-25
+### Added
+- FlowNFT contracts: `ConstantOutflowNFT`, `ConstantInflowNFT`, `FlowNFTBase` to replace the OG flow NFTs
+- `SuperAppBaseCFA` base contract to simplify CFA SuperApp development
+- `SuperTokenDeployer.sol` for deploying SuperTokens in local testing (split from `SuperfluidFrameworkDeployer.sol`)
+
+### Changed
+- `SuperToken` logic contract takes `ConstantOutflowNFT` and `ConstantInflowNFT` proxy contract addresses
+- `SuperTokenFactory` logic contract takes `ConstantOutflowNFT` and `ConstantInflowNFT` and handles the upgrade logic for the NFTs
+
 ## [v1.5.2] - 2023-03-14
 
 ### Added

--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 
-## [v1.6.0] - 2023-04-25
+## [v1.6.0] - 2023-04-26
 ### Added
 - FlowNFT contracts: `ConstantOutflowNFT`, `ConstantInflowNFT`, `FlowNFTBase` to replace the OG flow NFTs
 - `SuperAppBaseCFA` base contract to simplify CFA SuperApp development

--- a/packages/ethereum-contracts/contracts/superfluid/ConstantInflowNFT.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/ConstantInflowNFT.sol
@@ -27,8 +27,9 @@ contract ConstantInflowNFT is FlowNFTBase, IConstantInflowNFT {
     // solhint-disable-next-line no-empty-blocks
     constructor(
         ISuperfluid host,
-        IConstantOutflowNFT constantOutflowNFT
-    ) FlowNFTBase(host) {
+        IConstantOutflowNFT constantOutflowNFT,
+        string memory baseURI
+    ) FlowNFTBase(host, baseURI) {
         CONSTANT_OUTFLOW_NFT = constantOutflowNFT;
     }
 

--- a/packages/ethereum-contracts/contracts/superfluid/ConstantOutflowNFT.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/ConstantOutflowNFT.sol
@@ -36,8 +36,9 @@ contract ConstantOutflowNFT is FlowNFTBase, IConstantOutflowNFT {
     // solhint-disable-next-line no-empty-blocks
     constructor(
         ISuperfluid host,
-        IConstantInflowNFT constantInflowNFT
-    ) FlowNFTBase(host) {
+        IConstantInflowNFT constantInflowNFT,
+        string memory baseURI
+    ) FlowNFTBase(host, baseURI) {
         CONSTANT_INFLOW_NFT = constantInflowNFT;
     }
 

--- a/packages/ethereum-contracts/contracts/superfluid/FlowNFTBase.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/FlowNFTBase.sol
@@ -214,7 +214,7 @@ abstract contract FlowNFTBase is UUPSProxiable, IFlowNFTBase {
 
     function _flowDataString(
         uint256 tokenId
-    ) private view returns (string memory) {
+    ) internal view returns (string memory) {
         FlowNFTData memory flowData = flowDataByTokenId(tokenId);
 
         // @note taking this out to deal with the stack too deep issue

--- a/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeployer.sol
+++ b/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeployer.sol
@@ -133,7 +133,8 @@ contract SuperfluidFrameworkDeployer {
         // Deploy canonical Constant Outflow NFT logic contract
         ConstantOutflowNFT constantOutflowNFTLogic = new ConstantOutflowNFT(
             host,
-            IConstantInflowNFT(address(constantInflowNFTProxy))
+            IConstantInflowNFT(address(constantInflowNFTProxy)),
+            ""
         );
 
         // Initialize Constant Outflow NFT logic contract
@@ -142,7 +143,8 @@ contract SuperfluidFrameworkDeployer {
         // Deploy canonical Constant Inflow NFT logic contract
         ConstantInflowNFT constantInflowNFTLogic = new ConstantInflowNFT(
             host,
-            IConstantOutflowNFT(address(constantOutflowNFTProxy))
+            IConstantOutflowNFT(address(constantOutflowNFTProxy)),
+            ""
         );
 
         // Initialize Constant Inflow NFT logic contract

--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -131,6 +131,8 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
     cfaHookContract = cfaHookContract || process.env.CFA_HOOK_CONTRACT;
     console.log("CFA hook contract", cfaHookContract);
 
+    const NFT_BASE_URI = process.env.NFT_BASE_URI;
+
     // string to build a list of newly deployed contracts, written to a file if "outputFile" option set
     let output = "";
 
@@ -701,7 +703,11 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                 const constantOutflowNFTLogic = await web3tx(
                     ConstantOutflowNFT.new,
                     `ConstantOutflowNFT.new`
-                )(superfluid.address, constantInflowNFTProxy.address);
+                )(
+                    superfluid.address,
+                    constantInflowNFTProxy.address,
+                    NFT_BASE_URI
+                );
                 output += `CONSTANT_OUTFLOW_NFT_LOGIC_ADDRESS=${constantOutflowNFTLogic.address}\n`;
 
                 await constantOutflowNFTLogic.castrate();
@@ -709,7 +715,11 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                 const constantInflowNFTLogic = await web3tx(
                     ConstantOutflowNFT.new,
                     `ConstantOutflowNFT.new`
-                )(superfluid.address, constantOutflowNFTProxy.address);
+                )(
+                    superfluid.address,
+                    constantOutflowNFTProxy.address,
+                    NFT_BASE_URI
+                );
                 output += `CONSTANT_INFLOW_NFT_LOGIC_ADDRESS=${constantInflowNFTLogic.address}\n`;
 
                 await constantInflowNFTLogic.castrate();
@@ -756,7 +766,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                         const cofNFTLogic = await web3tx(
                             ConstantOutflowNFT.new,
                             "ConstantOutflowNFT.new"
-                        )(superfluid.address, cifNFTProxyAddress);
+                        )(superfluid.address, cifNFTProxyAddress, NFT_BASE_URI);
                         output += `CONSTANT_OUTFLOW_NFT_LOGIC_ADDRESS=${cofNFTLogic.address}\n`;
                         // castrate flow nft logic contract
                         await cofNFTLogic.castrate();
@@ -764,8 +774,14 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                     },
                     [
                         // See SuperToken constructor parameter
-                        superfluid.address.toLowerCase().slice(2).padStart(64, "0"),
-                        cifNFTProxyAddress.toLowerCase().slice(2).padStart(64, "0"),
+                        superfluid.address
+                            .toLowerCase()
+                            .slice(2)
+                            .padStart(64, "0"),
+                        cifNFTProxyAddress
+                            .toLowerCase()
+                            .slice(2)
+                            .padStart(64, "0"),
                     ]
                 );
                 const newCIFNFTLogic = await deployContractIfCodeChanged(
@@ -778,7 +794,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                         const cifNFTLogic = await web3tx(
                             ConstantInflowNFT.new,
                             "ConstantInflowNFT.new"
-                        )(superfluid.address, cofNFTProxyAddress);
+                        )(superfluid.address, cofNFTProxyAddress, NFT_BASE_URI);
                         output += `CONSTANT_INFLOW_NFT_LOGIC_ADDRESS=${cifNFTLogic.address}\n`;
                         // castrate flow nft logic contract
                         await cifNFTLogic.castrate();
@@ -786,8 +802,14 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                     },
                     [
                         // See SuperToken constructor parameter
-                        superfluid.address.toLowerCase().slice(2).padStart(64, "0"),
-                        cofNFTProxyAddress.toLowerCase().slice(2).padStart(64, "0"),
+                        superfluid.address
+                            .toLowerCase()
+                            .slice(2)
+                            .padStart(64, "0"),
+                        cofNFTProxyAddress
+                            .toLowerCase()
+                            .slice(2)
+                            .padStart(64, "0"),
                     ]
                 );
 

--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -127,7 +127,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
         console.log("output file: ", outputFile);
     }
 
-    const NFT_BASE_URI = process.env.NFT_BASE_URI;
+    const NFT_BASE_URI = process.env.NFT_BASE_URI || "";
 
     // string to build a list of newly deployed contracts, written to a file if "outputFile" option set
     let output = "";

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/ethereum-contracts",
-    "version": "1.5.2",
+    "version": "1.6.0",
     "description": " Ethereum contracts implementation for the Superfluid Protocol",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/ethereum-contracts#readme",
     "repository": {

--- a/packages/ethereum-contracts/test/foundry/superfluid/CFAv1NFTMock.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/CFAv1NFTMock.t.sol
@@ -31,8 +31,9 @@ import {
 contract ConstantOutflowNFTMock is ConstantOutflowNFT {
     constructor(
         ISuperfluid host,
-        IConstantInflowNFT constantInflowNFT
-    ) ConstantOutflowNFT(host, constantInflowNFT) {}
+        IConstantInflowNFT constantInflowNFT,
+        string memory baseURI
+    ) ConstantOutflowNFT(host, constantInflowNFT, baseURI) {}
 
     /// @dev a mock mint function that exposes the internal _mint function
     function mockMint(
@@ -63,8 +64,9 @@ contract ConstantOutflowNFTMock is ConstantOutflowNFT {
 contract ConstantInflowNFTMock is ConstantInflowNFT {
     constructor(
         ISuperfluid host,
-        IConstantOutflowNFT constantOutflowNFT
-    ) ConstantInflowNFT(host, constantOutflowNFT) {}
+        IConstantOutflowNFT constantOutflowNFT,
+        string memory baseURI
+    ) ConstantInflowNFT(host, constantOutflowNFT, baseURI) {}
 
     /// @dev a mock mint function to emit the mint Transfer event
     function mockMint(address _to, uint256 _newTokenId) public {

--- a/packages/ethereum-contracts/test/foundry/superfluid/FlowNFTBase.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/FlowNFTBase.t.sol
@@ -79,11 +79,13 @@ abstract contract FlowNFTBaseTest is FoundrySuperfluidTester {
         // we deploy mock NFT contracts for the tests to access internal functions
         constantOutflowNFTLogic = new ConstantOutflowNFTMock(
             sf.host,
-            IConstantInflowNFT(address(inflowProxy))
+            IConstantInflowNFT(address(inflowProxy)),
+            ""
         );
         constantInflowNFTLogic = new ConstantInflowNFTMock(
             sf.host,
-            IConstantOutflowNFT(address(outflowProxy))
+            IConstantOutflowNFT(address(outflowProxy)),
+            ""
         );
 
         constantOutflowNFTLogic.castrate();

--- a/packages/ethereum-contracts/test/foundry/superfluid/SuperToken.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/SuperToken.t.sol
@@ -33,11 +33,13 @@ contract SuperTokenTest is FoundrySuperfluidTester {
 
         ConstantInflowNFT cifNFTLogic = new ConstantInflowNFT(
             sf.host,
-            IConstantOutflowNFT(address(cofProxy))
+            IConstantOutflowNFT(address(cofProxy)),
+            ""
         );
         ConstantOutflowNFT cofNFTLogic = new ConstantOutflowNFT(
             sf.host,
-            IConstantInflowNFT(address(cifProxy))
+            IConstantInflowNFT(address(cifProxy)),
+            ""
         );
 
         cifNFTLogic.castrate();

--- a/packages/ethereum-contracts/test/foundry/superfluid/SuperTokenFactory.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/SuperTokenFactory.t.sol
@@ -36,11 +36,13 @@ contract SuperTokenFactoryTest is FoundrySuperfluidTester {
         );
         ConstantOutflowNFT newConstantOutflowNFTLogic = new ConstantOutflowNFT(
             sf.host,
-            IConstantInflowNFT(address(superToken.CONSTANT_INFLOW_NFT()))
+            IConstantInflowNFT(address(superToken.CONSTANT_INFLOW_NFT())),
+            ""
         );
         ConstantInflowNFT newConstantInflowNFTLogic = new ConstantInflowNFT(
             sf.host,
-            IConstantOutflowNFT(address(superToken.CONSTANT_OUTFLOW_NFT()))
+            IConstantOutflowNFT(address(superToken.CONSTANT_OUTFLOW_NFT())),
+            ""
         );
         assertEq(
             UUPSProxiable(address(superToken.CONSTANT_OUTFLOW_NFT()))

--- a/packages/ethereum-contracts/test/foundry/superfluid/nftUpgradability/CFAv1NFTUpgradability.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/nftUpgradability/CFAv1NFTUpgradability.t.sol
@@ -47,7 +47,8 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
     //////////////////////////////////////////////////////////////////////////*/
     function test_Storage_Layout_Of_FlowNFTBase() public {
         FlowNFTBaseStorageLayoutMock flowNFTBaseStorageLayoutMock = new FlowNFTBaseStorageLayoutMock(
-                sf.host
+                sf.host,
+                ""
             );
         flowNFTBaseStorageLayoutMock.validateStorageLayout();
     }
@@ -55,7 +56,8 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
     function test_Storage_Layout_Of_ConstantInflowNFT() public {
         ConstantInflowNFTStorageLayoutMock constantInflowNFTBaseStorageLayoutMock = new ConstantInflowNFTStorageLayoutMock(
                 sf.host,
-                constantOutflowNFTProxy
+                constantOutflowNFTProxy,
+                ""
             );
         constantInflowNFTBaseStorageLayoutMock.validateStorageLayout();
     }
@@ -63,7 +65,8 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
     function test_Storage_Layout_Of_ConstantOutflowNFT() public {
         ConstantOutflowNFTStorageLayoutMock constantOutflowNFTBaseStorageLayoutMock = new ConstantOutflowNFTStorageLayoutMock(
                 sf.host,
-                constantInflowNFTProxy
+                constantInflowNFTProxy,
+                ""
             );
         constantOutflowNFTBaseStorageLayoutMock.validateStorageLayout();
     }
@@ -77,7 +80,8 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
         vm.assume(notSuperTokenFactory != address(sf.superTokenFactory));
         ConstantOutflowNFT newOutflowLogic = new ConstantOutflowNFT(
             sf.host,
-            constantInflowNFTProxy
+            constantInflowNFTProxy,
+            ""
         );
         vm.expectRevert(IFlowNFTBase.CFA_NFT_ONLY_SUPER_TOKEN_FACTORY.selector);
         vm.prank(notSuperTokenFactory);
@@ -85,7 +89,8 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
 
         ConstantInflowNFT newInflowLogic = new ConstantInflowNFT(
             sf.host,
-            constantOutflowNFTProxy
+            constantOutflowNFTProxy,
+            ""
         );
         vm.expectRevert(IFlowNFTBase.CFA_NFT_ONLY_SUPER_TOKEN_FACTORY.selector);
         vm.prank(notSuperTokenFactory);
@@ -98,14 +103,16 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
     function test_Passing_NFT_Contracts_Can_Be_Upgraded_By_Host() public {
         ConstantOutflowNFT newOutflowLogic = new ConstantOutflowNFT(
             sf.host,
-            constantInflowNFTProxy
+            constantInflowNFTProxy,
+            ""
         );
         vm.prank(address(sf.superTokenFactory));
         constantOutflowNFTProxy.updateCode(address(newOutflowLogic));
 
         ConstantInflowNFT newInflowLogic = new ConstantInflowNFT(
             sf.host,
-            constantOutflowNFTProxy
+            constantOutflowNFTProxy,
+            ""
         );
         vm.prank(address(sf.superTokenFactory));
         constantInflowNFTProxy.updateCode(address(newInflowLogic));

--- a/packages/ethereum-contracts/test/foundry/superfluid/nftUpgradability/CFAv1NFTUpgradabilityMocks.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/nftUpgradability/CFAv1NFTUpgradabilityMocks.sol
@@ -34,8 +34,9 @@ contract FlowNFTBaseStorageLayoutMock is FlowNFTBase {
     error STORAGE_LOCATION_CHANGED(string _name);
 
     constructor(
-        ISuperfluid host
-    ) FlowNFTBase(host) {}
+        ISuperfluid host,
+        string memory baseURI
+    ) FlowNFTBase(host, baseURI) {}
 
     /// @notice Validates storage layout
     /// @dev This function is used by all the FlowNFTBase mock contracts to validate the layout
@@ -52,15 +53,18 @@ contract FlowNFTBaseStorageLayoutMock is FlowNFTBase {
 
         assembly { slot := _symbol.slot offset := _symbol.offset }
         if (slot != 2 || offset != 0) revert STORAGE_LOCATION_CHANGED("_symbol");
+
+        assembly { slot := _baseURI.slot offset := _baseURI.offset }
+        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("_baseURI");
         
         assembly { slot := _tokenApprovals.slot offset := _tokenApprovals.offset }
-        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
+        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
 
         assembly { slot := _operatorApprovals.slot offset := _operatorApprovals.offset }
-        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
+        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
 
-        assembly { slot := _reserve5.slot offset := _reserve5.offset }
-        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve5");
+        assembly { slot := _reserve6.slot offset := _reserve6.offset }
+        if (slot != 6 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve6");
 
         assembly { slot := _reserve21.slot offset := _reserve21.offset }
         if (slot != 21 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve21");
@@ -114,8 +118,9 @@ contract ConstantInflowNFTStorageLayoutMock is ConstantInflowNFT {
 
     constructor(
         ISuperfluid host,
-        IConstantOutflowNFT constantOutflowNFT
-    ) ConstantInflowNFT(host, constantOutflowNFT) {}
+        IConstantOutflowNFT constantOutflowNFT,
+        string memory baseURI
+    ) ConstantInflowNFT(host, constantOutflowNFT, baseURI) {}
 
     /// @notice Validates storage layout
     /// @dev This function is used to validate storage layout of ConstantInflowNFT
@@ -133,14 +138,17 @@ contract ConstantInflowNFTStorageLayoutMock is ConstantInflowNFT {
         assembly { slot := _symbol.slot offset := _symbol.offset }
         if (slot != 2 || offset != 0) revert STORAGE_LOCATION_CHANGED("_symbol");
         
+        assembly { slot := _baseURI.slot offset := _baseURI.offset }
+        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("_baseURI");
+        
         assembly { slot := _tokenApprovals.slot offset := _tokenApprovals.offset }
-        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
+        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
 
         assembly { slot := _operatorApprovals.slot offset := _operatorApprovals.offset }
-        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
+        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
 
-        assembly { slot := _reserve5.slot offset := _reserve5.offset }
-        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve5");
+        assembly { slot := _reserve6.slot offset := _reserve6.offset }
+        if (slot != 6 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve6");
 
         assembly { slot := _reserve21.slot offset := _reserve21.offset }
         if (slot != 21 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve21");
@@ -180,8 +188,9 @@ contract ConstantOutflowNFTStorageLayoutMock is ConstantOutflowNFT {
 
     constructor(
         ISuperfluid host,
-        IConstantInflowNFT constantInflowNFT
-    ) ConstantOutflowNFT(host, constantInflowNFT) {}
+        IConstantInflowNFT constantInflowNFT,
+        string memory baseURI
+    ) ConstantOutflowNFT(host, constantInflowNFT, baseURI) {}
 
     /// @notice Validates storage layout
     /// @dev This function is used to validate storage layout of ConstantOutflowNFT
@@ -199,14 +208,17 @@ contract ConstantOutflowNFTStorageLayoutMock is ConstantOutflowNFT {
         assembly { slot := _symbol.slot offset := _symbol.offset }
         if (slot != 2 || offset != 0) revert STORAGE_LOCATION_CHANGED("_symbol");
         
+        assembly { slot := _baseURI.slot offset := _baseURI.offset }
+        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("_baseURI");
+        
         assembly { slot := _tokenApprovals.slot offset := _tokenApprovals.offset }
-        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
+        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
 
         assembly { slot := _operatorApprovals.slot offset := _operatorApprovals.offset }
-        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
+        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
 
-        assembly { slot := _reserve5.slot offset := _reserve5.offset }
-        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve5");
+        assembly { slot := _reserve6.slot offset := _reserve6.offset }
+        if (slot != 6 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve6");
 
         assembly { slot := _reserve21.slot offset := _reserve21.offset }
         if (slot != 21 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve21");

--- a/packages/hot-fuzz/package.json
+++ b/packages/hot-fuzz/package.json
@@ -24,7 +24,7 @@
         "@superfluid-finance/ethereum-contracts": "1.2.2"
     },
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "1.5.2"
+        "@superfluid-finance/ethereum-contracts": "1.6.0"
     },
     "license": "AGPL-3.0",
     "bugs": {

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -52,7 +52,7 @@
         "@truffle/contract": "^4.0.0"
     },
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "1.5.2",
+        "@superfluid-finance/ethereum-contracts": "1.6.0",
         "chai-as-promised": "^7.1.1",
         "webpack": "^5.74.0",
         "webpack-bundle-analyzer": "^4.6.1",

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -56,7 +56,7 @@
     },
     "dependencies": {
         "@nomiclabs/hardhat-ethers": "^2.2.1",
-        "@superfluid-finance/ethereum-contracts": "1.5.2",
+        "@superfluid-finance/ethereum-contracts": "1.6.0",
         "@superfluid-finance/metadata": "git+https://github.com/superfluid-finance/metadata.git",
         "browserify": "^17.0.0",
         "graphql-request": "^4.3.0",

--- a/packages/solidity-semantic-money/package.json
+++ b/packages/solidity-semantic-money/package.json
@@ -21,9 +21,9 @@
     "solhint": "3.4.1"
   },
   "repository": {
-      "type": "git",
-      "url": "https://github.com/superfluid-finance/protocol-monorepo.git",
-      "directory": "packages/solidity-semantic-money"
+    "type": "git",
+    "url": "https://github.com/superfluid-finance/protocol-monorepo.git",
+    "directory": "packages/solidity-semantic-money"
   },
   "keywords": [
     "money",


### PR DESCRIPTION
**IMPORTANT: To set an NFT_BASE_URI, you must pass this as an environment variable when calling the workflow to deploy the framework.** 

## Changes
- bump version to 1.6.0
- update CHANGELOG.md
- make baseURI a constructor arg
- move part of baseURI into private function (gm stack too deep)