### PR TITLE
[METADATA] added autowrap contract addresses

### DIFF
--- a/packages/automation-contracts/autowrap/package.json
+++ b/packages/automation-contracts/autowrap/package.json
@@ -15,6 +15,6 @@
     "dependencies": {
         "@openzeppelin/contracts": "4.9.3",
         "@superfluid-finance/ethereum-contracts": "1.7.2",
-        "@superfluid-finance/metadata": "1.1.10"
+        "@superfluid-finance/metadata": "1.1.11"
     }
 }

--- a/packages/automation-contracts/scheduler/package.json
+++ b/packages/automation-contracts/scheduler/package.json
@@ -15,6 +15,6 @@
     "dependencies": {
         "@superfluid-finance/ethereum-contracts": "1.7.2",
         "@openzeppelin/contracts": "4.9.3",
-        "@superfluid-finance/metadata": "1.1.10"
+        "@superfluid-finance/metadata": "1.1.11"
     }
 }

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -83,7 +83,7 @@
     },
     "devDependencies": {
         "@nomiclabs/hardhat-truffle5": "^2.0.7",
-        "@superfluid-finance/metadata": "1.1.10",
+        "@superfluid-finance/metadata": "1.1.11",
         "@superfluid-finance/js-sdk": "0.6.3",
         "@safe-global/safe-core-sdk": "^3.3.4",
         "@safe-global/safe-service-client": "^2.0.2",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -43,7 +43,7 @@
         "cloc": "sh tasks/cloc.sh"
     },
     "dependencies": {
-        "@superfluid-finance/metadata": "1.1.10",
+        "@superfluid-finance/metadata": "1.1.11",
         "@truffle/contract": "4.6.28",
         "auto-bind": "4.0.0",
         "node-fetch": "2.6.12"

--- a/packages/metadata/CHANGELOG.md
+++ b/packages/metadata/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the metadata will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.1.11]
 
 - Node dependency updates.
 - Added addresses of autowrap contracts

--- a/packages/metadata/CHANGELOG.md
+++ b/packages/metadata/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 - Node dependency updates.
+- Added addresses of autowrap contracts
 
 ## [v1.1.10] - 2023-07-25
 - Fixed address of SuperTokenFactory for polygon-zkevm-testnet

--- a/packages/metadata/main/networks/list.cjs
+++ b/packages/metadata/main/networks/list.cjs
@@ -23,7 +23,11 @@ module.exports =
             "superfluidLoader": "0x74d860243Ff08A243d5485899f343117EbDa6eA8",
             "toga": "0xa54FC15FC75693447d70a57262F37a70B614721b",
             "flowScheduler": "0xf428308b426D7cD7Ad8eBE549d750f31C8E060Ca",
-            "vestingScheduler": "0xF9240F930d847F70ad900aBEE8949F25649Bf24a"
+            "vestingScheduler": "0xF9240F930d847F70ad900aBEE8949F25649Bf24a",
+            "autowrap": {
+                "manager": "0x0B82D14E9616ca4d260E77454834AdCf5887595F",
+                "wrapStrategy": "0xea49af829d3e28d3ec49e0e0a0ba1e7860a56f60"
+            }
         },
         "startBlockV1": 3550000,
         "logsQueryRange": 10000,
@@ -60,7 +64,11 @@ module.exports =
             "toga": "0x38DD80876DBA048d0050D28828522c313967D073",
             "superSpreader": "0x74CDF863b00789c29734F8dFd9F83423Bc55E4cE",
             "flowScheduler": "0x59A3Ba9d34c387FB70b4f4e4Fbc9eD7519194139",
-            "vestingScheduler": "0x3962EE56c9f7176215D149938BA685F91aBB633B"
+            "vestingScheduler": "0x3962EE56c9f7176215D149938BA685F91aBB633B",
+            "autowrap": {
+                "manager": "0x3eAB3c6207F488E475b7955B631B564F0E6317B9",
+                "wrapStrategy": "0x544728AFDBeEafBeC9e1329031788edb53017bC4"
+            }
         },
         "startBlockV1": 8100000,
         "logsQueryRange": 10000,
@@ -151,7 +159,11 @@ module.exports =
             "idaV1": "0xA44dEC7A0Dde1a56AeDe4143C1ef89cf5d956782",
             "gdaV1": "0x48ac69a0f8bc90d5b3b81f6162ec87c864ebd052",
             "superTokenFactory": "0x1C92042426B6bAAe497bEf461B6d8342D03aEc92",
