### PR TITLE
[ETHEREUM-CONTRACTS] make batchCall payable

### DIFF
--- a/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol
+++ b/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol
@@ -600,7 +600,7 @@ interface ISuperfluid {
      * @dev Batch call function
      * @param operations Array of batch operations
      */
-    function batchCall(Operation[] calldata operations) external;
+    function batchCall(Operation[] calldata operations) external payable;
 
     /**
      * @dev Batch call function for trusted forwarders (EIP-2771)

--- a/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
+++ b/packages/ethereum-contracts/contracts/mocks/SuperAppMocks.sol
@@ -270,6 +270,10 @@ contract SuperAppMock is ISuperApp {
         assert(false);
     }
 
+    function actionCallPayable(bytes calldata ctx) external payable returns (bytes memory newCtx) {
+        newCtx = ctx;
+    }
+
     /*************************************************************************
     * Callbacks
     **************************************************************************/

--- a/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/Superfluid.sol
@@ -851,6 +851,10 @@ contract Superfluid is
                revert HOST_UNKNOWN_BATCH_CALL_OPERATION_TYPE();
             }
         }
+        if (msg.value != 0 && !valueForwarded) {
+            // return ETH provided if not forwarded
+            payable(msg.sender).transfer(msg.value);
+        }
     }
 
     /// @dev ISuperfluid.batchCall implementation

--- a/packages/ethereum-contracts/test/foundry/superfluid/Superfluid.BatchCall.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/Superfluid.BatchCall.t.sol
@@ -192,4 +192,20 @@ contract SuperfluidBatchCallTest is FoundrySuperfluidTester {
         assertEq(address(alice).balance, 42);
         assertEq(address(sf.host).balance, 0);
     }
+
+    function testBatchCallWithValueToNonPayableTarget() public {
+        SuperAppMock superAppMock = new SuperAppMock(sf.host, 0xF, false);
+        ISuperfluid.Operation[] memory ops = new ISuperfluid.Operation[](1);
+        // the ETH is forwraded with the first action.
+        ops[0] = ISuperfluid.Operation({
+            operationType: BatchOperation.OPERATION_TYPE_SUPERFLUID_CALL_APP_ACTION,
+            target: address(superAppMock),
+            data: abi.encodeCall(superAppMock.actionCallActionNoop, (""))
+        });
+        vm.deal(alice, 42);
+        vm.prank(alice);
+
+        vm.expectRevert("CallUtils: target revert()");
+        sf.host.batchCall{value: 42}(ops);
+    }
 }

--- a/packages/ethereum-contracts/test/foundry/superfluid/Superfluid.BatchCall.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/Superfluid.BatchCall.t.sol
@@ -175,5 +175,21 @@ contract SuperfluidBatchCallTest is FoundrySuperfluidTester {
         vm.prank(alice);
         sf.host.batchCall{value: 42}(ops);
         assertEq(address(superAppMock).balance, 42);
+        assertEq(address(sf.host).balance, 0);
+    }
+
+    function testBatchCallWithValueFailIfNotForwarded() public {
+        ISuperfluid.Operation[] memory ops = new ISuperfluid.Operation[](1);
+        // random operation which doesn't consume the provided value
+        ops[0] = ISuperfluid.Operation({
+            operationType: BatchOperation.OPERATION_TYPE_ERC20_INCREASE_ALLOWANCE,
+            target: address(superToken),
+            data: abi.encode(bob, 100)
+        });
+        vm.deal(alice, 42);
+        vm.prank(alice);
+        sf.host.batchCall{value: 42}(ops);
+        assertEq(address(alice).balance, 42);
+        assertEq(address(sf.host).balance, 0);
     }
 }

--- a/packages/ethereum-contracts/test/foundry/superfluid/Superfluid.BatchCall.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/Superfluid.BatchCall.t.sol
@@ -9,6 +9,7 @@ import { IConstantFlowAgreementV1 } from "../../../contracts/interfaces/agreemen
 import { ISuperfluidToken } from "../../../contracts/interfaces/superfluid/ISuperfluidToken.sol";
 import { FoundrySuperfluidTester } from "../FoundrySuperfluidTester.sol";
 import { SuperTokenV1Library } from "../../../contracts/apps/SuperTokenV1Library.sol";
+import { SuperAppMock } from "../../../contracts/mocks/SuperAppMocks.sol";
 
 contract SuperfluidBatchCallTest is FoundrySuperfluidTester {
     using SuperTokenV1Library for SuperToken;
@@ -153,5 +154,26 @@ contract SuperfluidBatchCallTest is FoundrySuperfluidTester {
         (,, int96 flowRateAllowanceAfter) = sf.cfa.getFlowOperatorData(superToken, alice, bob);
         assertEq(aliceToBobAllowanceAfter, aliceToBobAllowanceBefore + 100);
         assertEq(flowRateAllowanceAfter, flowRateAllowanceBefore + 100);
+    }
+
+    function testBatchCallWithValue() public {
+        SuperAppMock superAppMock = new SuperAppMock(sf.host, 0xF, false);
+        ISuperfluid.Operation[] memory ops = new ISuperfluid.Operation[](2);
+        // the ETH is forwraded with the first action.
+        ops[0] = ISuperfluid.Operation({
+            operationType: BatchOperation.OPERATION_TYPE_SUPERFLUID_CALL_APP_ACTION,
+            target: address(superAppMock),
+            data: abi.encodeCall(superAppMock.actionCallPayable, (""))
+        });
+        // Adding a 2nd action to make sure this is properly handled
+        ops[1] = ISuperfluid.Operation({
+            operationType: BatchOperation.OPERATION_TYPE_SUPERFLUID_CALL_APP_ACTION,
+            target: address(superAppMock),
+            data: abi.encodeCall(superAppMock.actionCallPayable, (""))
+        });
+        vm.deal(alice, 42);
+        vm.prank(alice);
+        sf.host.batchCall{value: 42}(ops);
+        assertEq(address(superAppMock).balance, 42);
     }
 }


### PR DESCRIPTION
`Superfluid.batchCall` not being payable blocks some otherwise possible ways to use it.
This PR contains a minimal changeset which makes it payable, forwarding the value provided to the first operation of type `OPERATION_TYPE_SUPERFLUID_CALL_APP_ACTION`.

A more complete solution would allow to define the value to be forwarded per operation, [as done e.g. in Multicall3](OPERATION_TYPE_SUPERFLUID_CALL_APP_ACTION).  
That would however require major code changes and make only limited sense for SF batch calls as long as it doesn't support arbitrary calls.
This PR could be a stopgap solution for unlocking a usecase blocked by it, and with a future addition supporting arbirary call targets (see https://github.com/superfluid-finance/protocol-monorepo/issues/1038) we could provide Multicall interface compatibility which includes arbitrary value splitting.

Making `batchCall` payable shouldn't risk any breakage.