### PR TITLE
[ETHEREUM-CONTRACTS] flow nft cleanup/fixes

### DIFF
--- a/.github/workflows/cd.ethereum-contracts-stable.create-release-drafts.yml
+++ b/.github/workflows/cd.ethereum-contracts-stable.create-release-drafts.yml
@@ -18,6 +18,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions: write-all
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/cd.sdk-core-stable.create-release-drafts.yml
+++ b/.github/workflows/cd.sdk-core-stable.create-release-drafts.yml
@@ -35,6 +35,8 @@ jobs:
     needs: [ test-sdk-core-query-schema-against-deployed-v1-subgraphs
            , test-sdk-core-with-v1-release-subgraph
            ]
+    
+    permissions: write-all
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cd.sdk-redux-stable.create-release-drafts.yml
+++ b/.github/workflows/cd.sdk-redux-stable.create-release-drafts.yml
@@ -18,6 +18,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions: write-all
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/cd.subgraph-stable.create-release-drafts.yml
+++ b/.github/workflows/cd.subgraph-stable.create-release-drafts.yml
@@ -16,6 +16,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions: write-all
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/handler.changelog-reminder.yml
+++ b/.github/workflows/handler.changelog-reminder.yml
@@ -25,6 +25,10 @@ jobs:
   create-reminder:
     name: Create Changelog reminder in PR discussion
 
+    permissions:
+      pull-requests: write
+      issues: write
+
     runs-on: ubuntu-latest
 
     needs: [check]

--- a/.github/workflows/handler.publish-pr-packages.yml
+++ b/.github/workflows/handler.publish-pr-packages.yml
@@ -12,6 +12,8 @@ jobs:
   publish_pr_packages:
     name: NPM publish PR to Github
 
+    permissions: write-all
+
     runs-on: ubuntu-latest
 
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/handler.xkcd.yml
+++ b/.github/workflows/handler.xkcd.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   post-xkcd:
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      issues: write
+      
     if: github.event.pull_request.merged == true
     steps:
       - name: Search relif