-            "superfluidLoader": "0x96C3C2d23d143301cF363a02cB7fe3596d2834d7"
+            "superfluidLoader": "0x96C3C2d23d143301cF363a02cB7fe3596d2834d7",
+            "autowrap": {
+                "manager": "0x30aE282CF477E2eF28B14d0125aCEAd57Fe1d7a1",
+                "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
+            }
         },
         "startBlockV1": 3220000,
         "logsQueryRange": 50000,
@@ -279,7 +291,11 @@ module.exports =
             "flowScheduler": "0x9cC7fc484fF588926149577e9330fA5b2cA74336",
             "vestingScheduler": "0x0170FFCC75d178d426EBad5b1a31451d00Ddbd0D",
             "wrapManager": "0x7a2899D179a8F205C8EDAd2e52954cA5f6d48D1A",
-            "wrapStrategy": "0xc3B7f0b221a002fE8Fc93b4Ef9BB6362950510F2"
+            "wrapStrategy": "0xc3B7f0b221a002fE8Fc93b4Ef9BB6362950510F2",
+            "autowrap": {
+                "manager": "0x8082e58681350876aFe8f52d3Bf8672034A03Db0",
+                "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
+            }
         },
         "startBlockV1": 14820000,
         "logsQueryRange": 20000,
@@ -317,7 +333,11 @@ module.exports =
             "toga": "0x6AEAeE5Fd4D05A741723D752D30EE4D72690A8f7",
             "batchLiquidator": "0xA6Cdb472e7E22Bf30ae6fB752E4a13eBF3c12165",
             "flowScheduler": "0x55F7758dd99d5e185f4CC08d4Ad95B71f598264D",
-            "vestingScheduler": "0xcFE6382B33F2AdaFbE46e6A26A88E0182ae32b0c"
+            "vestingScheduler": "0xcFE6382B33F2AdaFbE46e6A26A88E0182ae32b0c",
+            "autowrap": {
+                "manager": "0x2581c27E7f6D6AF452E63fCe884EDE3EDd716b32",
+                "wrapStrategy": "0xb4afa36BAd8c76976Dc77a21c9Ad711EF720eE4b"
+            }
         },
         "startBlockV1": 11650500,
         "logsQueryRange": 10000,
@@ -355,7 +375,11 @@ module.exports =
             "toga": "0xA3c8502187fD7a7118eAD59dc811281448946C8f",
             "batchLiquidator": "0x36Df169DBf5CE3c6f58D46f0addeF58F01381232",
             "flowScheduler": "0x55c8fc400833eEa791087cF343Ff2409A39DeBcC",
-            "vestingScheduler": "0x65377d4dfE9c01639A41952B5083D58964782892"
+            "vestingScheduler": "0x65377d4dfE9c01639A41952B5083D58964782892",
+            "autowrap": {
+                "manager": "0x1fA76f2Cd0C3fe6c399A80111408d9C42C0CAC23",
+                "wrapStrategy": "0x0Cf060a501c0040e9CCC708eFE94079F501c6Bb4"
+            }
         },
         "startBlockV1": 4300000,
         "logsQueryRange": 50000,
@@ -392,7 +416,11 @@ module.exports =
             "toga": "0xFC63B7C762B10670Eda15cF3ca3970bCDB28C9eF",
             "batchLiquidator": "0x6C66e5c5D201A753ff497F2e9eC5D545631854d0",
             "flowScheduler": "0x3fA8B653F9abf91428800C0ba0F8D145a71F97A1",
-            "vestingScheduler": "0x55c8fc400833eEa791087cF343Ff2409A39DeBcC"
+            "vestingScheduler": "0x55c8fc400833eEa791087cF343Ff2409A39DeBcC",
+            "autowrap": {
+                "manager": "0xf01825eAFAe5CD1Dab5593EFAF218efC8968D272",
+                "wrapStrategy": "0x342076aA957B0ec8bC1d3893af719b288eA31e61"
+            }
         },
         "startBlockV1": 7600000,
         "logsQueryRange": 50000,
