### PR TITLE
chore: add devcontainer.json to enable GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,10 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "./tasks/fix-devcontainer.sh && nix develop . -c bash <(echo \"yarn install && yarn build\")"
+	// 1. using nix to create a reproduciable build
+	// 2. install foundry for people don't want to use nix
+	// 3. if you want to use nix further, do "nix develop"
+	"postCreateCommand": "./tasks/fix-devcontainer.sh && nix develop . -c bash <(echo \"yarn install && yarn build\") && curl -L https://foundry.paradigm.xyz | bash & foundryup"
 	
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,10 @@
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bookworm",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
+		// If having issues with Nix then consult:
+		// * Nix Dev Containers feature repo: https://github.com/devcontainers/features/tree/main/src/nix
+		// * Nix issue about using with GitHub Codespaces: https://github.com/NixOS/nix/issues/6680
+		// * Nix discourse talk about using with GitHub Codespaces: https://discourse.nixos.org/t/github-codespace-support/27152/2
 		"ghcr.io/devcontainers/features/nix:1": {
 			"multiUser": true,
 			"version": "latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,25 +4,29 @@
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bookworm",
+	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/devcontainers/features/nix:1": {},
+		"ghcr.io/devcontainers/features/nix:1": {
+			"multiUser": true,
+			"version": "latest",
+			"extraNixConfig": "experimental-features = nix-command flakes"
+		},
 		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
 		"ghcr.io/lukewiwa/features/shellcheck:0": {},
-		"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {}
+		"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers-contrib/features/act:1": {}
 	},
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "curl -L https://foundry.paradigm.xyz | bash & yarn install && yarn build"
-
+	"postCreateCommand": "curl -L https://foundry.paradigm.xyz | bash & foundryup & yarn install && yarn build"
+	
 	// Configure tool-specific properties.
 	// "customizations": {},
-
+	
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/nix:1": {},
+		"ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {},
+		"ghcr.io/lukewiwa/features/shellcheck:0": {},
+		"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {}
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "curl -L https://foundry.paradigm.xyz | bash & yarn install && yarn build"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "curl -L https://foundry.paradigm.xyz | bash & foundryup & yarn install && yarn build"
+	"postCreateCommand": "./tasks/fix-devcontainer.sh && nix develop . -c bash <(echo \"yarn install && yarn build\")"
 	
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
         "show-versions": "lerna ls --long",
         "postinstall": "husky install",
         "pre-commit": "yarn lint:shellcheck && yarn workspaces run pre-commit",
-        "shell": "nix develop",
-        "shell:spec": "nix develop .#spec",
-        "shell:whitehat": "nix develop .#whitehat",
-        "shell:full": "nix develop .#full"
+        "shell": "nix develop --extra-experimental-features 'nix-command flakes'",
+        "shell:spec": "nix develop .#spec --extra-experimental-features 'nix-command flakes'",
+        "shell:whitehat": "nix develop .#whitehat --extra-experimental-features 'nix-command flakes'",
+        "shell:full": "nix develop .#full --extra-experimental-features 'nix-command flakes'"
     },
     "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
         "show-versions": "lerna ls --long",
         "postinstall": "husky install",
         "pre-commit": "yarn lint:shellcheck && yarn workspaces run pre-commit",
-        "shell": "nix develop 'nix-command flakes'",
-        "shell:spec": "nix develop .#spec 'nix-command flakes'",
-        "shell:whitehat": "nix develop .#whitehat 'nix-command flakes'",
-        "shell:full": "nix develop .#full 'nix-command flakes'"
+        "shell": "nix develop",
+        "shell:spec": "nix develop .#spec",
+        "shell:whitehat": "nix develop .#whitehat",
+        "shell:full": "nix develop .#full"
     },
     "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
         "show-versions": "lerna ls --long",
         "postinstall": "husky install",
         "pre-commit": "yarn lint:shellcheck && yarn workspaces run pre-commit",
-        "shell": "nix develop --extra-experimental-features 'nix-command flakes'",
-        "shell:spec": "nix develop .#spec --extra-experimental-features 'nix-command flakes'",
-        "shell:whitehat": "nix develop .#whitehat --extra-experimental-features 'nix-command flakes'",
-        "shell:full": "nix develop .#full --extra-experimental-features 'nix-command flakes'"
+        "shell": "nix develop 'nix-command flakes'",
+        "shell:spec": "nix develop .#spec 'nix-command flakes'",
+        "shell:whitehat": "nix develop .#whitehat 'nix-command flakes'",
+        "shell:full": "nix develop .#full 'nix-command flakes'"
     },
     "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",

--- a/tasks/fix-devcontainer.sh
+++ b/tasks/fix-devcontainer.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# some fixes realted to devcontainer and nix
+# Ref: https://github.com/xtruder/nix-devcontainer/issues/12
+sudo apt install acl
+sudo chmod 1777 /tmp/ && sudo setfacl --remove-default  /tmp


### PR DESCRIPTION
* has `yarn`, `jq`, `foundry`, `shellcheck`, etc pre-installed
* Seems to work for building the monorepo and running the tests
* Can also run GitHub Actions using [act](https://github.com/nektos/act) and docker-in-docker
* Nix is running into some kind of a permissions issue that people are trying to figure out on issue boards