### PR TITLE
[ETHEREUM-CONTRACTS] Hotfix: publish hardhat artifacts

### DIFF
--- a/.github/workflows/call.test-ethereum-contracts.yml
+++ b/.github/workflows/call.test-ethereum-contracts.yml
@@ -95,7 +95,7 @@ jobs:
           echo "FOUNDRY_SOLC_VERSION=$SOLC" >> $GITHUB_ENV
           yarn test-coverage
         working-directory: ./packages/ethereum-contracts
-        env:
+        # env:
           # NOTE: they don't quite work, it seems each worker runs all tests hence making things even slower
           # IS_COVERAGE_TEST: true
           # HARDHAT_TEST_JOBS: 4

--- a/.github/workflows/call.test-ethereum-contracts.yml
+++ b/.github/workflows/call.test-ethereum-contracts.yml
@@ -95,6 +95,10 @@ jobs:
           echo "FOUNDRY_SOLC_VERSION=$SOLC" >> $GITHUB_ENV
           yarn test-coverage
         working-directory: ./packages/ethereum-contracts
+        env:
+          IS_COVERAGE_TEST: true
+          HARDHAT_TEST_JOBS: 4
+          HARDHAT_RUN_PARALLEL: true
 
       - name: Clean up and merge coverage artifacts
         if: inputs.run-coverage-tests == true

--- a/.github/workflows/call.test-ethereum-contracts.yml
+++ b/.github/workflows/call.test-ethereum-contracts.yml
@@ -96,9 +96,10 @@ jobs:
           yarn test-coverage
         working-directory: ./packages/ethereum-contracts
         env:
-          IS_COVERAGE_TEST: true
-          HARDHAT_TEST_JOBS: 4
-          HARDHAT_RUN_PARALLEL: true
+          # NOTE: they don't quite work, it seems each worker runs all tests hence making things even slower
+          # IS_COVERAGE_TEST: true
+          # HARDHAT_TEST_JOBS: 4
+          # HARDHAT_RUN_PARALLEL: true
 
       - name: Clean up and merge coverage artifacts
         if: inputs.run-coverage-tests == true

--- a/packages/automation-contracts/autowrap/package.json
+++ b/packages/automation-contracts/autowrap/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@openzeppelin/contracts": "4.9.3",
-        "@superfluid-finance/ethereum-contracts": "1.8.0",
+        "@superfluid-finance/ethereum-contracts": "1.8.1",
         "@superfluid-finance/metadata": "1.1.13"
     }
 }

--- a/packages/automation-contracts/scheduler/package.json
+++ b/packages/automation-contracts/scheduler/package.json
@@ -13,8 +13,8 @@
         "check-updates": "ncu --target minor"
     },
     "dependencies": {
-        "@superfluid-finance/ethereum-contracts": "1.8.0",
         "@openzeppelin/contracts": "4.9.3",
+        "@superfluid-finance/ethereum-contracts": "1.8.1",
         "@superfluid-finance/metadata": "1.1.13"
     }
 }

--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+## [v1.8.1] - 2023-08-28
+
+### Fixed
+
+- Publish `build/hardhat/*/*` again.
+
 ## [v1.8.0] - 2023-08-23
 
 ### Added

--- a/packages/ethereum-contracts/hardhat.config.ts
+++ b/packages/ethereum-contracts/hardhat.config.ts
@@ -163,8 +163,10 @@ const config: HardhatUserConfig = {
             ...createNetworkConfig("base-goerli"),
             url: process.env.BASE_GOERLI_PROVIDER_URL || "",
         },