@@ -429,7 +457,11 @@ module.exports =
             "toga": "0x3D9A67D5ec1E72CEcA8157e028855056786b6159",
             "batchLiquidator": "0xdddaD64A9Fe7709A729C4a5428617e369278e0b6",
             "flowScheduler": "0xF7AfF590E9DE493D7ACb421Fca7f1E35C1ad4Ce5",
-            "vestingScheduler": "0x3fA8B653F9abf91428800C0ba0F8D145a71F97A1"
+            "vestingScheduler": "0x3fA8B653F9abf91428800C0ba0F8D145a71F97A1",
+            "autowrap": {
+                "manager": "0x8082e58681350876aFe8f52d3Bf8672034A03Db0",
+                "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
+            }
         },
         "startBlockV1": 14700000,
         "logsQueryRange": 50000,
@@ -466,7 +498,11 @@ module.exports =
             "toga": "0xFCD84210f5d51Cd40a30443d44d6A5500d5D10dF",
             "batchLiquidator": "0x5487d078CA8933e83d91d5E7AFBe3A7bfC3412d6",
             "flowScheduler": "0x2f9e2A2A59405682d4F86779275CF5525AD7eC2B",
-            "vestingScheduler": "0x9B91c27f78376383003C6A12Ad12B341d016C5b9"
+            "vestingScheduler": "0x9B91c27f78376383003C6A12Ad12B341d016C5b9",
+            "autowrap": {
+                "manager": "0x2AcdD61ac1EFFe1535109449c31889bdE8d7f325",
+                "wrapStrategy": "0x9e308cb079ae130790F604b1030cDf386670f199"
+            }
         },
         "startBlockV1": 18800000,
         "logsQueryRange": 5000,
@@ -503,7 +539,11 @@ module.exports =
             "toga": "0x8B5a2CF69a56d7F8Fa027edcA23594cdDF544dDc",
             "batchLiquidator": "0x554c06487bEc8c890A0345eb05a5292C1b1017Bd",
             "flowScheduler": "0xAA0cD305eD020137E302CeCede7b18c0A05aCCDA",
-            "vestingScheduler": "0x39D5cBBa9adEBc25085a3918d36D5325546C001B"
+            "vestingScheduler": "0x39D5cBBa9adEBc25085a3918d36D5325546C001B",
+            "autowrap": {
+                "manager": "0x30aE282CF477E2eF28B14d0125aCEAd57Fe1d7a1",
+                "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
+            }
         },
         "startBlockV1": 15870000,
         "logsQueryRange": 10000,

--- a/packages/metadata/module/networks/list.d.ts
+++ b/packages/metadata/module/networks/list.d.ts
@@ -1,3 +1,7 @@
+interface AutowrapAddresses {
+    readonly manager: string;
+    readonly wrapStrategy: string;
+}
 interface ContractAddresses {
     readonly resolver: string;
     readonly host: string;
@@ -12,6 +16,7 @@ interface ContractAddresses {
     readonly vestingScheduler: string;
     readonly flowScheduler: string;
     readonly batchLiquidator: string;
+    readonly autowrap: AutowrapAddresses;
 }
 interface SubgraphData {
     readonly name: string;

--- a/packages/metadata/module/networks/list.js
+++ b/packages/metadata/module/networks/list.js
@@ -23,7 +23,11 @@ export default
             "superfluidLoader": "0x74d860243Ff08A243d5485899f343117EbDa6eA8",
             "toga": "0xa54FC15FC75693447d70a57262F37a70B614721b",
             "flowScheduler": "0xf428308b426D7cD7Ad8eBE549d750f31C8E060Ca",
-            "vestingScheduler": "0xF9240F930d847F70ad900aBEE8949F25649Bf24a"
+            "vestingScheduler": "0xF9240F930d847F70ad900aBEE8949F25649Bf24a",
+            "autowrap": {
+                "manager": "0x0B82D14E9616ca4d260E77454834AdCf5887595F",
+                "wrapStrategy": "0xea49af829d3e28d3ec49e0e0a0ba1e7860a56f60"
+            }
         },
         "startBlockV1": 3550000,
         "logsQueryRange": 10000,
@@ -60,7 +64,11 @@ export default
             "toga": "0x38DD80876DBA048d0050D28828522c313967D073",
             "superSpreader": "0x74CDF863b00789c29734F8dFd9F83423Bc55E4cE",
             "flowScheduler": "0x59A3Ba9d34c387FB70b4f4e4Fbc9eD7519194139",
-            "vestingScheduler": "0x3962EE56c9f7176215D149938BA685F91aBB633B"
+            "vestingScheduler": "0x3962EE56c9f7176215D149938BA685F91aBB633B",
+            "autowrap": {
+                "manager": "0x3eAB3c6207F488E475b7955B631B564F0E6317B9",
+                "wrapStrategy": "0x544728AFDBeEafBeC9e1329031788edb53017bC4"
+            }
         },
         "startBlockV1": 8100000,
         "logsQueryRange": 10000,
