### PR TITLE
[ETHEREUM-CONTRACTS] Make TestToken support permit

### DIFF
--- a/packages/ethereum-contracts/contracts/utils/TestToken.sol
+++ b/packages/ethereum-contracts/contracts/utils/TestToken.sol
@@ -1,23 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.11;
 
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC20, ERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 
 /**
  * @title Test token contract
  * @author Superfluid
  * @dev Test ERC20 token that allows any one mint new tokens.
  */
-contract TestToken is ERC20 {
+contract TestToken is ERC20Permit {
     uint256 private immutable _mintLimit;
     uint8 private _decimals;
 
-    constructor(
-        string memory name,
-        string memory symbol,
-        uint8 initDecimals,
-        uint256 mintLimit
-    ) ERC20(name, symbol) {
+    constructor(string memory name, string memory symbol, uint8 initDecimals, uint256 mintLimit)
+        ERC20Permit(name)
+        ERC20(name, symbol)
+    {
         _decimals = initDecimals;
         _mintLimit = mintLimit;
     }


### PR DESCRIPTION
- inherit from OZ's ERC20Permit instead of just ERC20