### PR TITLE
[WORKFLOWS] Update call.check-query-schema-against-subgraph.yml

### DIFF
--- a/.github/workflows/call.check-query-schema-against-subgraph.yml
+++ b/.github/workflows/call.check-query-schema-against-subgraph.yml
@@ -34,6 +34,10 @@ jobs:
         run: yarn build
         working-directory: ./packages/ethereum-contracts
 
+      - name: "Build SDK-Core"
+        run: yarn build
+        working-directory: ${{ env.sdk-core-working-directory }}
+
       - name: Get Hosted Service Networks from metadata
         run: npx ts-node ./scripts/getHostedServiceNetworks.ts
         working-directory: ./packages/subgraph


### PR DESCRIPTION
The `Reusable Workflow | Check SDK-Core Schema Against Deployed Subgraphs` workflow file was broken because it did not build sdk-core which meant that the `typechain-types` folder wasn't available.