@@ -151,7 +159,11 @@ export default
             "idaV1": "0xA44dEC7A0Dde1a56AeDe4143C1ef89cf5d956782",
             "gdaV1": "0x48ac69a0f8bc90d5b3b81f6162ec87c864ebd052",
             "superTokenFactory": "0x1C92042426B6bAAe497bEf461B6d8342D03aEc92",
-            "superfluidLoader": "0x96C3C2d23d143301cF363a02cB7fe3596d2834d7"
+            "superfluidLoader": "0x96C3C2d23d143301cF363a02cB7fe3596d2834d7",
+            "autowrap": {
+                "manager": "0x30aE282CF477E2eF28B14d0125aCEAd57Fe1d7a1",
+                "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
+            }
         },
         "startBlockV1": 3220000,
         "logsQueryRange": 50000,
@@ -279,7 +291,11 @@ export default
             "flowScheduler": "0x9cC7fc484fF588926149577e9330fA5b2cA74336",
             "vestingScheduler": "0x0170FFCC75d178d426EBad5b1a31451d00Ddbd0D",
             "wrapManager": "0x7a2899D179a8F205C8EDAd2e52954cA5f6d48D1A",
-            "wrapStrategy": "0xc3B7f0b221a002fE8Fc93b4Ef9BB6362950510F2"
+            "wrapStrategy": "0xc3B7f0b221a002fE8Fc93b4Ef9BB6362950510F2",
+            "autowrap": {
+                "manager": "0x8082e58681350876aFe8f52d3Bf8672034A03Db0",
+                "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
+            }
         },
         "startBlockV1": 14820000,
         "logsQueryRange": 20000,
@@ -317,7 +333,11 @@ export default
             "toga": "0x6AEAeE5Fd4D05A741723D752D30EE4D72690A8f7",
             "batchLiquidator": "0xA6Cdb472e7E22Bf30ae6fB752E4a13eBF3c12165",
             "flowScheduler": "0x55F7758dd99d5e185f4CC08d4Ad95B71f598264D",
-            "vestingScheduler": "0xcFE6382B33F2AdaFbE46e6A26A88E0182ae32b0c"
+            "vestingScheduler": "0xcFE6382B33F2AdaFbE46e6A26A88E0182ae32b0c",
+            "autowrap": {
+                "manager": "0x2581c27E7f6D6AF452E63fCe884EDE3EDd716b32",
+                "wrapStrategy": "0xb4afa36BAd8c76976Dc77a21c9Ad711EF720eE4b"
+            }
         },
         "startBlockV1": 11650500,
         "logsQueryRange": 10000,
@@ -355,7 +375,11 @@ export default
             "toga": "0xA3c8502187fD7a7118eAD59dc811281448946C8f",
             "batchLiquidator": "0x36Df169DBf5CE3c6f58D46f0addeF58F01381232",
             "flowScheduler": "0x55c8fc400833eEa791087cF343Ff2409A39DeBcC",
-            "vestingScheduler": "0x65377d4dfE9c01639A41952B5083D58964782892"
+            "vestingScheduler": "0x65377d4dfE9c01639A41952B5083D58964782892",
+            "autowrap": {
+                "manager": "0x1fA76f2Cd0C3fe6c399A80111408d9C42C0CAC23",
+                "wrapStrategy": "0x0Cf060a501c0040e9CCC708eFE94079F501c6Bb4"
+            }
         },
         "startBlockV1": 4300000,
         "logsQueryRange": 50000,
@@ -392,7 +416,11 @@ export default
             "toga": "0xFC63B7C762B10670Eda15cF3ca3970bCDB28C9eF",
             "batchLiquidator": "0x6C66e5c5D201A753ff497F2e9eC5D545631854d0",
             "flowScheduler": "0x3fA8B653F9abf91428800C0ba0F8D145a71F97A1",
