### PR TITLE
[METADATA] Add `cliName` to "subgraphV1" property

### DIFF
--- a/packages/automation-contracts/autowrap/package.json
+++ b/packages/automation-contracts/autowrap/package.json
@@ -15,6 +15,6 @@
     "dependencies": {
         "@openzeppelin/contracts": "4.9.3",
         "@superfluid-finance/ethereum-contracts": "1.8.1",
-        "@superfluid-finance/metadata": "1.1.18"
+        "@superfluid-finance/metadata": "1.1.19"
     }
 }

--- a/packages/automation-contracts/scheduler/package.json
+++ b/packages/automation-contracts/scheduler/package.json
@@ -15,6 +15,6 @@
     "dependencies": {
         "@openzeppelin/contracts": "4.9.3",
         "@superfluid-finance/ethereum-contracts": "1.8.1",
-        "@superfluid-finance/metadata": "1.1.18"
+        "@superfluid-finance/metadata": "1.1.19"
     }
 }

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -91,7 +91,7 @@
         "@safe-global/safe-service-client": "^2.0.3",
         "@safe-global/safe-web3-lib": "^1.9.4",
         "@superfluid-finance/js-sdk": "0.6.3",
-        "@superfluid-finance/metadata": "1.1.18",
+        "@superfluid-finance/metadata": "1.1.19",
         "async": "^3.2.4",
         "csv-writer": "^1.6.0",
         "ethers": "^5.7.2",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -43,7 +43,7 @@
         "cloc": "sh tasks/cloc.sh"
     },
     "dependencies": {
-        "@superfluid-finance/metadata": "1.1.18",
+        "@superfluid-finance/metadata": "1.1.19",
         "@truffle/contract": "4.6.29",
         "auto-bind": "4.0.0",
         "node-fetch": "2.7.0"

--- a/packages/metadata/CHANGELOG.md
+++ b/packages/metadata/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the metadata will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.19]
+### Added
+- `cliName` property under "subgraphV1" for the canonical subgraph network names, see [here](https://thegraph.com/docs/en/developing/supported-networks/#hosted-service)
+
 ## [v1.1.18]
 ### Fixed
 - Changed the `module/networks/list.d.ts` file to correctly reflect the `contractsV1` object in our `networks.json` file.

--- a/packages/metadata/main/networks/list.cjs
+++ b/packages/metadata/main/networks/list.cjs
@@ -37,6 +37,7 @@ module.exports =
         "logsQueryRange": 10000,
         "explorer": "https://goerli.etherscan.io",
         "subgraphV1": {
+            "cliName": "goerli",
             "name": "protocol-v1-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli"
         },
@@ -98,6 +99,7 @@ module.exports =
         "logsQueryRange": 10000,
         "explorer": "https://mumbai.polygonscan.com",
         "subgraphV1": {
+            "cliName": "mumbai",
             "name": "protocol-v1-mumbai",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai"
         },
@@ -152,6 +154,7 @@ module.exports =
         "logsQueryRange": 50000,
         "explorer": "https://goerli-optimism.etherscan.io",
         "subgraphV1": {
+            "cliName": "optimism-goerli",
             "name": "protocol-v1-optimism-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli"
         },
@@ -193,6 +196,7 @@ module.exports =
         "logsQueryRange": 50000,
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
+            "cliName": "arbitrum-goerli",
             "name": "protocol-v1-arbitrum-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
         },
@@ -237,6 +241,7 @@ module.exports =
         "logsQueryRange": 50000,
         "explorer": "https://testnet.snowtrace.io",
         "subgraphV1": {
+            "cliName": "fuji",
             "name": "protocol-v1-avalanche-fuji",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji"
         },
@@ -277,6 +282,7 @@ module.exports =
         "logsQueryRange": 10000,
         "explorer": "https://sepolia.etherscan.io",
         "subgraphV1": {
+            "cliName": "sepolia",
             "name": "protocol-v1-eth-sepolia",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-sepolia/api"
         },
@@ -350,6 +356,7 @@ module.exports =
         "logsQueryRange": 20000,
         "explorer": "https://testnet-zkevm.polygonscan.org/",
         "subgraphV1": {
+            "cliName": "polygon-zkevm-testnet",
             "name": "protocol-v1-polygon-zkevm-testnet"
         },
         "publicRPCs": ["https://rpc.public.zkevm-test.net"],
@@ -396,6 +403,7 @@ module.exports =
         "logsQueryRange": 20000,
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
+            "cliName": "gnosis",
             "name": "protocol-v1-xdai",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
