### PR TITLE
[WORKFLOW] fix publish artifact #1508

### DIFF
--- a/.github/workflows/cd.feature.create-pr-artifact.yml
+++ b/.github/workflows/cd.feature.create-pr-artifact.yml
@@ -79,17 +79,10 @@ jobs:
             mv -- "$f" "${f%.tgz}-${sha:0:7}.tgz"
           done
 
-      - name: Create empty artifact
-        if: env.PUBLISH_PR_ARTIFACT != 1
-        run: |
-          prNumber=${{ github.event.number }}
-          dirName="bin/${prNumber}"
-          mkdir -p $dirName
-          touch $dirName/.empty
-
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: pr-packages
           path: bin
           retention-days: 1
+          if-no-files-found: warn

--- a/.github/workflows/handler.publish-pr-packages.yml
+++ b/.github/workflows/handler.publish-pr-packages.yml
@@ -39,12 +39,16 @@ jobs:
           echo github.base_ref: ${{ github.base_ref }}
 
       - name: Download artifact
+        continue-on-error: true
+        id: download_artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
+          if_no_artifact_found: fail
 
       - name: Get PR data
+        if: steps.download_artifact.outcome == 'success'
         id: pr
         run: |
           ls -R pr-packages
@@ -57,10 +61,12 @@ jobs:
           echo "n_packages=$n_packages" >> "$GITHUB_OUTPUT"
 
       - name: Publish to github
+        if: steps.download_artifact.outcome == 'success'
         run: |
           pr_number="${{ steps.pr.outputs.pr_number }}"
           tasks/npmrc-use-github.sh > pr-packages/$pr_number/.npmrc # using GITHUB_TOKEN
           cd pr-packages/$pr_number
+          shopt -s nullglob
           for p in * ; do
             npm --userconfig .npmrc publish --access public --tag "PR$pr_number" "$p"
           done
@@ -69,14 +75,14 @@ jobs:
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1
-        if: ${{ steps.pr.outputs.n_packages > 0 }}
+        if: ${{ steps.pr.outputs.n_packages > 0 && steps.download_artifact.outcome == 'success' }}
         id: fc
         with:
           issue-number: ${{ steps.pr.outputs.pr_number }}
           comment-author: "github-actions[bot]"
 
       - name: Create comment
-        if: ${{ steps.pr.outputs.n_packages > 0 && steps.fc.outputs.comment-id == 0 }}
+        if: ${{ steps.pr.outputs.n_packages > 0 && steps.fc.outputs.comment-id == 0 && steps.download_artifact.outcome == 'success'}}
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ steps.pr.outputs.pr_number }}


### PR DESCRIPTION
Introduces nullglob to expand artifact pattern search(*) to null if empty.

`create-pr-artifact` does not create any package if PUBLISH_PR_ARTIFACT != 1.
`handler.publish-pr-packages` skips all other steps if there is no package from the workflow that triggered it.