-            "vestingScheduler": "0x55c8fc400833eEa791087cF343Ff2409A39DeBcC"
+            "vestingScheduler": "0x55c8fc400833eEa791087cF343Ff2409A39DeBcC",
+            "autowrap": {
+                "manager": "0xf01825eAFAe5CD1Dab5593EFAF218efC8968D272",
+                "wrapStrategy": "0x342076aA957B0ec8bC1d3893af719b288eA31e61"
+            }
         },
         "startBlockV1": 7600000,
         "logsQueryRange": 50000,
@@ -429,7 +457,11 @@ export default
             "toga": "0x3D9A67D5ec1E72CEcA8157e028855056786b6159",
             "batchLiquidator": "0xdddaD64A9Fe7709A729C4a5428617e369278e0b6",
             "flowScheduler": "0xF7AfF590E9DE493D7ACb421Fca7f1E35C1ad4Ce5",
-            "vestingScheduler": "0x3fA8B653F9abf91428800C0ba0F8D145a71F97A1"
+            "vestingScheduler": "0x3fA8B653F9abf91428800C0ba0F8D145a71F97A1",
+            "autowrap": {
+                "manager": "0x8082e58681350876aFe8f52d3Bf8672034A03Db0",
+                "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
+            }
         },
         "startBlockV1": 14700000,
         "logsQueryRange": 50000,
@@ -466,7 +498,11 @@ export default
             "toga": "0xFCD84210f5d51Cd40a30443d44d6A5500d5D10dF",
             "batchLiquidator": "0x5487d078CA8933e83d91d5E7AFBe3A7bfC3412d6",
             "flowScheduler": "0x2f9e2A2A59405682d4F86779275CF5525AD7eC2B",
-            "vestingScheduler": "0x9B91c27f78376383003C6A12Ad12B341d016C5b9"
+            "vestingScheduler": "0x9B91c27f78376383003C6A12Ad12B341d016C5b9",
+            "autowrap": {
+                "manager": "0x2AcdD61ac1EFFe1535109449c31889bdE8d7f325",
+                "wrapStrategy": "0x9e308cb079ae130790F604b1030cDf386670f199"
+            }
         },
         "startBlockV1": 18800000,
         "logsQueryRange": 5000,
@@ -503,7 +539,11 @@ export default
             "toga": "0x8B5a2CF69a56d7F8Fa027edcA23594cdDF544dDc",
             "batchLiquidator": "0x554c06487bEc8c890A0345eb05a5292C1b1017Bd",
             "flowScheduler": "0xAA0cD305eD020137E302CeCede7b18c0A05aCCDA",
-            "vestingScheduler": "0x39D5cBBa9adEBc25085a3918d36D5325546C001B"
+            "vestingScheduler": "0x39D5cBBa9adEBc25085a3918d36D5325546C001B",
+            "autowrap": {
+                "manager": "0x30aE282CF477E2eF28B14d0125aCEAd57Fe1d7a1",
+                "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
+            }
         },
         "startBlockV1": 15870000,
         "logsQueryRange": 10000,

--- a/packages/metadata/networks.json
+++ b/packages/metadata/networks.json
@@ -21,7 +21,11 @@
             "superfluidLoader": "0x74d860243Ff08A243d5485899f343117EbDa6eA8",
             "toga": "0xa54FC15FC75693447d70a57262F37a70B614721b",
             "flowScheduler": "0xf428308b426D7cD7Ad8eBE549d750f31C8E060Ca",
-            "vestingScheduler": "0xF9240F930d847F70ad900aBEE8949F25649Bf24a"
+            "vestingScheduler": "0xF9240F930d847F70ad900aBEE8949F25649Bf24a",
+            "autowrap": {
+                "manager": "0x0B82D14E9616ca4d260E77454834AdCf5887595F",
+                "wrapStrategy": "0xea49af829d3e28d3ec49e0e0a0ba1e7860a56f60"
+            }
         },
         "startBlockV1": 3550000,
         "logsQueryRange": 10000,
@@ -58,7 +62,11 @@
             "toga": "0x38DD80876DBA048d0050D28828522c313967D073",
             "superSpreader": "0x74CDF863b00789c29734F8dFd9F83423Bc55E4cE",
             "flowScheduler": "0x59A3Ba9d34c387FB70b4f4e4Fbc9eD7519194139",
