### PR TITLE
[SUBGRAPH] rename networks.json to hosted-service-networks

### DIFF
--- a/packages/sdk-core/tasks/testSchemasAndQueries.sh
+++ b/packages/sdk-core/tasks/testSchemasAndQueries.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "$SUBGRAPH_RELEASE_TAG" == "dev" ] || [ "$SUBGRAPH_RELEASE_TAG" == "v1" ];then
     # shellcheck disable=SC2207
-    NETWORKS=( $($JQ -r .[] ../subgraph/networks.json) )
+    NETWORKS=( $($JQ -r .[] ../subgraph/hosted-service-networks.json) )
 fi
 
 function testSchemaAndQueries() {

--- a/packages/sdk-core/test/5_subgraph.test.ts
+++ b/packages/sdk-core/test/5_subgraph.test.ts
@@ -48,11 +48,14 @@ describe("Subgraph Tests", () => {
             if (process.env.SUBGRAPH_ENDPOINT === "") {
                 await Promise.all(
                     resolverDataArray.map(async (x) => {
-                        const query = new Query({
-                            customSubgraphQueriesEndpoint:
-                                x.subgraphAPIEndpoint,
-                        });
-                        await testGetAllEventsQuery(query);
+                        // @note skip eth-sepolia because it is not deployed on hosted-service
+                        if (x.networkName !== "eth-sepolia") {
+                            const query = new Query({
+                                customSubgraphQueriesEndpoint:
+                                    x.subgraphAPIEndpoint,
+                            });
+                            await testGetAllEventsQuery(query);
+                        }
                     })
                 );
             } else {

--- a/packages/subgraph/README.md
+++ b/packages/subgraph/README.md
@@ -316,7 +316,7 @@ If the subgraph has not been created yet, you must create it first using the das
 When adding new networks, we must do the following:
 
 -   NOTE: The `network` field in the `/config/*.json` file must match the official naming of the network name from the [subgraph docs](https://thegraph.com/docs/developer/create-subgraph-hosted#supported-networks). This name can deviate from the name of the file itself. e.g. `avalanche-c.json` must have field: `"network": "avalanche"`.
--   Add a new file to `./config`, the name of the file should be derived from the canonical network name in `packages/ethereum-contracts/truffle-config.js`. e.g. adding network `avalanche-c` to the array in `./networks.json` and then adding `avalanche-c.json` to `/config`. The name of the network specific file in `/config` will dictate our subgraph endpoint, e.g. `protocol-dev-avalanche-c`.
+-   Add a new file to `./config`, the name of the file should be derived from the canonical network name in `packages/ethereum-contracts/truffle-config.js`. e.g. adding network `avalanche-c` to the array in `./hosted-service-networks.json` and then adding `avalanche-c.json` to `/config`. The name of the network specific file in `/config` will dictate our subgraph endpoint, e.g. `protocol-dev-avalanche-c`.
 -   We also need to add the host and resolver addresses to the `addresses.template.ts` file. NOTE: the `network` we are comparing in the `addresses.template.test` file should match the `"network"` field in `/config/*.json`.
 
 # Contributing

--- a/packages/subgraph/hosted-service-networks.json
+++ b/packages/subgraph/hosted-service-networks.json
@@ -11,6 +11,5 @@
     "optimism-goerli",
     "avalanche-fuji",
     "bsc-mainnet",
-    "celo-mainnet",
-    "eth-sepolia"
+    "celo-mainnet"
 ]

--- a/packages/subgraph/tasks/deploy-all-hosted-service-networks.sh
+++ b/packages/subgraph/tasks/deploy-all-hosted-service-networks.sh
@@ -7,7 +7,7 @@ JQ="npx --package=node-jq -- jq"
 
 # TODO: get the networks from metadata.json networks file
 # shellcheck disable=SC2207
-HOSTED_SERVICE_NETWORKS=( $($JQ -r .[] ./networks.json) ) || exit 1
+HOSTED_SERVICE_NETWORKS=( $($JQ -r .[] ./hosted-service-networks.json) ) || exit 1
 
 for i in "${HOSTED_SERVICE_NETWORKS[@]}";do
     ./tasks/deploy-to-hosted-service-network.sh "$1" "$i"


### PR DESCRIPTION
## Problem

Sepolia doesn't have hosted service subgraph support. This is currently breaking builds (daily check and SDK-release).

## Solution

A quick solution is to remove eth-sepolia from the `networks.json` file.
In addition, we rename `networks.json` to `hosted-service-networks.json` to differentiate it from the multiple subgraph sources we currently support and will support down the line:
- hosted service
- satsuma
- graph studio (staging)
- decentralized subgraph
- self-hosted