### PR TITLE
[ETHEREUM-CONTRACTS] host should be immutable

### DIFF
--- a/packages/ethereum-contracts/contracts/apps/SuperAppBaseFlow.sol
+++ b/packages/ethereum-contracts/contracts/apps/SuperAppBaseFlow.sol
@@ -9,7 +9,7 @@ abstract contract SuperAppBaseFlow is ISuperApp {
 
     bytes32 public constant CFAV1_TYPE = keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1");
 
-    ISuperfluid public host;
+    ISuperfluid public immutable host;
 
     /// @dev Thrown when the callback caller is not the host.
     error UnauthorizedHost();

--- a/packages/ethereum-contracts/contracts/apps/SuperAppBaseFlow.sol
+++ b/packages/ethereum-contracts/contracts/apps/SuperAppBaseFlow.sol
@@ -9,7 +9,7 @@ abstract contract SuperAppBaseFlow is ISuperApp {
 
     bytes32 public constant CFAV1_TYPE = keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1");
 
-    ISuperfluid public immutable host;
+    ISuperfluid public immutable HOST;
 
     /// @dev Thrown when the callback caller is not the host.
     error UnauthorizedHost();
@@ -30,7 +30,7 @@ abstract contract SuperAppBaseFlow is ISuperApp {
         bool activateOnUpdated,
         bool activateOnDeleted
     ) {
-        host = host_;
+        HOST = host_;
 
         uint256 callBackDefinitions = SuperAppDefinitions.APP_LEVEL_FINAL
             | SuperAppDefinitions.BEFORE_AGREEMENT_CREATED_NOOP;
@@ -131,7 +131,7 @@ abstract contract SuperAppBaseFlow is ISuperApp {
         bytes calldata /*cbdata*/,
         bytes calldata ctx
     ) external override returns (bytes memory newCtx) {
-        if (msg.sender != address(host)) revert UnauthorizedHost();
+        if (msg.sender != address(HOST)) revert UnauthorizedHost();
         if (!isAcceptedAgreement(agreementClass)) return ctx;
         if (!isAcceptedSuperToken(superToken)) revert NotAcceptedSuperToken();
 
@@ -154,7 +154,7 @@ abstract contract SuperAppBaseFlow is ISuperApp {
         bytes calldata agreementData,
         bytes calldata /*ctx*/
     ) external view override returns (bytes memory /*beforeData*/) {
-        if (msg.sender != address(host)) revert UnauthorizedHost();
+        if (msg.sender != address(HOST)) revert UnauthorizedHost();
         if (!isAcceptedAgreement(agreementClass)) return "0x";
         if (!isAcceptedSuperToken(superToken)) revert NotAcceptedSuperToken();
 
@@ -175,7 +175,7 @@ abstract contract SuperAppBaseFlow is ISuperApp {
         bytes calldata cbdata,
         bytes calldata ctx
     ) external override returns (bytes memory newCtx) {
-        if (msg.sender != address(host)) revert UnauthorizedHost();
+        if (msg.sender != address(HOST)) revert UnauthorizedHost();
         if (!isAcceptedAgreement(agreementClass)) return ctx;
         if (!isAcceptedSuperToken(superToken)) revert NotAcceptedSuperToken();
 
@@ -202,7 +202,7 @@ abstract contract SuperAppBaseFlow is ISuperApp {
         bytes calldata /*ctx*/
     ) external view override returns (bytes memory /*beforeData*/) {
         // we're not allowed to revert in this callback, thus just return empty beforeData on failing checks
-        if (msg.sender != address(host)
+        if (msg.sender != address(HOST)
             || !isAcceptedAgreement(agreementClass)
             || !isAcceptedSuperToken(superToken))
         {
@@ -227,7 +227,7 @@ abstract contract SuperAppBaseFlow is ISuperApp {
         bytes calldata ctx
     ) external override returns (bytes memory newCtx) {
         // we're not allowed to revert in this callback, thus just return ctx on failing checks
-        if (msg.sender != address(host)
+        if (msg.sender != address(HOST)
             || !isAcceptedAgreement(agreementClass)
             || !isAcceptedSuperToken(superToken))
         {
@@ -258,6 +258,6 @@ abstract contract SuperAppBaseFlow is ISuperApp {
      *      Current implementation expects ConstantFlowAgreement
      */
     function isAcceptedAgreement(address agreementClass) internal view virtual returns (bool) {
-        return agreementClass == address(host.getAgreementClass(CFAV1_TYPE));
+        return agreementClass == address(HOST.getAgreementClass(CFAV1_TYPE));
     }
 }


### PR DESCRIPTION
There is no reason the host contract shouldn't be immutable on the SuperAppBaseFlow contract.
Save some gas and also allow SuperApps to be clones/proxies.