-            "vestingScheduler": "0x3962EE56c9f7176215D149938BA685F91aBB633B"
+            "vestingScheduler": "0x3962EE56c9f7176215D149938BA685F91aBB633B",
+            "autowrap": {
+                "manager": "0x3eAB3c6207F488E475b7955B631B564F0E6317B9",
+                "wrapStrategy": "0x544728AFDBeEafBeC9e1329031788edb53017bC4"
+            }
         },
         "startBlockV1": 8100000,
         "logsQueryRange": 10000,
@@ -149,7 +157,11 @@
             "idaV1": "0xA44dEC7A0Dde1a56AeDe4143C1ef89cf5d956782",
             "gdaV1": "0x48ac69a0f8bc90d5b3b81f6162ec87c864ebd052",
             "superTokenFactory": "0x1C92042426B6bAAe497bEf461B6d8342D03aEc92",
-            "superfluidLoader": "0x96C3C2d23d143301cF363a02cB7fe3596d2834d7"
+            "superfluidLoader": "0x96C3C2d23d143301cF363a02cB7fe3596d2834d7",
+            "autowrap": {
+                "manager": "0x30aE282CF477E2eF28B14d0125aCEAd57Fe1d7a1",
+                "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
+            }
         },
         "startBlockV1": 3220000,
         "logsQueryRange": 50000,
@@ -277,7 +289,11 @@
             "flowScheduler": "0x9cC7fc484fF588926149577e9330fA5b2cA74336",
             "vestingScheduler": "0x0170FFCC75d178d426EBad5b1a31451d00Ddbd0D",
             "wrapManager": "0x7a2899D179a8F205C8EDAd2e52954cA5f6d48D1A",
-            "wrapStrategy": "0xc3B7f0b221a002fE8Fc93b4Ef9BB6362950510F2"
+            "wrapStrategy": "0xc3B7f0b221a002fE8Fc93b4Ef9BB6362950510F2",
+            "autowrap": {
+                "manager": "0x8082e58681350876aFe8f52d3Bf8672034A03Db0",
+                "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
+            }
         },
         "startBlockV1": 14820000,
         "logsQueryRange": 20000,
@@ -315,7 +331,11 @@
             "toga": "0x6AEAeE5Fd4D05A741723D752D30EE4D72690A8f7",
             "batchLiquidator": "0xA6Cdb472e7E22Bf30ae6fB752E4a13eBF3c12165",
             "flowScheduler": "0x55F7758dd99d5e185f4CC08d4Ad95B71f598264D",
-            "vestingScheduler": "0xcFE6382B33F2AdaFbE46e6A26A88E0182ae32b0c"
+            "vestingScheduler": "0xcFE6382B33F2AdaFbE46e6A26A88E0182ae32b0c",
+            "autowrap": {
+                "manager": "0x2581c27E7f6D6AF452E63fCe884EDE3EDd716b32",
+                "wrapStrategy": "0xb4afa36BAd8c76976Dc77a21c9Ad711EF720eE4b"
+            }
         },
         "startBlockV1": 11650500,
         "logsQueryRange": 10000,
@@ -353,7 +373,11 @@
             "toga": "0xA3c8502187fD7a7118eAD59dc811281448946C8f",
             "batchLiquidator": "0x36Df169DBf5CE3c6f58D46f0addeF58F01381232",
             "flowScheduler": "0x55c8fc400833eEa791087cF343Ff2409A39DeBcC",
-            "vestingScheduler": "0x65377d4dfE9c01639A41952B5083D58964782892"
+            "vestingScheduler": "0x65377d4dfE9c01639A41952B5083D58964782892",
+            "autowrap": {
+                "manager": "0x1fA76f2Cd0C3fe6c399A80111408d9C42C0CAC23",
+                "wrapStrategy": "0x0Cf060a501c0040e9CCC708eFE94079F501c6Bb4"
+            }
         },
         "startBlockV1": 4300000,
         "logsQueryRange": 50000,
@@ -390,7 +414,11 @@
             "toga": "0xFC63B7C762B10670Eda15cF3ca3970bCDB28C9eF",
             "batchLiquidator": "0x6C66e5c5D201A753ff497F2e9eC5D545631854d0",
             "flowScheduler": "0x3fA8B653F9abf91428800C0ba0F8D145a71F97A1",
