### PR TITLE
[SUBGRAPH] Bump subgraph version for tag

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/subgraph",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "Subgraph for the Superfluid Ethereum contracts.",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/subgraph",
     "repository": {


### PR DESCRIPTION
## Summary
It has been a while since the last subgraph version bump and recently ran into a situation where it might've been useful to have a tag to point to.

## Release Notes
### Added
- celo and eth-sepolia support
- SuperTokenMinimumDepositChangedEvent added
- `userData` property added to `Stream` entity
- `allowance` property added to `FlowOperator` entity
- `TokenGovernanceConfig` added
- `activeOutgoingStreamCount`, `activeIncomingStreamCount` added to `AccountTokenSnapshot` entity

### Changes
- bash scripts for subgraph deployment changed