### PR TITLE
[WORKFLOW] verify contracts in canary build

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -365,6 +365,8 @@ jobs:
         run: |
           cd packages/ethereum-contracts
           npx truffle exec --network ${{ matrix.network }} ops-scripts/deploy-test-environment.js
+          npx truffle exec --network ${{ matrix.network }} ops-scripts/info-print-contract-addresses.js : addresses.vars
+          tasks/etherscan-verify-framework.sh ${{ matrix.network }} addresses.vars
         env:
           RELEASE_VERSION: master
           AVALANCHE_FUJI_MNEMONIC: ${{ secrets.BUILD_AGENT_MNEMONIC  }}


### PR DESCRIPTION
We should be verifying the upgraded contracts that we are deploying in the canary build.