-            "vestingScheduler": "0x55c8fc400833eEa791087cF343Ff2409A39DeBcC"
+            "vestingScheduler": "0x55c8fc400833eEa791087cF343Ff2409A39DeBcC",
+            "autowrap": {
+                "manager": "0xf01825eAFAe5CD1Dab5593EFAF218efC8968D272",
+                "wrapStrategy": "0x342076aA957B0ec8bC1d3893af719b288eA31e61"
+            }
         },
         "startBlockV1": 7600000,
         "logsQueryRange": 50000,
@@ -427,7 +455,11 @@
             "toga": "0x3D9A67D5ec1E72CEcA8157e028855056786b6159",
             "batchLiquidator": "0xdddaD64A9Fe7709A729C4a5428617e369278e0b6",
             "flowScheduler": "0xF7AfF590E9DE493D7ACb421Fca7f1E35C1ad4Ce5",
-            "vestingScheduler": "0x3fA8B653F9abf91428800C0ba0F8D145a71F97A1"
+            "vestingScheduler": "0x3fA8B653F9abf91428800C0ba0F8D145a71F97A1",
+            "autowrap": {
+                "manager": "0x8082e58681350876aFe8f52d3Bf8672034A03Db0",
+                "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
+            }
         },
         "startBlockV1": 14700000,
         "logsQueryRange": 50000,
@@ -464,7 +496,11 @@
             "toga": "0xFCD84210f5d51Cd40a30443d44d6A5500d5D10dF",
             "batchLiquidator": "0x5487d078CA8933e83d91d5E7AFBe3A7bfC3412d6",
             "flowScheduler": "0x2f9e2A2A59405682d4F86779275CF5525AD7eC2B",
-            "vestingScheduler": "0x9B91c27f78376383003C6A12Ad12B341d016C5b9"
+            "vestingScheduler": "0x9B91c27f78376383003C6A12Ad12B341d016C5b9",
+            "autowrap": {
+                "manager": "0x2AcdD61ac1EFFe1535109449c31889bdE8d7f325",
+                "wrapStrategy": "0x9e308cb079ae130790F604b1030cDf386670f199"
+            }
         },
         "startBlockV1": 18800000,
         "logsQueryRange": 5000,
@@ -501,7 +537,11 @@
             "toga": "0x8B5a2CF69a56d7F8Fa027edcA23594cdDF544dDc",
             "batchLiquidator": "0x554c06487bEc8c890A0345eb05a5292C1b1017Bd",
             "flowScheduler": "0xAA0cD305eD020137E302CeCede7b18c0A05aCCDA",
-            "vestingScheduler": "0x39D5cBBa9adEBc25085a3918d36D5325546C001B"
+            "vestingScheduler": "0x39D5cBBa9adEBc25085a3918d36D5325546C001B",
+            "autowrap": {
+                "manager": "0x30aE282CF477E2eF28B14d0125aCEAd57Fe1d7a1",
+                "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
+            }
         },
         "startBlockV1": 15870000,
         "logsQueryRange": 10000,

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfluid-finance/metadata",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Superfluid Metadata",
   "main": "main/index.cjs",
   "module": "module/index.js",

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -56,7 +56,7 @@
     },
     "dependencies": {
         "@superfluid-finance/ethereum-contracts": "1.7.2",
-        "@superfluid-finance/metadata": "1.1.10",
+        "@superfluid-finance/metadata": "1.1.11",
         "browserify": "^17.0.0",
         "graphql-request": "^4.3.0",
         "lodash": "^4.17.21",

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -54,7 +54,7 @@
         "mustache": "^4.2.0"
     },
     "devDependencies": {
-        "@superfluid-finance/metadata": "1.1.10",
+        "@superfluid-finance/metadata": "1.1.11",
         "coingecko-api": "^1.0.10",
         "graphql": "^16.7.1",
         "graphql-request": "^6.1.0",


### PR DESCRIPTION
having `flowScheduler` and  `vestingScheduler` in metadata, we should also have autowrap.
This PR adds it.
Since there's 2 contracts (see https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/automation-contracts/autowrap), I mapped that to a nested object with 2 fields.

Contract addresses are taken from https://github.com/superfluid-finance/widget/blob/master/packages/widget/wagmi.config.ts#L28 which I assume is complete.

Note: the [autowrap README](https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/automation-contracts/autowrap) contains an incomplete list of addresses, could be removed and pointed to metadata instead in order to avoid such inconsistencies going forward.