### PR TITLE
Misc: ops-scripts, metadata, forwarders

### DIFF
--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -362,8 +362,8 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
     if (governanceInitializationRequired) {
         const accounts = await web3.eth.getAccounts();
         const trustedForwarders = [];
-        if (config.biconomyForwarder) {
-            trustedForwarders.push(config.biconomyForwarder);
+        if (config.trustedForwarders) {
+            trustedForwarders.push(...config.trustedForwarders);
         }
         if (config.cfaFwd) {
             trustedForwarders.push(config.cfaFwd);

--- a/packages/ethereum-contracts/ops-scripts/gov-upgrade-super-token-logic.js
+++ b/packages/ethereum-contracts/ops-scripts/gov-upgrade-super-token-logic.js
@@ -25,6 +25,8 @@ const {
  *                  (overriding env: SKIP_TOKENS_FILE) - defaults to "./upgrade_skip_tokens.json"
  * @param {string} options.outputFile Name of file where to log addresses of tokens (to be) updated
  *                  (overriding env: OUTPUT_FILE)
+ * @param {string} options.superTokenLogic override address for the logic to upgrade to instead of the canonical one
+ *                  (overriding env: SUPER_TOKEN_LOGIC
  *
  * Usage: npx truffle exec ops-scripts/gov-upgrade-super-token-logic.js : ALL | {SUPER_TOKEN_ADDRESS} ...
  */
@@ -33,7 +35,7 @@ module.exports = eval(`(${S.toString()})()`)(async function (
     options = {}
 ) {
     console.log("======== Upgrade super token logic ========");
-    let {protocolReleaseVersion, skipTokensFile, dryRun, outputFile} = options;
+    let {protocolReleaseVersion, skipTokensFile, dryRun, outputFile, superTokenLogic} = options;
 
     console.log("protocol release version:", protocolReleaseVersion);
     dryRun = dryRun || process.env.DRY_RUN !== undefined;
@@ -59,13 +61,14 @@ module.exports = eval(`(${S.toString()})()`)(async function (
     outputFile = outputFile || process.env.OUTPUT_FILE;
     console.log("output file: ", outputFile);
 
+    superTokenLogic = superTokenLogic || process.env.SUPER_TOKEN_LOGIC;
+
     const sf = new SuperfluidSDK.Framework({
         ...extractWeb3Options(options),
         version: protocolReleaseVersion,
         additionalContracts: [
             "Ownable",
             "IMultiSigWallet",
-            "ISafe",
             "SuperfluidGovernanceBase",
             "Resolver",
             "UUPSProxiable",
@@ -75,84 +78,20 @@ module.exports = eval(`(${S.toString()})()`)(async function (
     });
     await sf.initialize();
 
-    const {UUPSProxiable, ISuperToken} = sf.contracts;
+    const canonicalSuperTokenLogic = await getCanonicalSuperTokenLogic(sf);
+    console.log(`current canonical super token logic: ${canonicalSuperTokenLogic}`);
 
-    const superTokenFactory = await sf.contracts.ISuperTokenFactory.at(
-        await sf.host.getSuperTokenFactory.call()
-    );
+    let tokensToBeUpgraded = (args.length === 1 && args[0] === "ALL") ?
+        await getTokensToBeUpgraded(sf, canonicalSuperTokenLogic, skipTokens) :
+        Array.from(args);
 
-    let tokensToBeChecked;
-    const maxItems = parseInt(process.env.MAX_ITEMS) || 1000;
-    const skipItems = parseInt(process.env.SKIP_ITEMS) || 0;
-    if (args.length === 1 && args[0] === "ALL") {
-        tokensToBeChecked = (
-            await sf.subgraphQuery(`{
-            tokenStatistics(first: ${maxItems}, skip: ${skipItems}) {
-                token {
-                    id
-                }
-            }
-        }`)
-        ).tokenStatistics.map((i) => i.token.id);
-    } else {
-        tokensToBeChecked = Array.from(args);
-    }
+    console.log(`${tokensToBeUpgraded.length} tokens to be upgraded)`);
 
-    console.log(`Got ${tokensToBeChecked.length} candidates`);
-    if (tokensToBeChecked.length >= maxItems) {
-        console.warn("### There's more items than returned by the query");
-    }
+    const superTokenLogicAddr = superTokenLogic !== undefined ?
+        superTokenLogic :
+        canonicalSuperTokenLogic;
 
-    const latestSuperTokenLogic = await superTokenFactory.getSuperTokenLogic();
-    console.log("Latest SuperToken logic address", latestSuperTokenLogic);
-
-    // before applying skip list
-    let tokensToMaybeBeUpgraded = (
-        await async.mapLimit(
-            tokensToBeChecked,
-            MAX_REQUESTS,
-            async (superTokenAddress) => {
-                const superToken = await ISuperToken.at(superTokenAddress);
-                try {
-                    const symbol = await superToken.symbol();
-                    if ((await superToken.getHost()) !== sf.host.address) {
-                        throw new Error(
-                            "Super token is from a different universe"
-                        );
-                    }
-                    const superTokenLogic = await (
-                        await UUPSProxiable.at(superTokenAddress)
-                    ).getCodeAddress();
-
-                    if (superTokenLogic === ZERO_ADDRESS) {
-                        console.log(
-                            `SuperToken@${superToken.address} (${symbol}) is likely a not initalized proxy`
-                        );
-                    } else if (latestSuperTokenLogic !== superTokenLogic) {
-                        console.log(
-                            `SuperToken@${superToken.address} (${symbol}) logic needs upgrade from ${superTokenLogic}`
-                        );
-                        return superTokenAddress;
-                    } else {
-                        console.log(
-                            `SuperToken@${superToken.address} (${symbol}) logic is up to date`
-                        );
-                        return undefined;
-                    }
-                } catch {
-                    console.warn(
-                        `[WARN] SuperToken@${superToken.address} is smelly`
-                    );
-                    return undefined;
-                }
-            }
-        )
-    ).filter((i) => typeof i !== "undefined");
-
-    console.log(`${tokensToMaybeBeUpgraded.length} tokens to maybe be upgraded (before applying skip list)`);
-
-    const tokensToBeUpgraded = tokensToMaybeBeUpgraded.filter(
-        (item) => !skipTokens.map(e => e.toLowerCase()).includes(item.toLowerCase()));
+    console.log("SuperToken logic to update to:", superTokenLogicAddr);
 
     if (tokensToBeUpgraded.length > 0) {
         console.log(`${tokensToBeUpgraded.length} tokens to be upgraded`);
@@ -168,21 +107,25 @@ module.exports = eval(`(${S.toString()})()`)(async function (
                 `*** Batch ${offset/batchSize+1} | upgrading ${batch.length} super tokens: ${JSON.stringify(batch, null, 2)}`
             );
             if (!dryRun) {
-                await sendGovernanceAction(sf, (gov) =>
-                    gov.batchUpdateSuperTokenLogic(sf.host.address, batch)
-                );
+                // a non-canonical logic address can be provided in an extra array (batchUpdateSuperTokenLogic is overloaded)
+                const govAction = superTokenLogic !== undefined ?
+                    (gov) => gov.batchUpdateSuperTokenLogic(sf.host.address, batch, [...new Array(batch.length)].map(e => superTokenLogicAddr)) :
+                    (gov) => gov.batchUpdateSuperTokenLogic(sf.host.address, batch)
 
-                console.log("checking if 2nd run needed");
+                await sendGovernanceAction(sf, govAction);
+
+                // When first updating to the version adding native flow NFTs, this needs to be run twice
+                console.log("checking if 2nd run needed...");
                 try {
-                    const beaconST = await ISuperToken.at(batch[0]);
+                    const beaconST = await sf.contracts.ISuperToken.at(batch[0]);
                     const cofAddr = await beaconST.CONSTANT_OUTFLOW_NFT();
                     if (cofAddr === ZERO_ADDRESS) {
-                        console.log("running upgrade again for NFT initialization...");
+                        console.log("...running upgrade again for NFT initialization...");
                         // the first time it is to get the code to initialize the NFT proxies there
                         // the second time is to actually execute that code in updateCode
-                        await sendGovernanceAction(sf, (gov) =>
-                            gov.batchUpdateSuperTokenLogic(sf.host.address, batch)
-                        );
+                        await sendGovernanceAction(sf, govAction);
+                    } else {
+                        console.log("...not needed");
                     }
                 } catch (e) {
                     console.log(`failed to read constantOutflowNFT addr: ${e.toString()}`);
@@ -192,3 +135,75 @@ module.exports = eval(`(${S.toString()})()`)(async function (
         }
     }
 });
+
+// returns the current canonical SuperToken logic of the SF deployment
+async function getCanonicalSuperTokenLogic(sf) {
+    const superTokenFactory = await sf.contracts.ISuperTokenFactory.at(
+        await sf.host.getSuperTokenFactory.call()
+    );
+    return superTokenFactory.getSuperTokenLogic();
+}
+
+// gets a list of tokens (addresses) to be upgraded
+// starts from the list of all SuperTokens returned by the subgraph,
+// from there filters out those
+// - having a different host
+// - not being a proxy or not having a logic address
+// - already pointing to the latest logic
+// - in the skip list (e.g. because not managed by SF gov)
+async function getTokensToBeUpgraded(sf, canonicalSuperTokenLogic, skipList) {
+    const maxItems = parseInt(process.env.MAX_ITEMS) || 1000;
+    const skipItems = parseInt(process.env.SKIP_ITEMS) || 0;
+
+    const candidateTokens = (await sf.subgraphQuery(`{
+        tokens(where: {isSuperToken: true}, first: ${maxItems}, skip: ${skipItems}) {
+            id
+        }
+    }`)).tokens.map((i) => i.id);
+
+    console.log(`Got ${candidateTokens.length} candidates`);
+    if (candidateTokens.length >= maxItems) {
+        console.warn("### There's more items than returned by the query");
+    }
+
+    return (await async.mapLimit(
+        candidateTokens,
+        MAX_REQUESTS,
+        async (superTokenAddress) => {
+            const superToken = await sf.contracts.ISuperToken.at(superTokenAddress);
+            try {
+                const symbol = await superToken.symbol();
+                if ((await superToken.getHost()) !== sf.host.address) {
+                    throw new Error(
+                        "Super token is from a different universe"
+                    );
+                }
+                const superTokenLogic = await (
+                    await sf.contracts.UUPSProxiable.at(superTokenAddress)
+                ).getCodeAddress();
+
+                if (superTokenLogic === ZERO_ADDRESS) {
+                    console.log(
+                        `SuperToken@${superToken.address} (${symbol}) is likely an uninitalized proxy`
+                    );
+                } else if (canonicalSuperTokenLogic !== superTokenLogic) {
+                    console.log(
+                        `SuperToken@${superToken.address} (${symbol}) logic needs upgrade from ${superTokenLogic}`
+                    );
+                    return superTokenAddress;
+                } else {
+                    console.log(
+                        `SuperToken@${superToken.address} (${symbol}) logic is up to date`
+                    );
+                    return undefined;
+                }
+            } catch {
+                console.warn(
+                    `[WARN] SuperToken@${superToken.address} is smelly`
+                );
+                return undefined;
+            }
+        }
+    )).filter((i) => typeof i !== "undefined")
+    .filter((item) => !skipList.map(e => e.toLowerCase()).includes(item.toLowerCase()));
+}

--- a/packages/ethereum-contracts/ops-scripts/libs/common.js
+++ b/packages/ethereum-contracts/ops-scripts/libs/common.js
@@ -161,7 +161,13 @@ async function setResolver(sf, key, value) {
         sf.resolver.address
     );
     const nrAdmins = (await ac.getRoleMemberCount(ADMIN_ROLE)).toNumber();
-    const resolverAdmin = await ac.getRoleMember(ADMIN_ROLE, nrAdmins - 1);
+    const resolverAdmin = nrAdmins > 0 ?
+        await ac.getRoleMember(ADMIN_ROLE, nrAdmins - 1):
+        await (async () => {
+            // This is for eth-goerli (and maybe other networks too)
+            console.log(`!!! resolver.getRoleMemberCount() returned 0. Trying account[0] as resolver admin.`);
+            return (await web3.eth.getAccounts())[0];
+        })();
 
     const adminType = process.env.RESOLVER_ADMIN_TYPE
         || await autodetectAdminType(sf, resolverAdmin);

--- a/packages/ethereum-contracts/ops-scripts/libs/getConfig.js
+++ b/packages/ethereum-contracts/ops-scripts/libs/getConfig.js
@@ -22,29 +22,6 @@ module.exports = function getConfig(chainId) {
             trustedForwarders: ["0x3075b4dc7085C48A14A5A39BBa68F58B19545971"],
         },
 
-        // Ethereum Goerli Testnet
-        5: {
-            trustedForwarders: ["0xE041608922d06a4F26C0d4c27d8bCD01daf1f792"], // biconomy
-        },
-
-        // Optimism Goerli Testnet
-        420: {
-            trustedForwarders: ["0x9C73373C70F23920EA54F7883dCB1F85b162Df40"], // biconomy
-        },
-
-        // Avalanche Fuji Testnet
-        43113: {
-            trustedForwarders: ["0x6271Ca63D30507f2Dcbf99B52787032506D75BBF"], // biconomy
-        },
-
-        // Polygon Mumbai Testnet
-        80001: {
-            trustedForwarders: [
-                "0x9399bb24dbb5c4b782c70c2969f58716ebbd6a3b", // biconomy 1
-                "0x69015912AA33720b842dCD6aC059Ed623F28d9f7"  // biconomy 2
-            ]
-        },
-
         // Celo Mainnet
         42220: {
             gov_enableAppWhiteListing: false,
@@ -72,6 +49,7 @@ module.exports = function getConfig(chainId) {
         nativeTokenSymbol: sfNw?.nativeTokenSymbol || "ETH",
         metadata: sfNw,
         resolverAddress: global?.process.env.RESOLVER_ADDRESS || sfNw?.contractsV1?.resolver,
+        trustedForwarders: sfNw?.trustedForwarders,
         ...EXTRA_CONFIG[chainId]
     };
 };

--- a/packages/ethereum-contracts/ops-scripts/libs/getConfig.js
+++ b/packages/ethereum-contracts/ops-scripts/libs/getConfig.js
@@ -2,37 +2,47 @@ const sfMetadata = require("@superfluid-finance/metadata");
 
 module.exports = function getConfig(chainId) {
 
-/*
- * REFERENCES:
- * - https://docs.biconomy.io/misc/contract-addresses
- */
-
     const EXTRA_CONFIG = {
+        // here go the trusted forwarders which aren't part of the framework contracts
+
         // Local Testing
         4447: {
             // for local testing (truffle internal ganache and TestEnvironment)
             // this is a fake forwarder address, it is to test the deployment script
-            biconomyForwarder: "0x3075b4dc7085C48A14A5A39BBa68F58B19545971",
+            trustedForwarders: ["0x3075b4dc7085C48A14A5A39BBa68F58B19545971"],
         },
         5777: {
             // for local testing (external ganache)
             // this is a fake forwarder address, it is to test the deployment script
-            biconomyForwarder: "0x3075b4dc7085C48A14A5A39BBa68F58B19545971",
+            trustedForwarders: ["0x3075b4dc7085C48A14A5A39BBa68F58B19545971"],
         },
         6777: {
             // for coverage testing
             // this is a fake forwarder address, it is to test the deployment script
-            biconomyForwarder: "0x3075b4dc7085C48A14A5A39BBa68F58B19545971",
+            trustedForwarders: ["0x3075b4dc7085C48A14A5A39BBa68F58B19545971"],
         },
 
         // Ethereum Goerli Testnet
         5: {
-            biconomyForwarder: "0x3075b4dc7085C48A14A5A39BBa68F58B19545971",
+            trustedForwarders: ["0xE041608922d06a4F26C0d4c27d8bCD01daf1f792"], // biconomy
+        },
+
+        // Optimism Goerli Testnet
+        420: {
+            trustedForwarders: ["0x9C73373C70F23920EA54F7883dCB1F85b162Df40"], // biconomy
+        },
+
+        // Avalanche Fuji Testnet
+        43113: {
+            trustedForwarders: ["0x6271Ca63D30507f2Dcbf99B52787032506D75BBF"], // biconomy
         },
 
         // Polygon Mumbai Testnet
         80001: {
-            biconomyForwarder: "0x2B99251eC9650e507936fa9530D11dE4d6C9C05c",
+            trustedForwarders: [
+                "0x9399bb24dbb5c4b782c70c2969f58716ebbd6a3b", // biconomy 1
+                "0x69015912AA33720b842dCD6aC059Ed623F28d9f7"  // biconomy 2
+            ]
         },
 
         // Celo Mainnet

--- a/packages/metadata/main/networks/list.cjs
+++ b/packages/metadata/main/networks/list.cjs
@@ -6,6 +6,7 @@ module.exports =
         "isTestnet": true,
         "networkId": 5,
         "chainId": 5,
+        "sfId": 101,
         "shortName": "goerli",
         "uppercaseName": "ETH_GOERLI",
         "humanReadableName": "Goerli",
@@ -54,6 +55,11 @@ module.exports =
         "publicRPCs": [
             "https://rpc.ankr.com/eth_goerli",
             "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
+        ],
+        "trustedForwarders": [
+            "0xE041608922d06a4F26C0d4c27d8bCD01daf1f792",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
         ]
     },
     {
@@ -61,6 +67,7 @@ module.exports =
         "isTestnet": true,
         "networkId": 80001,
         "chainId": 80001,
+        "sfId": 102,
         "shortName": "mumbai",
         "uppercaseName": "POLYGON_MUMBAI",
         "humanReadableName": "Polygon Mumbai",
@@ -110,6 +117,12 @@ module.exports =
         "publicRPCs": [
             "https://rpc.ankr.com/polygon_mumbai",
             "https://matic-mumbai.chainstacklabs.com"
+        ],
+        "trustedForwarders": [
+            "0x9399bb24dbb5c4b782c70c2969f58716ebbd6a3b",
+            "0x69015912AA33720b842dCD6aC059Ed623F28d9f7",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
         ]
     },
     {
@@ -117,6 +130,7 @@ module.exports =
         "isTestnet": true,
         "networkId": 420,
         "chainId": 420,
+        "sfId": 103,
         "shortName": "opgoerli",
         "uppercaseName": "OPTIMISM_GOERLI",
         "humanReadableName": "Optimism Goerli",
@@ -142,13 +156,23 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-optimism-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli"
-        }
+        },
+        "publicRPCs": [
+            "https://goerli.optimism.io",
+            "https://opt-goerli.g.alchemy.com/v2/demo"
+        ],
+        "trustedForwarders": [
+            "0x9C73373C70F23920EA54F7883dCB1F85b162Df40",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "arbitrum-goerli",
         "isTestnet": true,
         "networkId": 421613,
         "chainId": 421613,
+        "sfId": 104,
         "shortName": "arbgoerli",
         "uppercaseName": "ARBITRUM_GOERLI",
         "humanReadableName": "Arbitrum Goerli",
@@ -174,13 +198,22 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
-        }
+        },
+        "publicRPCs": [
+            "https://goerli-rollup.arbitrum.io/rpc",
+            "https://arb-goerli.g.alchemy.com/v2/demo"
+        ],
+        "trustedForwarders": [
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "avalanche-fuji",
         "isTestnet": true,
         "networkId": 43113,
         "chainId": 43113,
+        "sfId": 105,
         "shortName": "fuji",
         "uppercaseName": "AVALANCHE_FUJI",
         "humanReadableName": "Avalanche Fuji",
@@ -210,13 +243,23 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-avalanche-fuji",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji"
-        }
+        },
+        "publicRPCs": [
+            "https://api.avax-test.network/ext/bc/C/rpc",
+            "https://avalanche-fuji-c-chain.publicnode.com"
+        ],
+        "trustedForwarders": [
+            "0x6271Ca63D30507f2Dcbf99B52787032506D75BBF",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "eth-sepolia",
         "isTestnet": true,
         "networkId": 11155111,
         "chainId": 11155111,
+        "sfId": 106,
         "shortName": "sepolia",
         "uppercaseName": "ETH_SEPOLIA",
         "humanReadableName": "Sepolia",
@@ -252,6 +295,7 @@ module.exports =
         "isTestnet": true,
         "networkId": 84531,
         "chainId": 84531,
+        "sfId": 107,
         "shortName": "bgoerli",
         "uppercaseName": "BASE_GOERLI",
         "humanReadableName": "Base Goerli",
@@ -279,6 +323,10 @@ module.exports =
         "publicRPCs": [
             "https://goerli.base.org",
             "https://base-goerli.public.blastapi.io"
+        ],
+        "trustedForwarders": [
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
         ]
     },
     {
@@ -286,6 +334,7 @@ module.exports =
         "isTestnet": true,
         "networkId": 1442,
         "chainId": 1442,
+        "sfId": 108,
         "shortName": "pzkevmtest",
         "uppercaseName": "POLYGON_ZKEVM_TESTNET",
         "humanReadableName": "Polygon zkEVM Testnet",
@@ -310,13 +359,18 @@ module.exports =
         "subgraphV1": {
             "name": "protocol-v1-polygon-zkevm-testnet"
         },
-        "publicRPCs": ["https://rpc.public.zkevm-test.net"]
+        "publicRPCs": ["https://rpc.public.zkevm-test.net"],
+        "trustedForwarders": [
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "xdai-mainnet",
         "isTestnet": false,
         "networkId": 100,
         "chainId": 100,
+        "sfId": 1,
         "shortName": "xdai",
         "uppercaseName": "XDAI_MAINNET",
         "humanReadableName": "Gnosis Chain",
@@ -377,6 +431,7 @@ module.exports =
         "isTestnet": false,
         "networkId": 137,
         "chainId": 137,
+        "sfId": 2,
         "shortName": "matic",
         "uppercaseName": "POLYGON_MAINNET",
         "humanReadableName": "Polygon",
@@ -434,6 +489,7 @@ module.exports =
         "isTestnet": false,
         "networkId": 10,
         "chainId": 10,
+        "sfId": 3,
         "shortName": "optimism",
         "uppercaseName": "OPTIMISM_MAINNET",
         "humanReadableName": "Optimism",
@@ -490,6 +546,7 @@ module.exports =
         "isTestnet": false,
         "networkId": 42161,
         "chainId": 42161,
+        "sfId": 4,
         "shortName": "arbone",
         "uppercaseName": "ARBITRUM_ONE",
         "humanReadableName": "Arbitrum One",
@@ -546,6 +603,7 @@ module.exports =
         "isTestnet": false,
         "networkId": 43114,
         "chainId": 43114,
+        "sfId": 5,
         "shortName": "avalanche",
         "uppercaseName": "AVALANCHE_C",
         "humanReadableName": "Avalanche C",
@@ -602,6 +660,7 @@ module.exports =
         "isTestnet": false,
         "networkId": 56,
         "chainId": 56,
+        "sfId": 5,
         "shortName": "bsc",
         "uppercaseName": "BSC_MAINNET",
         "humanReadableName": "BNB Smart Chain",
@@ -658,6 +717,7 @@ module.exports =
         "isTestnet": false,
         "networkId": 1,
         "chainId": 1,
+        "sfId": 6,
         "shortName": "mainnet",
         "uppercaseName": "ETH_MAINNET",
         "humanReadableName": "Ethereum",
@@ -712,6 +772,7 @@ module.exports =
         "isTestnet": false,
         "networkId": 42220,
         "chainId": 42220,
+        "sfId": 7,
         "shortName": "celo",
         "uppercaseName": "CELO_MAINNET",
         "humanReadableName": "Celo",
@@ -747,6 +808,7 @@ module.exports =
         "isTestnet": false,
         "networkId": 8453,
         "chainId": 8453,
+        "sfId": 8,
         "shortName": "base",
         "uppercaseName": "BASE_MAINNET",
         "humanReadableName": "Base",

--- a/packages/metadata/module/networks/list.d.ts
+++ b/packages/metadata/module/networks/list.d.ts
@@ -27,10 +27,11 @@ interface SubgraphData {
     readonly satsumaEndpoint?: string;
 }
 export interface NetworkMetaData {
-    readonly name: string;
+    readonly name: string; // Superfluid canonical network name
     readonly isTestnet: boolean;
     readonly networkId: number;
     readonly chainId: number;
+    readonly sfId: number; // Superfluid canonical network id
     readonly shortName: string;
     readonly uppercaseName: string;
     readonly humanReadableName: string;
@@ -43,6 +44,7 @@ export interface NetworkMetaData {
     readonly subgraphV1: SubgraphData;
     readonly publicRPCs?: string[];
     readonly coinGeckoId?: string;
+    readonly trustedForwarders?: string[]; // list of additional trusted forwarders
 }
 declare const _default: NetworkMetaData[];
 export default _default;

--- a/packages/metadata/module/networks/list.js
+++ b/packages/metadata/module/networks/list.js
@@ -6,6 +6,7 @@ export default
         "isTestnet": true,
         "networkId": 5,
         "chainId": 5,
+        "sfId": 101,
         "shortName": "goerli",
         "uppercaseName": "ETH_GOERLI",
         "humanReadableName": "Goerli",
@@ -54,6 +55,11 @@ export default
         "publicRPCs": [
             "https://rpc.ankr.com/eth_goerli",
             "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
+        ],
+        "trustedForwarders": [
+            "0xE041608922d06a4F26C0d4c27d8bCD01daf1f792",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
         ]
     },
     {
@@ -61,6 +67,7 @@ export default
         "isTestnet": true,
         "networkId": 80001,
         "chainId": 80001,
+        "sfId": 102,
         "shortName": "mumbai",
         "uppercaseName": "POLYGON_MUMBAI",
         "humanReadableName": "Polygon Mumbai",
@@ -110,6 +117,12 @@ export default
         "publicRPCs": [
             "https://rpc.ankr.com/polygon_mumbai",
             "https://matic-mumbai.chainstacklabs.com"
+        ],
+        "trustedForwarders": [
+            "0x9399bb24dbb5c4b782c70c2969f58716ebbd6a3b",
+            "0x69015912AA33720b842dCD6aC059Ed623F28d9f7",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
         ]
     },
     {
@@ -117,6 +130,7 @@ export default
         "isTestnet": true,
         "networkId": 420,
         "chainId": 420,
+        "sfId": 103,
         "shortName": "opgoerli",
         "uppercaseName": "OPTIMISM_GOERLI",
         "humanReadableName": "Optimism Goerli",
@@ -142,13 +156,23 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-optimism-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli"
-        }
+        },
+        "publicRPCs": [
+            "https://goerli.optimism.io",
+            "https://opt-goerli.g.alchemy.com/v2/demo"
+        ],
+        "trustedForwarders": [
+            "0x9C73373C70F23920EA54F7883dCB1F85b162Df40",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "arbitrum-goerli",
         "isTestnet": true,
         "networkId": 421613,
         "chainId": 421613,
+        "sfId": 104,
         "shortName": "arbgoerli",
         "uppercaseName": "ARBITRUM_GOERLI",
         "humanReadableName": "Arbitrum Goerli",
@@ -174,13 +198,22 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
-        }
+        },
+        "publicRPCs": [
+            "https://goerli-rollup.arbitrum.io/rpc",
+            "https://arb-goerli.g.alchemy.com/v2/demo"
+        ],
+        "trustedForwarders": [
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "avalanche-fuji",
         "isTestnet": true,
         "networkId": 43113,
         "chainId": 43113,
+        "sfId": 105,
         "shortName": "fuji",
         "uppercaseName": "AVALANCHE_FUJI",
         "humanReadableName": "Avalanche Fuji",
@@ -210,13 +243,23 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-avalanche-fuji",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji"
-        }
+        },
+        "publicRPCs": [
+            "https://api.avax-test.network/ext/bc/C/rpc",
+            "https://avalanche-fuji-c-chain.publicnode.com"
+        ],
+        "trustedForwarders": [
+            "0x6271Ca63D30507f2Dcbf99B52787032506D75BBF",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "eth-sepolia",
         "isTestnet": true,
         "networkId": 11155111,
         "chainId": 11155111,
+        "sfId": 106,
         "shortName": "sepolia",
         "uppercaseName": "ETH_SEPOLIA",
         "humanReadableName": "Sepolia",
@@ -252,6 +295,7 @@ export default
         "isTestnet": true,
         "networkId": 84531,
         "chainId": 84531,
+        "sfId": 107,
         "shortName": "bgoerli",
         "uppercaseName": "BASE_GOERLI",
         "humanReadableName": "Base Goerli",
@@ -279,6 +323,10 @@ export default
         "publicRPCs": [
             "https://goerli.base.org",
             "https://base-goerli.public.blastapi.io"
+        ],
+        "trustedForwarders": [
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
         ]
     },
     {
@@ -286,6 +334,7 @@ export default
         "isTestnet": true,
         "networkId": 1442,
         "chainId": 1442,
+        "sfId": 108,
         "shortName": "pzkevmtest",
         "uppercaseName": "POLYGON_ZKEVM_TESTNET",
         "humanReadableName": "Polygon zkEVM Testnet",
@@ -310,13 +359,18 @@ export default
         "subgraphV1": {
             "name": "protocol-v1-polygon-zkevm-testnet"
         },
-        "publicRPCs": ["https://rpc.public.zkevm-test.net"]
+        "publicRPCs": ["https://rpc.public.zkevm-test.net"],
+        "trustedForwarders": [
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "xdai-mainnet",
         "isTestnet": false,
         "networkId": 100,
         "chainId": 100,
+        "sfId": 1,
         "shortName": "xdai",
         "uppercaseName": "XDAI_MAINNET",
         "humanReadableName": "Gnosis Chain",
@@ -377,6 +431,7 @@ export default
         "isTestnet": false,
         "networkId": 137,
         "chainId": 137,
+        "sfId": 2,
         "shortName": "matic",
         "uppercaseName": "POLYGON_MAINNET",
         "humanReadableName": "Polygon",
@@ -434,6 +489,7 @@ export default
         "isTestnet": false,
         "networkId": 10,
         "chainId": 10,
+        "sfId": 3,
         "shortName": "optimism",
         "uppercaseName": "OPTIMISM_MAINNET",
         "humanReadableName": "Optimism",
@@ -490,6 +546,7 @@ export default
         "isTestnet": false,
         "networkId": 42161,
         "chainId": 42161,
+        "sfId": 4,
         "shortName": "arbone",
         "uppercaseName": "ARBITRUM_ONE",
         "humanReadableName": "Arbitrum One",
@@ -546,6 +603,7 @@ export default
         "isTestnet": false,
         "networkId": 43114,
         "chainId": 43114,
+        "sfId": 5,
         "shortName": "avalanche",
         "uppercaseName": "AVALANCHE_C",
         "humanReadableName": "Avalanche C",
@@ -602,6 +660,7 @@ export default
         "isTestnet": false,
         "networkId": 56,
         "chainId": 56,
+        "sfId": 5,
         "shortName": "bsc",
         "uppercaseName": "BSC_MAINNET",
         "humanReadableName": "BNB Smart Chain",
@@ -658,6 +717,7 @@ export default
         "isTestnet": false,
         "networkId": 1,
         "chainId": 1,
+        "sfId": 6,
         "shortName": "mainnet",
         "uppercaseName": "ETH_MAINNET",
         "humanReadableName": "Ethereum",
@@ -712,6 +772,7 @@ export default
         "isTestnet": false,
         "networkId": 42220,
         "chainId": 42220,
+        "sfId": 7,
         "shortName": "celo",
         "uppercaseName": "CELO_MAINNET",
         "humanReadableName": "Celo",
@@ -747,6 +808,7 @@ export default
         "isTestnet": false,
         "networkId": 8453,
         "chainId": 8453,
+        "sfId": 8,
         "shortName": "base",
         "uppercaseName": "BASE_MAINNET",
         "humanReadableName": "Base",

--- a/packages/metadata/networks.json
+++ b/packages/metadata/networks.json
@@ -4,6 +4,7 @@
         "isTestnet": true,
         "networkId": 5,
         "chainId": 5,
+        "sfId": 101,
         "shortName": "goerli",
         "uppercaseName": "ETH_GOERLI",
         "humanReadableName": "Goerli",
@@ -52,6 +53,11 @@
         "publicRPCs": [
             "https://rpc.ankr.com/eth_goerli",
             "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
+        ],
+        "trustedForwarders": [
+            "0xE041608922d06a4F26C0d4c27d8bCD01daf1f792",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
         ]
     },
     {
@@ -59,6 +65,7 @@
         "isTestnet": true,
         "networkId": 80001,
         "chainId": 80001,
+        "sfId": 102,
         "shortName": "mumbai",
         "uppercaseName": "POLYGON_MUMBAI",
         "humanReadableName": "Polygon Mumbai",
@@ -108,6 +115,12 @@
         "publicRPCs": [
             "https://rpc.ankr.com/polygon_mumbai",
             "https://matic-mumbai.chainstacklabs.com"
+        ],
+        "trustedForwarders": [
+            "0x9399bb24dbb5c4b782c70c2969f58716ebbd6a3b",
+            "0x69015912AA33720b842dCD6aC059Ed623F28d9f7",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
         ]
     },
     {
@@ -115,6 +128,7 @@
         "isTestnet": true,
         "networkId": 420,
         "chainId": 420,
+        "sfId": 103,
         "shortName": "opgoerli",
         "uppercaseName": "OPTIMISM_GOERLI",
         "humanReadableName": "Optimism Goerli",
@@ -140,13 +154,23 @@
         "subgraphV1": {
             "name": "protocol-v1-optimism-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli"
-        }
+        },
+        "publicRPCs": [
+            "https://goerli.optimism.io",
+            "https://opt-goerli.g.alchemy.com/v2/demo"
+        ],
+        "trustedForwarders": [
+            "0x9C73373C70F23920EA54F7883dCB1F85b162Df40",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "arbitrum-goerli",
         "isTestnet": true,
         "networkId": 421613,
         "chainId": 421613,
+        "sfId": 104,
         "shortName": "arbgoerli",
         "uppercaseName": "ARBITRUM_GOERLI",
         "humanReadableName": "Arbitrum Goerli",
@@ -172,13 +196,22 @@
         "subgraphV1": {
             "name": "protocol-v1-arbitrum-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
-        }
+        },
+        "publicRPCs": [
+            "https://goerli-rollup.arbitrum.io/rpc",
+            "https://arb-goerli.g.alchemy.com/v2/demo"
+        ],
+        "trustedForwarders": [
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "avalanche-fuji",
         "isTestnet": true,
         "networkId": 43113,
         "chainId": 43113,
+        "sfId": 105,
         "shortName": "fuji",
         "uppercaseName": "AVALANCHE_FUJI",
         "humanReadableName": "Avalanche Fuji",
@@ -208,13 +241,23 @@
         "subgraphV1": {
             "name": "protocol-v1-avalanche-fuji",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji"
-        }
+        },
+        "publicRPCs": [
+            "https://api.avax-test.network/ext/bc/C/rpc",
+            "https://avalanche-fuji-c-chain.publicnode.com"
+        ],
+        "trustedForwarders": [
+            "0x6271Ca63D30507f2Dcbf99B52787032506D75BBF",
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "eth-sepolia",
         "isTestnet": true,
         "networkId": 11155111,
         "chainId": 11155111,
+        "sfId": 106,
         "shortName": "sepolia",
         "uppercaseName": "ETH_SEPOLIA",
         "humanReadableName": "Sepolia",
@@ -250,6 +293,7 @@
         "isTestnet": true,
         "networkId": 84531,
         "chainId": 84531,
+        "sfId": 107,
         "shortName": "bgoerli",
         "uppercaseName": "BASE_GOERLI",
         "humanReadableName": "Base Goerli",
@@ -277,6 +321,10 @@
         "publicRPCs": [
             "https://goerli.base.org",
             "https://base-goerli.public.blastapi.io"
+        ],
+        "trustedForwarders": [
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
         ]
     },
     {
@@ -284,6 +332,7 @@
         "isTestnet": true,
         "networkId": 1442,
         "chainId": 1442,
+        "sfId": 108,
         "shortName": "pzkevmtest",
         "uppercaseName": "POLYGON_ZKEVM_TESTNET",
         "humanReadableName": "Polygon zkEVM Testnet",
@@ -308,13 +357,18 @@
         "subgraphV1": {
             "name": "protocol-v1-polygon-zkevm-testnet"
         },
-        "publicRPCs": ["https://rpc.public.zkevm-test.net"]
+        "publicRPCs": ["https://rpc.public.zkevm-test.net"],
+        "trustedForwarders": [
+            "0xb539068872230f20456CF38EC52EF2f91AF4AE49",
+            "0xd8253782c45a12053594b9deB72d8e8aB2Fca54c"
+        ]
     },
     {
         "name": "xdai-mainnet",
         "isTestnet": false,
         "networkId": 100,
         "chainId": 100,
+        "sfId": 1,
         "shortName": "xdai",
         "uppercaseName": "XDAI_MAINNET",
         "humanReadableName": "Gnosis Chain",
@@ -375,6 +429,7 @@
         "isTestnet": false,
         "networkId": 137,
         "chainId": 137,
+        "sfId": 2,
         "shortName": "matic",
         "uppercaseName": "POLYGON_MAINNET",
         "humanReadableName": "Polygon",
@@ -432,6 +487,7 @@
         "isTestnet": false,
         "networkId": 10,
         "chainId": 10,
+        "sfId": 3,
         "shortName": "optimism",
         "uppercaseName": "OPTIMISM_MAINNET",
         "humanReadableName": "Optimism",
@@ -488,6 +544,7 @@
         "isTestnet": false,
         "networkId": 42161,
         "chainId": 42161,
+        "sfId": 4,
         "shortName": "arbone",
         "uppercaseName": "ARBITRUM_ONE",
         "humanReadableName": "Arbitrum One",
@@ -544,6 +601,7 @@
         "isTestnet": false,
         "networkId": 43114,
         "chainId": 43114,
+        "sfId": 5,
         "shortName": "avalanche",
         "uppercaseName": "AVALANCHE_C",
         "humanReadableName": "Avalanche C",
@@ -600,6 +658,7 @@
         "isTestnet": false,
         "networkId": 56,
         "chainId": 56,
+        "sfId": 5,
         "shortName": "bsc",
         "uppercaseName": "BSC_MAINNET",
         "humanReadableName": "BNB Smart Chain",
@@ -656,6 +715,7 @@
         "isTestnet": false,
         "networkId": 1,
         "chainId": 1,
+        "sfId": 6,
         "shortName": "mainnet",
         "uppercaseName": "ETH_MAINNET",
         "humanReadableName": "Ethereum",
@@ -710,6 +770,7 @@
         "isTestnet": false,
         "networkId": 42220,
         "chainId": 42220,
+        "sfId": 7,
         "shortName": "celo",
         "uppercaseName": "CELO_MAINNET",
         "humanReadableName": "Celo",
@@ -745,6 +806,7 @@
         "isTestnet": false,
         "networkId": 8453,
         "chainId": 8453,
+        "sfId": 8,
         "shortName": "base",
         "uppercaseName": "BASE_MAINNET",
         "humanReadableName": "Base",


### PR DESCRIPTION
* ops-scripts/gov-upgrade-super-token-logic.js: added option to upgrade to non-canonical SuperToken logic (for the devolution revolution)
* replace config item `biconomyForwarder` with more generic `trustedForwarders` list and move it to metadata
* add Gelato's GelatoRelayERC2771 and GelatoRelay1BalanceERC2771 ([docs](https://docs.gelato.network/developer-services/relay/erc-2771-recommended)) as trusted forwarders on testnets (currently being explored as option for the widget for SuperUpgrader txs - we'll do a security check before adding to mainnets) - see https://github.com/superfluid-finance/protocol-monorepo/issues/1850
* add numeric network id's to metadata (see https://www.notion.so/superfluidhq/edc1845ec0ef4b83a2d27fb767f992d2?v=5a9ee2b933ec4bc0988ee80fa7adaffa&p=7d490209ea294d9482eb884126d1bff1&pm=s) - this is cheap and unblocks any progress on this (mainly for internal infra code)
* add public RPCs to metadata where missing