### PR TITLE
[SUBGRAPH-OPS] Update deploy.sh

### DIFF
--- a/packages/subgraph/tasks/deploy.sh
+++ b/packages/subgraph/tasks/deploy.sh
@@ -13,7 +13,7 @@ SUPPORTED_VENDORS=( "graph" "satsuma" "superfluid" )
 # shellcheck disable=SC2034,SC2207
 GRAPH_NETWORKS=( $($JQ -r .[] ./hosted-service-networks.json) ) || exit 1
 # shellcheck disable=SC2034
-SATSUMA_NETWORKS=( "matic" "xdai" "eth-mainnet" "eth-sepolia" "optimism-mainnet" "base-mainnet")
+SATSUMA_NETWORKS=( "polygon-mainnet" "xdai-mainnet" "eth-mainnet" "eth-sepolia" "optimism-mainnet" "base-mainnet")
 # shellcheck disable=SC2034
 SUPERFLUID_NETWORKS=( "polygon-zkevm-testnet" "polygon-mainnet" "eth-sepolia" "base-goerli" "eth-mainnet" "xdai-mainnet" "base-mainnet" "optimism-mainnet" "arbitrum-one")
 


### PR DESCRIPTION
The list of `SATSUMA_NETWORKS` should include the canonical names as we have a `legacyNetworkNames` which maps it to the correct name anyways.

Our `buildNetworkConfig.ts` script (we removed hardcoded configs and are building it based off metadata) expects the canonical name (the one in metadata) otherwise it won't create the .json file and the subgraph deployment will fail.