### PR TITLE
[ETHEREUM-CONTRACTS] Fix SuperTokenV1Library hash

### DIFF
--- a/packages/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol
+++ b/packages/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol
@@ -1566,7 +1566,7 @@ library SuperTokenV1Library {
             }
             cfa = IConstantFlowAgreementV1(address(ISuperfluid(host).getAgreementClass(
                 //keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1")
-                    0xa9214cc96615e0085d3bb077758db69497dc2dce3b2b1e97bc93c3d18d83efd3)));
+                0xa9214cc96615e0085d3bb077758db69497dc2dce3b2b1e97bc93c3d18d83efd3)));
             // now that we got them and are in a transaction context, persist in storage
             assembly {
             // solium-disable-line
@@ -1594,7 +1594,8 @@ library SuperTokenV1Library {
                 host = ISuperfluid(token.getHost());
             }
             ida = IInstantDistributionAgreementV1(address(ISuperfluid(host).getAgreementClass(
-                    keccak256("org.superfluid-finance.agreements.InstantDistributionAgreement.v1"))));
+                //keccak256("org.superfluid-finance.agreements.InstantDistributionAgreement.v1")
+                0x8aedc3b5d4bf031e11a7e2940f7251c005698405d58e02e1c247fed3b1b3a674)));
             // now that we got them and are in a transaction context, persist in storage
             assembly {
             // solium-disable-line
@@ -1623,7 +1624,7 @@ library SuperTokenV1Library {
             }
             cfa = IConstantFlowAgreementV1(address(ISuperfluid(host).getAgreementClass(
                 //keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1")
-                    0xa9214cc96615e0085d3bb077758db69497dc2dce3b2b1e97bc93c3d18d83efd3)));
+                0xa9214cc96615e0085d3bb077758db69497dc2dce3b2b1e97bc93c3d18d83efd3)));
         }
         assert(address(host) != address(0));
         assert(address(cfa) != address(0));
@@ -1646,7 +1647,7 @@ library SuperTokenV1Library {
             }
             ida = IInstantDistributionAgreementV1(address(ISuperfluid(host).getAgreementClass(
                 //keccak256("org.superfluid-finance.agreements.InstantDistributionAgreement.v1")
-                    0x15609310ae3c30189a1218b7adabaf36c267255e70cf91b6cba384367d9eda32)));
+                0x8aedc3b5d4bf031e11a7e2940f7251c005698405d58e02e1c247fed3b1b3a674)));
         }
         assert(address(host) != address(0));
         assert(address(ida) != address(0));

--- a/packages/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol
+++ b/packages/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol
@@ -1542,12 +1542,9 @@ library SuperTokenV1Library {
 
     // ************** private helpers **************
 
-    // keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.host")
-    bytes32 private constant _HOST_SLOT = 0x65599bf746e17a00ea62e3610586992d88101b78eec3cf380706621fb97ea837;
-    // keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.cfa")
-    bytes32 private constant _CFA_SLOT = 0xb969d79d88acd02d04ed7ee7d43b949e7daf093d363abcfbbc43dfdfd1ce969a;
-    // keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.ida");
-    bytes32 private constant _IDA_SLOT = 0xa832ee1924ea960211af2df07d65d166232018f613ac6708043cd8f8773eddeb;
+    bytes32 private constant _HOST_SLOT = keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.host");
+    bytes32 private constant _CFA_SLOT = keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.cfa");
+    bytes32 private constant _IDA_SLOT = keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.ida");
 
     // gets the host and cfa addrs for the token and caches it in storage for gas efficiency
     // to be used in state changing methods
@@ -1565,8 +1562,7 @@ library SuperTokenV1Library {
                 host = ISuperfluid(token.getHost());
             }
             cfa = IConstantFlowAgreementV1(address(ISuperfluid(host).getAgreementClass(
-                //keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1")
-                0xa9214cc96615e0085d3bb077758db69497dc2dce3b2b1e97bc93c3d18d83efd3)));
+                keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1"))));
             // now that we got them and are in a transaction context, persist in storage
             assembly {
             // solium-disable-line
@@ -1594,8 +1590,7 @@ library SuperTokenV1Library {
                 host = ISuperfluid(token.getHost());
             }
             ida = IInstantDistributionAgreementV1(address(ISuperfluid(host).getAgreementClass(
-                //keccak256("org.superfluid-finance.agreements.InstantDistributionAgreement.v1")
-                0x8aedc3b5d4bf031e11a7e2940f7251c005698405d58e02e1c247fed3b1b3a674)));
+                keccak256("org.superfluid-finance.agreements.InstantDistributionAgreement.v1"))));
             // now that we got them and are in a transaction context, persist in storage
             assembly {
             // solium-disable-line
@@ -1623,8 +1618,7 @@ library SuperTokenV1Library {
                 host = ISuperfluid(token.getHost());
             }
             cfa = IConstantFlowAgreementV1(address(ISuperfluid(host).getAgreementClass(
-                //keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1")
-                0xa9214cc96615e0085d3bb077758db69497dc2dce3b2b1e97bc93c3d18d83efd3)));
+                keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1"))));
         }
         assert(address(host) != address(0));
         assert(address(cfa) != address(0));
