### PR TITLE
[SDK-core] prepare sdk-core 0.6.4 release

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [0.6.4] - 2023-05-07
+
 ### Changed
 - `getPopulatedTransactionRequest` doesn't use the signer to populate the transaction anymore as `signer.sendTransaction` does it already. The double `signer.populateTransaction` was causing issues with some wallets (e.g. Rainbow Wallet)
 - Map `isNativeAssetSuperToken` to `Token` from Subgraph

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-core",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "description": "SDK Core for building with Superfluid Protocol",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/sdk-core#readme",
     "repository": {

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -50,7 +50,7 @@
     "dependencies": {
         "@graphprotocol/graph-cli": "0.47.1",
         "@graphprotocol/graph-ts": "0.29.3",
-        "@superfluid-finance/sdk-core": "0.6.3",
+        "@superfluid-finance/sdk-core": "0.6.4",
         "mustache": "^4.2.0"
     },
     "devDependencies": {


### PR DESCRIPTION
The dev-package was battle-tested with the Superfluid Dashboard for the transactional part change.