-        coverage: {
-            url: "http://127.0.0.1:8555",
+        hardhat: {
+            // Fixing an issue that parallel coverage test is not working for unkown reason.
+            // Ref: https://github.com/NomicFoundation/hardhat/issues/4310
+            allowUnlimitedContractSize: process.env.IS_COVERAGE_TEST ? true : undefined,
         },
     },
     mocha: {

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/ethereum-contracts",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "description": " Ethereum contracts implementation for the Superfluid Protocol",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/ethereum-contracts#readme",
     "repository": {
@@ -13,6 +13,7 @@
         "/contracts/**/*",
         "!/contracts/mocks/*",
         "/build/truffle/*.json",
+        "/build/hardhat/**/*",
         "!/build/truffle/*Mock*.json",
         "!/build/truffle/*Tester*.json",
         "!/build/truffle/*Anvil.json",

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/ethereum-contracts",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "description": " Ethereum contracts implementation for the Superfluid Protocol",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/ethereum-contracts#readme",
     "repository": {
@@ -85,22 +85,22 @@
     },
     "devDependencies": {
         "@nomiclabs/hardhat-truffle5": "^2.0.7",
-        "@superfluid-finance/metadata": "1.1.13",
-        "@superfluid-finance/js-sdk": "0.6.3",
         "@safe-global/safe-core-sdk": "^3.3.4",
         "@safe-global/safe-service-client": "^2.0.2",
         "@safe-global/safe-web3-lib": "^1.9.4",
-        "stack-trace": "0.0.10",
+        "@superfluid-finance/js-sdk": "0.6.3",
+        "@superfluid-finance/metadata": "1.1.13",
         "async": "^3.2.4",
         "csv-writer": "^1.6.0",
+        "ethers": "^5.7.2",
         "ganache-time-traveler": "1.0.16",
         "mochawesome": "^7.1.3",
         "readline": "1.3.0",
         "solidity-coverage": "0.8.4",
         "solidity-docgen": "^0.6.0-beta.35",
+        "stack-trace": "0.0.10",
         "truffle-flattener": "^1.6.0",
-        "truffle-plugin-verify": "0.6.5",
-        "ethers": "^5.7.2"
+        "truffle-plugin-verify": "0.6.5"
     },
     "peerDependencies": {
         "ethers": "^5.7.2"

--- a/packages/hot-fuzz/package.json
+++ b/packages/hot-fuzz/package.json
@@ -25,7 +25,7 @@
         "@superfluid-finance/ethereum-contracts": "1.8.0"
     },
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "1.8.0"
+        "@superfluid-finance/ethereum-contracts": "1.8.1"
     },
     "license": "AGPL-3.0",
     "bugs": {

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -49,7 +49,7 @@
         "node-fetch": "2.6.12"
     },
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "1.8.0",
+        "@superfluid-finance/ethereum-contracts": "1.8.1",
         "chai-as-promised": "^7.1.1",
         "webpack": "^5.88.2",
         "webpack-bundle-analyzer": "^4.9.0",

--- a/packages/sdk-core/contracts/SuperAppTester.sol
+++ b/packages/sdk-core/contracts/SuperAppTester.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.19;
 
 import {
     ISuperfluid,

--- a/packages/sdk-core/hardhat.config.ts
+++ b/packages/sdk-core/hardhat.config.ts
@@ -1,4 +1,4 @@
-import { HardhatUserConfig } from "hardhat/config";
+import { HardhatUserConfig, subtask } from "hardhat/config";
 import "@typechain/hardhat";
 import "@nomiclabs/hardhat-ethers";
 import "@nomicfoundation/hardhat-chai-matchers";

--- a/packages/sdk-core/hardhat.config.ts
+++ b/packages/sdk-core/hardhat.config.ts
@@ -3,8 +3,33 @@ import "@typechain/hardhat";
 import "@nomiclabs/hardhat-ethers";
 import "@nomicfoundation/hardhat-chai-matchers";
 import "@nomiclabs/hardhat-web3";
+import {
+    TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD,
+} from "hardhat/builtin-tasks/task-names";
 import { config as dotenvConfig } from "dotenv";
 dotenvConfig();
+
+// The built-in compiler (auto-downloaded if not yet present) can be overridden by setting SOLC
+// If set, we assume it's a native compiler which matches the required Solidity version.
+subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD).setAction(
+    async (args, hre, runSuper) => {
+        console.log("subtask TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD");
+        if (process.env.SOLC !== undefined) {
+            console.log(
+                "Using Solidity compiler set in SOLC:",
+                process.env.SOLC
+            );
+            return {
+                compilerPath: process.env.SOLC,
+                isSolcJs: false, // false for native compiler
+                version: args.solcVersion,
+            };
+        } else {
+            // fall back to the default
+            return runSuper();
+        }
+    }
+);
 
 /**
  * This Hardhat config is only used for testing the SDK-Core.
@@ -13,7 +38,7 @@ dotenvConfig();
  */
 const config: HardhatUserConfig = {
     solidity: {
-        version: "0.8.15",
+        version: "0.8.19",
         settings: {
             optimizer: {
                 enabled: true,

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -55,7 +55,7 @@
         "url": "https://github.com/superfluid-finance/protocol-monorepo/issues"
     },
     "dependencies": {
-        "@superfluid-finance/ethereum-contracts": "1.8.0",
+        "@superfluid-finance/ethereum-contracts": "1.8.1",
         "@superfluid-finance/metadata": "1.1.13",
         "browserify": "^17.0.0",
         "graphql-request": "^6.1.0",
@@ -71,8 +71,8 @@
         "@graphql-codegen/typescript-operations": "^4.0.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "ajv": "^8.12.0",
-        "get-graphql-schema": "^2.1.2",
         "ethers": "^5.7.2",
+        "get-graphql-schema": "^2.1.2",
         "mocha": "^10.2.0"
     },
     "peerDependencies": {

--- a/packages/sdk-core/test/2_operation.test.ts
+++ b/packages/sdk-core/test/2_operation.test.ts
@@ -141,17 +141,24 @@ makeSuite("Operation Tests", (testEnv: TestEnvironment) => {
         });
 
         it("Should be able to use arbitrary gas estimation limit", async () => {
-            const { operation: updateOp1 } = await createCallAppActionOperation(
+            const GAS_MULTIPLIER = 2;
+
+            const { operation } = await createCallAppActionOperation(
                 testEnv.alice,
                 testEnv.sdkFramework,
                 420
             );
-            const populatedTxn = await updateOp1.populateTransactionPromise;
-            const estimatedGas = await testEnv.alice.estimateGas(populatedTxn);
-            const updateOpTxn1 = await updateOp1.exec(testEnv.alice, 2);
 
-            expect(updateOpTxn1.gasLimit).to.equal(
-                multiplyGasLimit(estimatedGas, 2)
+            const populatedTxn = await operation.populateTransactionPromise;
+            const estimatedGas = await testEnv.alice.estimateGas(populatedTxn);
+
+            const callAppActionTxn = await operation.exec(
+                testEnv.alice,
+                GAS_MULTIPLIER
+            );
+
+            expect(callAppActionTxn.gasLimit).to.equal(
+                multiplyGasLimit(estimatedGas, GAS_MULTIPLIER)
             );
         });
 


### PR DESCRIPTION
Our dev-scripts still have dependency on hardhat artifacts. Let's re-ship them.

> This PR also bumps a contract used for testing calling app actions in SDK-Core from 0.8.15 to 0.8.19 and fixes a test related to the gas multiplier by simplifying it, making it less flakey and tests the desired outcome more directly.