### PR TITLE
[SDK-CORE] patch getUnderlyingToken

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -5,8 +5,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+
+## [0.6.10] - 2023-10-16
+
 ### Added
 - Support for `ConstantOutflowNFT` and `ConstantInflowNFT` functions
+
+### Fixed
+- Support for `CustomSuperToken` contracts without `getUnderlyingToken()` function implemented
 
 ## [0.6.9] - 2023-09-11
 

--- a/packages/sdk-core/contracts/NoGetUnderlyingToken.sol
+++ b/packages/sdk-core/contracts/NoGetUnderlyingToken.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+contract NoGetUnderlyingToken {
+
+    // solhint-disable-next-line var-name-mixedcase
+    address public CONSTANT_OUTFLOW_NFT;
+
+    // solhint-disable-next-line var-name-mixedcase
+    address public CONSTANT_INFLOW_NFT;
+
+    function symbol() public pure returns (string memory) {
+        return "NOGET";
+    }
+}

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-core",
-    "version": "0.6.9",
+    "version": "0.6.10",
     "description": "SDK Core for building with Superfluid Protocol",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/sdk-core#readme",
     "repository": {

--- a/packages/sdk-core/src/SuperToken.ts
+++ b/packages/sdk-core/src/SuperToken.ts
@@ -54,6 +54,7 @@ import {
     getSanitizedTimestamp,
     getStringCurrentTimeInSeconds,
     normalizeAddress,
+    tryGet,
 } from "./utils";
 
 export interface NFTAddresses {
@@ -135,9 +136,13 @@ export default abstract class SuperToken extends ERC20Token {
                 options.address,
                 options.provider
             );
-            const underlyingTokenAddress = await superToken
+            const getUnderlyingTokenPromise = superToken
                 .connect(options.provider)
                 .getUnderlyingToken();
+            const underlyingTokenAddress = await tryGet(
+                getUnderlyingTokenPromise,
+                ethers.constants.AddressZero
+            );
             const settings: ITokenSettings = {
                 address: options.address,
                 config: options.config,

--- a/packages/sdk-core/src/utils.ts
+++ b/packages/sdk-core/src/utils.ts
@@ -314,3 +314,14 @@ export const clipDepositNumber = (deposit: BigNumber, roundingDown = false) => {
         : 1;
     return deposit.shr(32).add(toBN(rounding)).shl(32);
 };
+
+export async function tryGet<T>(
+    somePromise: Promise<T>,
+    defaultReturnValue: T
+): Promise<T> {
+    try {
+        return await somePromise;
+    } catch {
+        return defaultReturnValue;
+    }
+}

--- a/packages/sdk-core/test/1.0_supertoken.test.ts
+++ b/packages/sdk-core/test/1.0_supertoken.test.ts
@@ -1,3 +1,4 @@
+import hre from "hardhat";
 import { expect } from "chai";
 import { NativeAssetSuperToken, SuperToken, toBN } from "../src";
 import { ethers } from "ethers";
@@ -123,6 +124,17 @@ makeSuite("SuperToken Tests", (testEnv: TestEnvironment) => {
                 );
                 expect(err.cause).to.be.instanceOf(Error);
             }
+        });
+
+        it("Should support SuperToken without getUnderlyingToken() function implemented",async () => {
+            const noGetUnderlyingTokenFactory = await hre.ethers.getContractFactory("NoGetUnderlyingToken");
+            const noGetUnderlyingToken = await noGetUnderlyingTokenFactory.deploy();
+            await SuperToken.create({
+                address: noGetUnderlyingToken.address,
+                provider: testEnv.alice.provider!,
+                config: testEnv.sdkFramework.settings.config,
+                networkName: "custom",
+            });
         });
 
         it("Should properly return totalSupply", async () => {


### PR DESCRIPTION
- this fixes an issue first reported on slack [here](https://superfluidhq.slack.com/archives/C02K8UDDLR0/p1697137370913019?thread_ts=1697123027.550069&cid=C02K8UDDLR0) where supertoken creation is broken because of the assumption that getUnderlyingToken exists