### PR TITLE
[ETHEREUM-CONTRACTS] Fix canary build

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -272,7 +272,7 @@ jobs:
           cloudfront_distribution_id: E3JEO5R14CT8IH
 
   upgrade-contracts:
-    name: Upgrade ethereum-contracts on canary testnet (protocol release version "test")
+    name: Upgrade ethereum-contracts on canary testnet (protocol release version "canary")
 
     needs: [all-packages-tested]
 
@@ -306,6 +306,6 @@ jobs:
           npx truffle exec --network ${{ matrix.network }} ops-scripts/info-print-contract-addresses.js : addresses.vars
           tasks/etherscan-verify-framework.sh ${{ matrix.network }} addresses.vars
         env:
-          RELEASE_VERSION: master
+          RELEASE_VERSION: canary
           AVALANCHE_FUJI_MNEMONIC: ${{ secrets.BUILD_AGENT_MNEMONIC  }}
           AVALANCHE_FUJI_PROVIDER_URL: ${{ secrets.AVALANCHE_FUJI_PROVIDER_URL }}

--- a/packages/ethereum-contracts/ops-scripts/resolver-list-super-token.js
+++ b/packages/ethereum-contracts/ops-scripts/resolver-list-super-token.js
@@ -64,7 +64,8 @@ module.exports = eval(`(${S.toString()})()`)(async function (
             "org.superfluid-finance.contracts.SuperToken.implementation"
         )
     ) {
-        throw new Error("Not a super token");
+        // This may be ok, but may also point to a mistake in address handling (e.g. not a SuperToken).
+        console.warn('!!! proxiableUUID is not keccak("org.superfluid-finance.contracts.SuperToken.implementation")');
     }
     const tokenSymbol = symbolOverride !== undefined ? symbolOverride : await superToken.symbol.call();
     const superTokenKey = `supertokens.${protocolReleaseVersion}.${tokenSymbol}`;


### PR DESCRIPTION
Problem was that the deployment was bricked, probably due to an incomplete gov init (for testnets, that's possible).
Fixde by changing release version from "master" to "canary".