@@ -1646,8 +1640,7 @@ library SuperTokenV1Library {
                 host = ISuperfluid(token.getHost());
             }
             ida = IInstantDistributionAgreementV1(address(ISuperfluid(host).getAgreementClass(
-                //keccak256("org.superfluid-finance.agreements.InstantDistributionAgreement.v1")
-                0x8aedc3b5d4bf031e11a7e2940f7251c005698405d58e02e1c247fed3b1b3a674)));
+                keccak256("org.superfluid-finance.agreements.InstantDistributionAgreement.v1"))));
         }
         assert(address(host) != address(0));
         assert(address(ida) != address(0));

--- a/packages/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol
+++ b/packages/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol
@@ -1542,9 +1542,14 @@ library SuperTokenV1Library {
 
     // ************** private helpers **************
 
-    bytes32 private constant _HOST_SLOT = keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.host");
-    bytes32 private constant _CFA_SLOT = keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.cfa");
-    bytes32 private constant _IDA_SLOT = keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.ida");
+    // @note We must use hardcoded constants here because:
+    // Only direct number constants and references to such constants are supported by inline assembly.
+    // keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.host")
+    bytes32 private constant _HOST_SLOT = 0x65599bf746e17a00ea62e3610586992d88101b78eec3cf380706621fb97ea837;
+    // keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.cfa")
+    bytes32 private constant _CFA_SLOT = 0xb969d79d88acd02d04ed7ee7d43b949e7daf093d363abcfbbc43dfdfd1ce969a;
+    // keccak256("org.superfluid-finance.apps.SuperTokenLibrary.v1.ida");
+    bytes32 private constant _IDA_SLOT = 0xa832ee1924ea960211af2df07d65d166232018f613ac6708043cd8f8773eddeb;
 
     // gets the host and cfa addrs for the token and caches it in storage for gas efficiency
     // to be used in state changing methods

--- a/packages/ethereum-contracts/contracts/libs/ERC777Helper.sol
+++ b/packages/ethereum-contracts/contracts/libs/ERC777Helper.sol
@@ -12,13 +12,8 @@ library ERC777Helper {
     IERC1820Registry constant internal _ERC1820_REGISTRY =
         IERC1820Registry(0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24);
 
-    // keccak256("ERC777TokensSender")
-    bytes32 constant internal _TOKENS_SENDER_INTERFACE_HASH =
-        0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895;
-
-    // keccak256("ERC777TokensRecipient")
-    bytes32 constant internal _TOKENS_RECIPIENT_INTERFACE_HASH =
-        0xb281fc8c12954d22544db45de3159a39272895b169a852b314f9cc762e44c53b;
+    bytes32 constant internal _TOKENS_SENDER_INTERFACE_HASH = keccak256("ERC777TokensSender");
+    bytes32 constant internal _TOKENS_RECIPIENT_INTERFACE_HASH = keccak256("ERC777TokensRecipient");
 
 
     /// @dev ERC777 operators support self structure

--- a/packages/ethereum-contracts/contracts/superfluid/FlowNFTBase.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/FlowNFTBase.sol
@@ -96,8 +96,7 @@ abstract contract FlowNFTBase is UUPSProxiable, IFlowNFTBase {
         CONSTANT_FLOW_AGREEMENT_V1 = IConstantFlowAgreementV1(
             address(
                 ISuperfluid(host).getAgreementClass(
-                    //keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1")
-                    0xa9214cc96615e0085d3bb077758db69497dc2dce3b2b1e97bc93c3d18d83efd3
+                    keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1")
                 )
             )
         );

--- a/packages/ethereum-contracts/test/contracts/apps/SuperTokenV1Library.IDA.test.ts
+++ b/packages/ethereum-contracts/test/contracts/apps/SuperTokenV1Library.IDA.test.ts
@@ -288,12 +288,10 @@ describe("IDAv1Library testing", function () {
         });
 
         it("#1.7 - _getHostAndIDA empty cache test", async () => {
-            await expect(
-                superTokenLibIDAMock.listSubscriptionsTest(
-                    superToken.address,
-                    bob
-                )
-            ).to.be.reverted;
+            await superTokenLibIDAMock.listSubscriptionsTest(
+                superToken.address,
+                bob
+            );
         });
     });
 


### PR DESCRIPTION
keccak256("org.superfluid-finance.agreements.InstantDistributionAgreement.v1") is `0x8aedc3b5d4bf031e11a7e2940f7251c005698405d58e02e1c247fed3b1b3a674`, not `0x15609310ae3c30189a1218b7adabaf36c267255e70cf91b6cba384367d9eda32`.



[Verify](https://emn178.github.io/online-tools/keccak_256.html): `org.superfluid-finance.agreements.InstantDistributionAgreement.v1`