--- a/packages/ethereum-contracts/contracts/mocks/CFAv1NFTMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFAv1NFTMock.sol
@@ -32,9 +32,8 @@ import {
 contract ConstantOutflowNFTMock is ConstantOutflowNFT {
     constructor(
         ISuperfluid host,
-        IConstantInflowNFT constantInflowNFT,
-        string memory baseURI
-    ) ConstantOutflowNFT(host, constantInflowNFT, baseURI) {}
+        IConstantInflowNFT constantInflowNFT
+    ) ConstantOutflowNFT(host, constantInflowNFT) {}
 
     /// @dev a mock mint function that exposes the internal _mint function
     function mockMint(
@@ -65,9 +64,8 @@ contract ConstantOutflowNFTMock is ConstantOutflowNFT {
 contract ConstantInflowNFTMock is ConstantInflowNFT {
     constructor(
         ISuperfluid host,
-        IConstantOutflowNFT constantOutflowNFT,
-        string memory baseURI
-    ) ConstantInflowNFT(host, constantOutflowNFT, baseURI) {}
+        IConstantOutflowNFT constantOutflowNFT
+    ) ConstantInflowNFT(host, constantOutflowNFT) {}
 
     /// @dev a mock mint function to emit the mint Transfer event
     function mockMint(address _to, uint256 _newTokenId) public {

--- a/packages/ethereum-contracts/contracts/mocks/CFAv1NFTUpgradabilityMock.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFAv1NFTUpgradabilityMock.sol
@@ -34,9 +34,8 @@ contract FlowNFTBaseStorageLayoutMock is FlowNFTBase {
     error STORAGE_LOCATION_CHANGED(string _name);
 
     constructor(
-        ISuperfluid host,
-        string memory baseURI
-    ) FlowNFTBase(host, baseURI) {}
+        ISuperfluid host
+    ) FlowNFTBase(host) {}
 
     /// @notice Validates storage layout
     /// @dev This function is used by all the FlowNFTBase mock contracts to validate the layout
@@ -53,18 +52,15 @@ contract FlowNFTBaseStorageLayoutMock is FlowNFTBase {
 
         assembly { slot := _symbol.slot offset := _symbol.offset }
         if (slot != 2 || offset != 0) revert STORAGE_LOCATION_CHANGED("_symbol");
-
-        assembly { slot := baseURI.slot offset := baseURI.offset }
-        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("baseURI");
         
         assembly { slot := _tokenApprovals.slot offset := _tokenApprovals.offset }
-        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
+        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
 
         assembly { slot := _operatorApprovals.slot offset := _operatorApprovals.offset }
-        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
+        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
 
-        assembly { slot := _reserve6.slot offset := _reserve6.offset }
-        if (slot != 6 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve6");
+        assembly { slot := _reserve5.slot offset := _reserve5.offset }
+        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve5");
 
         assembly { slot := _reserve21.slot offset := _reserve21.offset }
         if (slot != 21 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve21");
@@ -118,9 +114,8 @@ contract ConstantInflowNFTStorageLayoutMock is ConstantInflowNFT {
 
     constructor(
         ISuperfluid host,
-        IConstantOutflowNFT constantOutflowNFT,
-        string memory baseURI
-    ) ConstantInflowNFT(host, constantOutflowNFT, baseURI) {}
+        IConstantOutflowNFT constantOutflowNFT
+    ) ConstantInflowNFT(host, constantOutflowNFT) {}
 
     /// @notice Validates storage layout
     /// @dev This function is used to validate storage layout of ConstantInflowNFT
@@ -137,18 +132,15 @@ contract ConstantInflowNFTStorageLayoutMock is ConstantInflowNFT {
 
         assembly { slot := _symbol.slot offset := _symbol.offset }
         if (slot != 2 || offset != 0) revert STORAGE_LOCATION_CHANGED("_symbol");
-        
-        assembly { slot := baseURI.slot offset := baseURI.offset }
-        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("baseURI");
-        
+
         assembly { slot := _tokenApprovals.slot offset := _tokenApprovals.offset }
-        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
+        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
 
         assembly { slot := _operatorApprovals.slot offset := _operatorApprovals.offset }
-        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
+        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
 
-        assembly { slot := _reserve6.slot offset := _reserve6.offset }
-        if (slot != 6 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve6");
+        assembly { slot := _reserve5.slot offset := _reserve5.offset }
+        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve5");
 
         assembly { slot := _reserve21.slot offset := _reserve21.offset }
         if (slot != 21 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve21");
@@ -188,9 +180,8 @@ contract ConstantOutflowNFTStorageLayoutMock is ConstantOutflowNFT {
 
     constructor(
         ISuperfluid host,
-        IConstantInflowNFT constantInflowNFT,
-        string memory baseURI
-    ) ConstantOutflowNFT(host, constantInflowNFT, baseURI) {}
+        IConstantInflowNFT constantInflowNFT
+    ) ConstantOutflowNFT(host, constantInflowNFT) {}
 
     /// @notice Validates storage layout
     /// @dev This function is used to validate storage layout of ConstantOutflowNFT
@@ -207,18 +198,15 @@ contract ConstantOutflowNFTStorageLayoutMock is ConstantOutflowNFT {
 
         assembly { slot := _symbol.slot offset := _symbol.offset }
         if (slot != 2 || offset != 0) revert STORAGE_LOCATION_CHANGED("_symbol");
-        
-        assembly { slot := baseURI.slot offset := baseURI.offset }
-        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("baseURI");
-        
+
         assembly { slot := _tokenApprovals.slot offset := _tokenApprovals.offset }
-        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
+        if (slot != 3 || offset != 0) revert STORAGE_LOCATION_CHANGED("_tokenApprovals");
 
         assembly { slot := _operatorApprovals.slot offset := _operatorApprovals.offset }
-        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
+        if (slot != 4 || offset != 0) revert STORAGE_LOCATION_CHANGED("_operatorApprovals");
 
-        assembly { slot := _reserve6.slot offset := _reserve6.offset }
-        if (slot != 6 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve6");
+        assembly { slot := _reserve5.slot offset := _reserve5.offset }
+        if (slot != 5 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve5");
 
         assembly { slot := _reserve21.slot offset := _reserve21.offset }
         if (slot != 21 || offset != 0) revert STORAGE_LOCATION_CHANGED("_reserve21");

--- a/packages/ethereum-contracts/contracts/superfluid/ConstantInflowNFT.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/ConstantInflowNFT.sol
@@ -27,9 +27,8 @@ contract ConstantInflowNFT is FlowNFTBase, IConstantInflowNFT {
     // solhint-disable-next-line no-empty-blocks
     constructor(
         ISuperfluid host,
-        IConstantOutflowNFT constantOutflowNFT,
-        string memory baseURI
-    ) FlowNFTBase(host, baseURI) {
+        IConstantOutflowNFT constantOutflowNFT
+    ) FlowNFTBase(host) {
         CONSTANT_OUTFLOW_NFT = constantOutflowNFT;
     }
 

--- a/packages/ethereum-contracts/contracts/superfluid/ConstantOutflowNFT.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/ConstantOutflowNFT.sol
@@ -36,9 +36,8 @@ contract ConstantOutflowNFT is FlowNFTBase, IConstantOutflowNFT {
     // solhint-disable-next-line no-empty-blocks
     constructor(
         ISuperfluid host,
-        IConstantInflowNFT constantInflowNFT,
-        string memory baseURI
-    ) FlowNFTBase(host, baseURI) {
+        IConstantInflowNFT constantInflowNFT
+    ) FlowNFTBase(host) {
         CONSTANT_INFLOW_NFT = constantInflowNFT;
     }
 

--- a/packages/ethereum-contracts/contracts/superfluid/FlowNFTBase.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/FlowNFTBase.sol
@@ -32,6 +32,8 @@ import {
 abstract contract FlowNFTBase is UUPSProxiable, IFlowNFTBase {
     using Strings for uint256;
 
+    string public constant baseURI = "https://nft.superfluid.finance/cfa/v2/getmeta";
+
     /// @notice ConstantFlowAgreementV1 contract address
     /// @dev This is the address of the CFAv1 contract cached so we don't have to
     /// do an external call for every flow created.
@@ -55,7 +57,6 @@ abstract contract FlowNFTBase is UUPSProxiable, IFlowNFTBase {
 
     string internal _name;
     string internal _symbol;
-    string public baseURI;
 
     /// @notice Mapping for token approvals
     /// @dev tokenID => approved address mapping
@@ -72,7 +73,8 @@ abstract contract FlowNFTBase is UUPSProxiable, IFlowNFTBase {
     /// We use this pattern in SuperToken.sol and favor this over the OpenZeppelin pattern
     /// as this prevents silly footgunning.
     /// See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-    uint256 internal _reserve6;
+    uint256 internal _reserve5;
+    uint256 private _reserve6;
     uint256 private _reserve7;
     uint256 private _reserve8;
     uint256 private _reserve9;
@@ -89,7 +91,7 @@ abstract contract FlowNFTBase is UUPSProxiable, IFlowNFTBase {
     uint256 private _reserve20;
     uint256 internal _reserve21;
 
-    constructor(ISuperfluid host, string memory baseURI_) {
+    constructor(ISuperfluid host) {
         HOST = host;
         CONSTANT_FLOW_AGREEMENT_V1 = IConstantFlowAgreementV1(
             address(
@@ -99,7 +101,6 @@ abstract contract FlowNFTBase is UUPSProxiable, IFlowNFTBase {
                 )
             )
         );
-        baseURI = baseURI_;
     }
 
     function initialize(

--- a/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol
@@ -129,18 +129,17 @@ abstract contract SuperTokenFactoryBase is
         // Upgrade the Flow NFT logic contracts on the canonical proxies
         // We only do this if the new logic contracts passed in updating the SuperTokenFactory
         // are different from the current logic contracts
+        SuperTokenFactory newFactory = SuperTokenFactory(newAddress);
+        address newConstantOutflowLogic = address(newFactory.CONSTANT_OUTFLOW_NFT_LOGIC());
+        address newConstantInflowLogic = address(newFactory.CONSTANT_INFLOW_NFT_LOGIC());
+
         if (
-            address(CONSTANT_OUTFLOW_NFT_LOGIC) !=
-            UUPSProxiable(address(_SUPER_TOKEN_LOGIC.CONSTANT_OUTFLOW_NFT()))
-                .getCodeAddress() ||
-            address(CONSTANT_INFLOW_NFT_LOGIC) !=
-            UUPSProxiable(address(_SUPER_TOKEN_LOGIC.CONSTANT_INFLOW_NFT()))
-                .getCodeAddress()
+            address(CONSTANT_OUTFLOW_NFT_LOGIC) != newConstantOutflowLogic
+                || address(CONSTANT_INFLOW_NFT_LOGIC) != newConstantInflowLogic
         ) {
-            UUPSProxiable(address(_SUPER_TOKEN_LOGIC.CONSTANT_OUTFLOW_NFT()))
-                .updateCode(address(CONSTANT_OUTFLOW_NFT_LOGIC));
-            UUPSProxiable(address(_SUPER_TOKEN_LOGIC.CONSTANT_INFLOW_NFT()))
-                .updateCode(address(CONSTANT_INFLOW_NFT_LOGIC));
+            UUPSProxiable(address(_SUPER_TOKEN_LOGIC.CONSTANT_OUTFLOW_NFT())).updateCode(newConstantOutflowLogic);
+
+            UUPSProxiable(address(_SUPER_TOKEN_LOGIC.CONSTANT_INFLOW_NFT())).updateCode(newConstantInflowLogic);
         }
     }
 

--- a/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SuperTokenFactory.sol
@@ -133,12 +133,11 @@ abstract contract SuperTokenFactoryBase is
         address newConstantOutflowLogic = address(newFactory.CONSTANT_OUTFLOW_NFT_LOGIC());
         address newConstantInflowLogic = address(newFactory.CONSTANT_INFLOW_NFT_LOGIC());
 
-        if (
-            address(CONSTANT_OUTFLOW_NFT_LOGIC) != newConstantOutflowLogic
-                || address(CONSTANT_INFLOW_NFT_LOGIC) != newConstantInflowLogic
-        ) {
+        if (address(CONSTANT_OUTFLOW_NFT_LOGIC) != newConstantOutflowLogic) {
             UUPSProxiable(address(_SUPER_TOKEN_LOGIC.CONSTANT_OUTFLOW_NFT())).updateCode(newConstantOutflowLogic);
+        }
 
+        if (address(CONSTANT_INFLOW_NFT_LOGIC) != newConstantInflowLogic) {
             UUPSProxiable(address(_SUPER_TOKEN_LOGIC.CONSTANT_INFLOW_NFT())).updateCode(newConstantInflowLogic);
         }
     }

--- a/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeploymentSteps.sol
+++ b/packages/ethereum-contracts/contracts/utils/SuperfluidFrameworkDeploymentSteps.sol
@@ -500,7 +500,7 @@ library SuperfluidNFTLogicDeployerLibrary {
         ISuperfluid _host,
         IConstantInflowNFT _constantInflowNFTProxy
     ) external returns (ConstantOutflowNFT) {
-        return new ConstantOutflowNFT(_host, _constantInflowNFTProxy, "");
+        return new ConstantOutflowNFT(_host, _constantInflowNFTProxy);
     }
 
     /// @notice deploys the Superfluid ConstantInflowNFT contract
@@ -511,7 +511,7 @@ library SuperfluidNFTLogicDeployerLibrary {
         ISuperfluid _host,
         IConstantOutflowNFT _constantOutflowNFTProxy
     ) external returns (ConstantInflowNFT) {
-        return new ConstantInflowNFT(_host, _constantOutflowNFTProxy, "");
+        return new ConstantInflowNFT(_host, _constantOutflowNFTProxy);
     }
 }
 

--- a/packages/ethereum-contracts/ops-scripts/validate-nft-addresses.ts
+++ b/packages/ethereum-contracts/ops-scripts/validate-nft-addresses.ts
@@ -1,0 +1,49 @@
+import { ethers } from "hardhat";
+import metadata from "@superfluid-finance/metadata";
+
+async function main() {
+    const networkId = (await ethers.provider.getNetwork()).chainId;
+    const RESOLVER_ADDRESS = metadata.getNetworkByChainId(networkId)?.contractsV1.resolver;
+    const resolver = await ethers.getContractAt("Resolver", RESOLVER_ADDRESS || "");
+    const hostAddress = await resolver.get("Superfluid.v1");
+    const hostContract = await ethers.getContractAt("Superfluid", hostAddress);
+    const superTokenFactoryAddress = await hostContract.getSuperTokenFactory();
+    const superTokenFactoryContract = await ethers.getContractAt("SuperTokenFactory", superTokenFactoryAddress);
+    console.log("superTokenFactoryAddress", superTokenFactoryAddress);
+    
+    const constantOutflowNFTCanonicalLogic = await superTokenFactoryContract.CONSTANT_OUTFLOW_NFT_LOGIC();
+    console.log("constantOutflowNFTCanonicalLogic", constantOutflowNFTCanonicalLogic);
+    const constantInflowNFTCanonicalLogic = await superTokenFactoryContract.CONSTANT_INFLOW_NFT_LOGIC();
+    console.log("constantInflowNFTCanonicalLogic", constantInflowNFTCanonicalLogic);
+
+    const superTokenFactoryLogicAddress = await hostContract.getSuperTokenFactoryLogic();
+    console.log("superTokenFactoryLogicAddress", superTokenFactoryLogicAddress);
+    const superTokenLogicAddress = await superTokenFactoryContract.getSuperTokenLogic();
+    const superTokenLogicContract = await ethers.getContractAt("SuperToken", superTokenLogicAddress);
+
+    const constantOutflowNFProxy = await superTokenLogicContract.CONSTANT_OUTFLOW_NFT();
+    const cofNFTContract = await ethers.getContractAt("ConstantOutflowNFT", constantOutflowNFProxy);
+    console.log("constantOutflowNFProxy", constantOutflowNFProxy);
+    const outflowProxyLogic = await cofNFTContract.getCodeAddress();
+    console.log("outflowProxyLogic", outflowProxyLogic);
+    console.log("cof baseURI", await cofNFTContract.baseURI());
+
+    const constantInflowNFProxy = await superTokenLogicContract.CONSTANT_INFLOW_NFT();
+    console.log("constantInflowNFProxy", constantInflowNFProxy);
+    const cifNFTContract = await ethers.getContractAt("ConstantInflowNFT", constantInflowNFProxy);
+    const inflowProxyLogic = await cifNFTContract.getCodeAddress();
+    console.log("inflowProxyLogic", inflowProxyLogic);
+    const differentImplementations = await cofNFTContract.proxiableUUID() !== await cifNFTContract.proxiableUUID();
+    console.log("nft's have different implementations:", differentImplementations);
+    console.log("cif baseURI", await cofNFTContract.baseURI());
+
+    if (!differentImplementations) throw new Error("nft's have the same implementation");
+
+    console.log("outflow proxy logic equal canonical logic", outflowProxyLogic === constantOutflowNFTCanonicalLogic);
+    console.log("inflow proxy logic equal canonical logic", inflowProxyLogic === constantInflowNFTCanonicalLogic);
+
+    if (outflowProxyLogic !== constantOutflowNFTCanonicalLogic) throw new Error("outflow proxy logic not equal canonical logic");
+    if (inflowProxyLogic !== constantInflowNFTCanonicalLogic) throw new Error("inflow proxy logic not equal canonical logic");
+}
+
+main();

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -84,6 +84,7 @@
     },
     "devDependencies": {
         "@nomiclabs/hardhat-truffle5": "^2.0.7",
+        "@superfluid-finance/metadata": "git+https://github.com/superfluid-finance/metadata.git",
         "async": "^3.2.4",
         "csv-writer": "^1.6.0",
         "ganache-time-traveler": "1.0.16",

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -32,7 +32,7 @@
     "scripts": {
         "dev": "tasks/dev.sh",
         "dev-forge": "nodemon -e sol -x yarn run-forge test --hardhat",
-        "clean": "rm -rf node_modules; rm -rf cache; rm -rf build; rm -rf artifacts; rm -rf typechain-types; rm -rf scripts/*.d.ts scripts/*.d.ts.map",
+        "clean": "rm -rf node_modules; rm -rf cache; rm -rf build; rm -rf artifacts; rm -rf typechain-types; rm -rf dev-scripts/*.d.ts dev-scripts/*.d.ts.map",
         "run-hardhat": "IS_HARDHAT=true hardhat",
         "run-truffle": "IS_TRUFFLE=true truffle",
         "run-forge": "IS_FOUNDRY=true forge",

--- a/packages/ethereum-contracts/test/foundry/superfluid/ConstantOutflowNFT.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/ConstantOutflowNFT.t.sol
@@ -694,7 +694,7 @@ function testRevertIfInternalMintToZeroAddress(
             constantOutflowNFTProxy.tokenURI(nftId),
             string(
                 abi.encodePacked(
-                    "?flowRate=",
+                    "https://nft.superfluid.finance/cfa/v2/getmeta?flowRate=",
                     uint256(uint96(flowRate)).toString(),
                     "&outgoing=true",
                     "&token_address=",

--- a/packages/ethereum-contracts/test/foundry/superfluid/FlowNFTBase.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/FlowNFTBase.t.sol
@@ -85,13 +85,11 @@ abstract contract FlowNFTBaseTest is FoundrySuperfluidTester {
         // we deploy mock NFT contracts for the tests to access internal functions
         constantOutflowNFTLogic = new ConstantOutflowNFTMock(
             sf.host,
-            IConstantInflowNFT(address(inflowProxy)),
-            ""
+            IConstantInflowNFT(address(inflowProxy))
         );
         constantInflowNFTLogic = new ConstantInflowNFTMock(
             sf.host,
-            IConstantOutflowNFT(address(outflowProxy)),
-            ""
+            IConstantOutflowNFT(address(outflowProxy))
         );
 
         constantOutflowNFTLogic.castrate();
@@ -403,8 +401,7 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
     //////////////////////////////////////////////////////////////////////////*/
     function testStorageLayoutOfFlowNFTBase() public {
         FlowNFTBaseStorageLayoutMock flowNFTBaseStorageLayoutMock = new FlowNFTBaseStorageLayoutMock(
-                sf.host,
-                ""
+                sf.host
             );
         flowNFTBaseStorageLayoutMock.validateStorageLayout();
     }
@@ -412,8 +409,7 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
     function testStorageLayoutOfConstantInflowNFT() public {
         ConstantInflowNFTStorageLayoutMock constantInflowNFTBaseStorageLayoutMock = new ConstantInflowNFTStorageLayoutMock(
                 sf.host,
-                constantOutflowNFTProxy,
-                ""
+                constantOutflowNFTProxy
             );
         constantInflowNFTBaseStorageLayoutMock.validateStorageLayout();
     }
@@ -421,8 +417,7 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
     function testStorageLayoutOfConstantOutflowNFT() public {
         ConstantOutflowNFTStorageLayoutMock constantOutflowNFTBaseStorageLayoutMock = new ConstantOutflowNFTStorageLayoutMock(
                 sf.host,
-                constantInflowNFTProxy,
-                ""
+                constantInflowNFTProxy
             );
         constantOutflowNFTBaseStorageLayoutMock.validateStorageLayout();
     }
@@ -436,8 +431,7 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
         vm.assume(notSuperTokenFactory != address(sf.superTokenFactory));
         ConstantOutflowNFT newOutflowLogic = new ConstantOutflowNFT(
             sf.host,
-            constantInflowNFTProxy,
-            ""
+            constantInflowNFTProxy
         );
         vm.expectRevert(IFlowNFTBase.CFA_NFT_ONLY_SUPER_TOKEN_FACTORY.selector);
         vm.prank(notSuperTokenFactory);
@@ -445,8 +439,7 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
 
         ConstantInflowNFT newInflowLogic = new ConstantInflowNFT(
             sf.host,
-            constantOutflowNFTProxy,
-            ""
+            constantOutflowNFTProxy
         );
         vm.expectRevert(IFlowNFTBase.CFA_NFT_ONLY_SUPER_TOKEN_FACTORY.selector);
         vm.prank(notSuperTokenFactory);
@@ -459,16 +452,14 @@ contract ConstantFAv1NFTsUpgradabilityTest is FlowNFTBaseTest {
     function testNFTContractsCanBeUpgradedByHost() public {
         ConstantOutflowNFT newOutflowLogic = new ConstantOutflowNFT(
             sf.host,
-            constantInflowNFTProxy,
-            ""
+            constantInflowNFTProxy
         );
         vm.prank(address(sf.superTokenFactory));
         constantOutflowNFTProxy.updateCode(address(newOutflowLogic));
 
         ConstantInflowNFT newInflowLogic = new ConstantInflowNFT(
             sf.host,
-            constantOutflowNFTProxy,
-            ""
+            constantOutflowNFTProxy
         );
         vm.prank(address(sf.superTokenFactory));
         constantInflowNFTProxy.updateCode(address(newInflowLogic));

--- a/packages/ethereum-contracts/test/foundry/superfluid/SuperToken.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/SuperToken.t.sol
@@ -33,13 +33,11 @@ contract SuperTokenTest is FoundrySuperfluidTester {
 
         ConstantInflowNFT cifNFTLogic = new ConstantInflowNFT(
             sf.host,
-            IConstantOutflowNFT(address(cofProxy)),
-            ""
+            IConstantOutflowNFT(address(cofProxy))
         );
         ConstantOutflowNFT cofNFTLogic = new ConstantOutflowNFT(
             sf.host,
-            IConstantInflowNFT(address(cifProxy)),
-            ""
+            IConstantInflowNFT(address(cifProxy))
         );
 
         cifNFTLogic.castrate();

--- a/packages/ethereum-contracts/test/foundry/superfluid/SuperTokenFactory.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/SuperTokenFactory.t.sol
@@ -36,13 +36,11 @@ contract SuperTokenFactoryTest is FoundrySuperfluidTester {
         );
         ConstantOutflowNFT newConstantOutflowNFTLogic = new ConstantOutflowNFT(
             sf.host,
-            IConstantInflowNFT(address(superToken.CONSTANT_INFLOW_NFT())),
-            ""
+            IConstantInflowNFT(address(superToken.CONSTANT_INFLOW_NFT()))
         );
         ConstantInflowNFT newConstantInflowNFTLogic = new ConstantInflowNFT(
             sf.host,
-            IConstantOutflowNFT(address(superToken.CONSTANT_OUTFLOW_NFT())),
-            ""
+            IConstantOutflowNFT(address(superToken.CONSTANT_OUTFLOW_NFT()))
         );
         assertEq(
             UUPSProxiable(address(superToken.CONSTANT_OUTFLOW_NFT()))

--- a/packages/ethereum-contracts/tsconfig.json
+++ b/packages/ethereum-contracts/tsconfig.json
@@ -101,5 +101,5 @@
         // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
         "skipLibCheck": true /* Skip type checking all .d.ts files. */
     },
-    "include": ["testsuites", "test", "./typechain-types", "scripts", "hardhat.config.ts"]
+    "include": ["testsuites", "test", "./typechain-types", "ops-scripts", "hardhat.config.ts"]
 }


### PR DESCRIPTION
- Contracts AND deploy scripts cleaned up
- add metadata to ethereum-contracts
- FlowNFT's do not take baseURI in constructor, it is a constant variable now, no longer in storage
- SuperTokenFactory fixed to check existing canonical addresses against new contract canonical logic addresses
- add validate nft deployments addresses script