@@ -454,6 +462,7 @@ module.exports =
         "logsQueryRange": 10000,
         "explorer": "https://polygonscan.com",
         "subgraphV1": {
+            "cliName": "matic",
             "name": "protocol-v1-matic",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/matic/api"
@@ -512,6 +521,7 @@ module.exports =
         "logsQueryRange": 50000,
         "explorer": "https://optimistic.etherscan.io",
         "subgraphV1": {
+            "cliName": "optimism",
             "name": "protocol-v1-optimism-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet"
         },
@@ -569,6 +579,7 @@ module.exports =
         "logsQueryRange": 50000,
         "explorer": "https://arbiscan.io",
         "subgraphV1": {
+            "cliName": "arbitrum-one",
             "name": "protocol-v1-arbitrum-one",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one"
         },
@@ -626,6 +637,7 @@ module.exports =
         "logsQueryRange": 50000,
         "explorer": "https://snowtrace.io",
         "subgraphV1": {
+            "cliName": "avalanche",
             "name": "protocol-v1-avalanche-c",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c"
         },
@@ -683,6 +695,7 @@ module.exports =
         "logsQueryRange": 5000,
         "explorer": "https://bscscan.com",
         "subgraphV1": {
+            "cliName": "bsc",
             "name": "protocol-v1-bsc-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet"
         },
@@ -737,6 +750,7 @@ module.exports =
         "logsQueryRange": 10000,
         "explorer": "https://etherscan.io",
         "subgraphV1": {
+            "cliName": "mainnet",
             "name": "protocol-v1-eth-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
@@ -789,6 +803,7 @@ module.exports =
         "logsQueryRange": 20000,
         "explorer": "https://celoscan.io",
         "subgraphV1": {
+            "cliName": "celo",
             "name": "protocol-v1-celo-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet"
         },
@@ -825,6 +840,7 @@ module.exports =
         "logsQueryRange": 20000,
         "explorer": "https://basescan.org",
         "subgraphV1": {
+            "cliName": "base",
             "name": "protocol-v1-base-mainnet"
         },
         "publicRPCs": ["https://developer-access-mainnet.base.org"],

--- a/packages/metadata/module/networks/list.d.ts
+++ b/packages/metadata/module/networks/list.d.ts
@@ -24,6 +24,7 @@ interface ContractAddresses {
 }
 interface SubgraphData {
     readonly name: string;
+    readonly cliName?: string;
     readonly hostedEndpoint?: string;
     readonly satsumaEndpoint?: string;
 }

--- a/packages/metadata/module/networks/list.js
+++ b/packages/metadata/module/networks/list.js
@@ -37,6 +37,7 @@ export default
         "logsQueryRange": 10000,
         "explorer": "https://goerli.etherscan.io",
         "subgraphV1": {
+            "cliName": "goerli",
             "name": "protocol-v1-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli"
         },
@@ -98,6 +99,7 @@ export default
         "logsQueryRange": 10000,
         "explorer": "https://mumbai.polygonscan.com",
         "subgraphV1": {
+            "cliName": "mumbai",
             "name": "protocol-v1-mumbai",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai"
         },
@@ -152,6 +154,7 @@ export default
         "logsQueryRange": 50000,
         "explorer": "https://goerli-optimism.etherscan.io",
         "subgraphV1": {
+            "cliName": "optimism-goerli",
             "name": "protocol-v1-optimism-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli"
         },
@@ -193,6 +196,7 @@ export default
         "logsQueryRange": 50000,
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
+            "cliName": "arbitrum-goerli",
             "name": "protocol-v1-arbitrum-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
         },
@@ -237,6 +241,7 @@ export default
         "logsQueryRange": 50000,
         "explorer": "https://testnet.snowtrace.io",
         "subgraphV1": {
+            "cliName": "fuji",
             "name": "protocol-v1-avalanche-fuji",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji"
         },
@@ -277,6 +282,7 @@ export default
         "logsQueryRange": 10000,
         "explorer": "https://sepolia.etherscan.io",
         "subgraphV1": {
+            "cliName": "sepolia",
             "name": "protocol-v1-eth-sepolia",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-sepolia/api"
         },
@@ -350,6 +356,7 @@ export default
         "logsQueryRange": 20000,
         "explorer": "https://testnet-zkevm.polygonscan.org/",
         "subgraphV1": {
+            "cliName": "polygon-zkevm-testnet",
             "name": "protocol-v1-polygon-zkevm-testnet"
         },
         "publicRPCs": ["https://rpc.public.zkevm-test.net"],
@@ -396,6 +403,7 @@ export default
         "logsQueryRange": 20000,
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
+            "cliName": "gnosis",
             "name": "protocol-v1-xdai",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
@@ -454,6 +462,7 @@ export default
         "logsQueryRange": 10000,
         "explorer": "https://polygonscan.com",
         "subgraphV1": {
+            "cliName": "matic",
             "name": "protocol-v1-matic",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/matic/api"
@@ -512,6 +521,7 @@ export default
         "logsQueryRange": 50000,
         "explorer": "https://optimistic.etherscan.io",
         "subgraphV1": {
+            "cliName": "optimism",
             "name": "protocol-v1-optimism-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet"
         },
@@ -569,6 +579,7 @@ export default
         "logsQueryRange": 50000,
         "explorer": "https://arbiscan.io",
         "subgraphV1": {
+            "cliName": "arbitrum-one",
             "name": "protocol-v1-arbitrum-one",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one"
         },
@@ -626,6 +637,7 @@ export default
         "logsQueryRange": 50000,
         "explorer": "https://snowtrace.io",
         "subgraphV1": {
+            "cliName": "avalanche",
             "name": "protocol-v1-avalanche-c",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c"
         },
@@ -683,6 +695,7 @@ export default
         "logsQueryRange": 5000,
         "explorer": "https://bscscan.com",
         "subgraphV1": {
+            "cliName": "bsc",
             "name": "protocol-v1-bsc-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet"
         },
@@ -737,6 +750,7 @@ export default
         "logsQueryRange": 10000,
         "explorer": "https://etherscan.io",
         "subgraphV1": {
+            "cliName": "mainnet",
             "name": "protocol-v1-eth-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
@@ -789,6 +803,7 @@ export default
         "logsQueryRange": 20000,
         "explorer": "https://celoscan.io",
         "subgraphV1": {
+            "cliName": "celo",
             "name": "protocol-v1-celo-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet"
         },
@@ -825,6 +840,7 @@ export default
         "logsQueryRange": 20000,
         "explorer": "https://basescan.org",
         "subgraphV1": {
+            "cliName": "base",
             "name": "protocol-v1-base-mainnet"
         },
         "publicRPCs": ["https://developer-access-mainnet.base.org"],

--- a/packages/metadata/networks.json
+++ b/packages/metadata/networks.json
@@ -35,6 +35,7 @@
         "logsQueryRange": 10000,
         "explorer": "https://goerli.etherscan.io",
         "subgraphV1": {
+            "cliName": "goerli",
             "name": "protocol-v1-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-goerli"
         },
@@ -96,6 +97,7 @@
         "logsQueryRange": 10000,
         "explorer": "https://mumbai.polygonscan.com",
         "subgraphV1": {
+            "cliName": "mumbai",
             "name": "protocol-v1-mumbai",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-mumbai"
         },
@@ -150,6 +152,7 @@
         "logsQueryRange": 50000,
         "explorer": "https://goerli-optimism.etherscan.io",
         "subgraphV1": {
+            "cliName": "optimism-goerli",
             "name": "protocol-v1-optimism-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-goerli"
         },
@@ -191,6 +194,7 @@
         "logsQueryRange": 50000,
         "explorer": "https://goerli.arbiscan.io",
         "subgraphV1": {
+            "cliName": "arbitrum-goerli",
             "name": "protocol-v1-arbitrum-goerli",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-goerli"
         },
@@ -235,6 +239,7 @@
         "logsQueryRange": 50000,
         "explorer": "https://testnet.snowtrace.io",
         "subgraphV1": {
+            "cliName": "fuji",
             "name": "protocol-v1-avalanche-fuji",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-fuji"
         },
@@ -275,6 +280,7 @@
         "logsQueryRange": 10000,
         "explorer": "https://sepolia.etherscan.io",
         "subgraphV1": {
+            "cliName": "sepolia",
             "name": "protocol-v1-eth-sepolia",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-sepolia/api"
         },
@@ -348,6 +354,7 @@
         "logsQueryRange": 20000,
         "explorer": "https://testnet-zkevm.polygonscan.org/",
         "subgraphV1": {
+            "cliName": "polygon-zkevm-testnet",
             "name": "protocol-v1-polygon-zkevm-testnet"
         },
         "publicRPCs": ["https://rpc.public.zkevm-test.net"],
@@ -394,6 +401,7 @@
         "logsQueryRange": 20000,
         "explorer": "https://gnosisscan.io",
         "subgraphV1": {
+            "cliName": "gnosis",
             "name": "protocol-v1-xdai",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-xdai",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/xdai/api"
@@ -452,6 +460,7 @@
         "logsQueryRange": 10000,
         "explorer": "https://polygonscan.com",
         "subgraphV1": {
+            "cliName": "matic",
             "name": "protocol-v1-matic",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-matic",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/matic/api"
@@ -510,6 +519,7 @@
         "logsQueryRange": 50000,
         "explorer": "https://optimistic.etherscan.io",
         "subgraphV1": {
+            "cliName": "optimism",
             "name": "protocol-v1-optimism-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-optimism-mainnet"
         },
@@ -567,6 +577,7 @@
         "logsQueryRange": 50000,
         "explorer": "https://arbiscan.io",
         "subgraphV1": {
+            "cliName": "arbitrum-one",
             "name": "protocol-v1-arbitrum-one",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-arbitrum-one"
         },
@@ -624,6 +635,7 @@
         "logsQueryRange": 50000,
         "explorer": "https://snowtrace.io",
         "subgraphV1": {
+            "cliName": "avalanche",
             "name": "protocol-v1-avalanche-c",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-avalanche-c"
         },
@@ -681,6 +693,7 @@
         "logsQueryRange": 5000,
         "explorer": "https://bscscan.com",
         "subgraphV1": {
+            "cliName": "bsc",
             "name": "protocol-v1-bsc-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-bsc-mainnet"
         },
@@ -735,6 +748,7 @@
         "logsQueryRange": 10000,
         "explorer": "https://etherscan.io",
         "subgraphV1": {
+            "cliName": "mainnet",
             "name": "protocol-v1-eth-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-eth-mainnet",
             "satsumaEndpoint": "https://subgraph.satsuma-prod.com/c5br3jaVlJI6/superfluid/eth-mainnet/api"
@@ -787,6 +801,7 @@
         "logsQueryRange": 20000,
         "explorer": "https://celoscan.io",
         "subgraphV1": {
+            "cliName": "celo",
             "name": "protocol-v1-celo-mainnet",
             "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-celo-mainnet"
         },
@@ -823,6 +838,7 @@
         "logsQueryRange": 20000,
         "explorer": "https://basescan.org",
         "subgraphV1": {
+            "cliName": "base",
             "name": "protocol-v1-base-mainnet"
         },
         "publicRPCs": ["https://developer-access-mainnet.base.org"],

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfluid-finance/metadata",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Superfluid Metadata",
   "main": "main/index.cjs",
   "module": "module/index.js",

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -57,7 +57,7 @@
     },
     "dependencies": {
         "@superfluid-finance/ethereum-contracts": "1.8.1",
-        "@superfluid-finance/metadata": "1.1.18",
+        "@superfluid-finance/metadata": "1.1.19",
         "browserify": "^17.0.0",
         "graphql-request": "^6.1.0",
         "lodash": "^4.17.21",

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -54,7 +54,7 @@
         "mustache": "^4.2.0"
     },
     "devDependencies": {
-        "@superfluid-finance/metadata": "1.1.18",
+        "@superfluid-finance/metadata": "1.1.19",
         "coingecko-api": "^1.0.10",
         "graphql": "^16.8.0",
         "graphql-request": "^6.1.0",

--- a/packages/subgraph/scripts/buildNetworkConfig.ts
+++ b/packages/subgraph/scripts/buildNetworkConfig.ts
@@ -25,8 +25,10 @@ function main() {
     if (!networkMetadata) {
         throw new Error("No metadata found");
     }
+
     const subgraphConfig: SubgraphConfig = {
-        network: networkMetadata.shortName,
+        // cliName exists for networks supported by the hosted service
+        network: networkMetadata.subgraphV1.cliName || networkMetadata.shortName,
         hostStartBlock: networkMetadata.startBlockV1,
         hostAddress: networkMetadata.contractsV1.host,
         cfaAddress: networkMetadata.contractsV1.cfaV1,
@@ -34,14 +36,11 @@ function main() {
         superTokenFactoryAddress: networkMetadata.contractsV1.superTokenFactory,
         resolverV1Address: networkMetadata.contractsV1.resolver,
         nativeAssetSuperTokenAddress: networkMetadata.nativeTokenWrapper,
-        constantOutflowNFTAddress:
-            networkMetadata.contractsV1.constantOutflowNFT || ADDRESS_ZERO,
-        constantInflowNFTAddress:
-            networkMetadata.contractsV1.constantInflowNFT || ADDRESS_ZERO,
+        constantOutflowNFTAddress: networkMetadata.contractsV1.constantOutflowNFT || ADDRESS_ZERO,
+        constantInflowNFTAddress: networkMetadata.contractsV1.constantInflowNFT || ADDRESS_ZERO,
     };
 
-    const writeToDir =
-        __dirname.split("subgraph")[0] + `subgraph/config/${networkName}.json`;
+    const writeToDir = __dirname.split("subgraph")[0] + `subgraph/config/${networkName}.json`;
 
     fs.writeFile(writeToDir, JSON.stringify(subgraphConfig), (err) => {
         if (err) {


### PR DESCRIPTION
We add the canonical subgraph name in our metadata as these will be constant, see [here](https://thegraph.com/docs/en/developing/supported-networks/#hosted-service).
This PR is the first step in fixing: https://github.com/superfluid-finance/protocol-monorepo/issues/1747