### PR TITLE
[SUBGRAPH] Updated sf and satsuma supported network lists

### DIFF
--- a/packages/subgraph/tasks/deploy.sh
+++ b/packages/subgraph/tasks/deploy.sh
@@ -13,9 +13,9 @@ SUPPORTED_VENDORS=( "graph" "satsuma" "superfluid" )
 # shellcheck disable=SC2034,SC2207
 GRAPH_NETWORKS=( $($JQ -r .[] ./hosted-service-networks.json) ) || exit 1
 # shellcheck disable=SC2034
-SATSUMA_NETWORKS=( "matic" "xdai" "eth-mainnet" "eth-sepolia" "optimism-mainnet" )
+SATSUMA_NETWORKS=( "matic" "xdai" "eth-mainnet" "eth-sepolia" "optimism-mainnet" "base-mainnet")
 # shellcheck disable=SC2034
-SUPERFLUID_NETWORKS=( "polygon-zkevm-testnet" "polygon-mainnet" "eth-sepolia" "base-goerli" )
+SUPERFLUID_NETWORKS=( "polygon-zkevm-testnet" "polygon-mainnet" "eth-sepolia" "base-goerli" "eth-mainnet" "xdai-mainnet" "base-mainnet" "optimism-mainnet" "arbitrum-one")
 
 VENDOR=""
 NETWORK=""


### PR DESCRIPTION
PR adds to the list of networks supported by self hosted subgraph nodes. Also adds base-mainnet to list of networks for Satsuma.