### PR TITLE
[SUBGRAPH] remove getIsListed workaround assuming resolver exists

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -18,6 +18,7 @@
         "pretest": "yarn testenv:start",
         "test": "npx hardhat test",
         "matchstick": "run-s matchstick:*",
+        "matchstick:build-network-config": "npx ts-node scripts/buildNetworkConfig.ts polygon-mainnet",
         "matchstick:prepare-manifest": "mustache config/polygon-mainnet.json subgraph.template.yaml > subgraph.yaml",
         "matchstick:prepare-addresses": "mustache config/polygon-mainnet.json src/addresses.template.ts > src/addresses.ts",
         "matchstick:prepare-generated": "yarn getAbi && yarn codegen && yarn generate-sf-meta-local",

--- a/packages/subgraph/src/addresses.template.ts
+++ b/packages/subgraph/src/addresses.template.ts
@@ -15,7 +15,3 @@ export function getResolverAddress(): Address {
 export function getNativeAssetSuperTokenAddress(): Address {
     return Address.fromString("{{nativeAssetSuperTokenAddress}}");
 }
-
-export function getIsLocalIntegrationTesting(): boolean {
-    return "{{testNetwork}}".length > 0;
-}

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -112,6 +112,7 @@ export function getOrInitSuperToken(
         );
 
         token = handleTokenRPCCalls(token, resolverAddress);
+        token.isListed = false;
         const underlyingAddress = token.underlyingAddress;
         token.underlyingToken = underlyingAddress.toHexString();
 

--- a/packages/subgraph/src/utils.ts
+++ b/packages/subgraph/src/utils.ts
@@ -6,7 +6,6 @@ import {
     Token,
     TokenStatistic,
 } from "../generated/schema";
-import { getIsLocalIntegrationTesting } from "./addresses";
 
 /**************************************************************************
  * Constants
@@ -106,9 +105,6 @@ export function handleTokenRPCCalls(
     if (token.name.length == 0 || token.symbol.length == 0) {
         token = getTokenInfoAndReturn(token);
     }
-    
-    // we do getIsListedToken after getTokenInfoAndReturn because it requires the token symbol
-    token = getIsListedToken(token, resolverAddress);
     return token;
 }
 
@@ -125,22 +121,6 @@ export function getTokenInfoAndReturn(token: Token): Token {
     token.name = nameResult.reverted ? "" : nameResult.value;
     token.symbol = symbolResult.reverted ? "" : symbolResult.value;
     token.decimals = decimalsResult.reverted ? 0 : decimalsResult.value;
-
-    return token;
-}
-
-export function getIsListedToken(
-    token: Token,
-    resolverAddress: Address
-): Token {
-    const resolverContract = Resolver.bind(resolverAddress);
-    const isLocalIntegrationTesting = getIsLocalIntegrationTesting();
-    const version = isLocalIntegrationTesting ? "test" : "v1";
-    const result = resolverContract.try_get(
-        "supertokens." + version + "." + token.symbol
-    );
-    const superTokenAddress = result.reverted ? ZERO_ADDRESS : result.value;
-    token.isListed = token.id == superTokenAddress.toHex();
 
     return token;
 }

--- a/packages/subgraph/tests/cfav1/cfav1.helper.ts
+++ b/packages/subgraph/tests/cfav1/cfav1.helper.ts
@@ -89,7 +89,7 @@ export function createFlowOperatorUpdatedEvent(
  * @param flowRate
  * @param previousSenderFlowRate
  * @param previousReceiverFlowRate
- * @param isListed
+ * @param stringUserData
  * @returns FlowUpdated event
  */
  export function modifyFlowAndAssertFlowUpdatedEventProperties(
@@ -104,7 +104,6 @@ export function createFlowOperatorUpdatedEvent(
     flowRate: BigInt,
     previousSenderFlowRate: BigInt,
     previousReceiverFlowRate: BigInt,
-    isListed: boolean,
     stringUserData: string
 ): FlowUpdated {
     const oldFlowRate = previousSenderFlowRate.abs();
@@ -133,8 +132,7 @@ export function createFlowOperatorUpdatedEvent(
         tokenSymbol,
         underlyingToken,
         deposit,
-        expectedOwedDeposit,
-        isListed
+        expectedOwedDeposit
     );
 
     handleFlowUpdated(flowUpdatedEvent);

--- a/packages/subgraph/tests/cfav1/event/cfav1.event.test.ts
+++ b/packages/subgraph/tests/cfav1/event/cfav1.event.test.ts
@@ -6,17 +6,25 @@ import {
     describe,
     test,
 } from "matchstick-as/assembly/index";
+import { handleFlowOperatorUpdated } from "../../../src/mappings/cfav1";
 import {
-    handleFlowOperatorUpdated,
-} from "../../../src/mappings/cfav1";
-import { BIG_INT_ZERO, getFlowOperatorID, ZERO_ADDRESS } from "../../../src/utils";
-import {assertEventBaseProperties } from "../../assertionHelpers";
-import { alice, bob, maticXAddress, maticXName, maticXSymbol } from "../../constants";
+    BIG_INT_ZERO,
+    getFlowOperatorID,
+    ZERO_ADDRESS,
+} from "../../../src/utils";
+import { assertEventBaseProperties } from "../../assertionHelpers";
+import {
+    alice,
+    bob,
+    maticXAddress,
+    maticXName,
+    maticXSymbol,
+} from "../../constants";
 import {
     createFlowOperatorUpdatedEvent,
     modifyFlowAndAssertFlowUpdatedEventProperties,
 } from "../cfav1.helper";
-import {mockedApprove} from "../../mockedFunctions";
+import { mockedApprove } from "../../mockedFunctions";
 
 const initialFlowRate = BigInt.fromI32(100);
 
@@ -39,7 +47,6 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
             initialFlowRate,    // flowRate
             BIG_INT_ZERO,       // previousSenderFlowRate
             BIG_INT_ZERO,       // previousReceiverFlowRate
-            true,               // isListed,
             ""                  // userData
         );
     });
@@ -58,7 +65,6 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
             initialFlowRate,    // flowRate
             BIG_INT_ZERO,       // previousSenderFlowRate
             BIG_INT_ZERO,       // previousReceiverFlowRate
-            true,               // isListed,
             ""                  // userData
         );
 
@@ -76,7 +82,6 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
             increasedFlowRate,  // flowRate
             initialFlowRate,    // previousSenderFlowRate
             initialFlowRate,    // previousReceiverFlowRate
-            true,               // isListed,
             ""                  // userData
         );
 
@@ -93,7 +98,6 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
             initialFlowRate,    // flowRate
             increasedFlowRate,  // previousSenderFlowRate
             increasedFlowRate,  // previousReceiverFlowRate
-            true,               // isListed,
             ""                  // userData
         );
     });
@@ -112,7 +116,6 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
             initialFlowRate,    // flowRate
             BIG_INT_ZERO,       // previousSenderFlowRate
             BIG_INT_ZERO,       // previousReceiverFlowRate
-            true,               // isListed,
             ""                  // userData
         );
 
@@ -130,7 +133,6 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
             increasedFlowRate,  // flowRate
             initialFlowRate,    // previousSenderFlowRate
             initialFlowRate,    // previousReceiverFlowRate
-            true,               // isListed,
             ""                  // userData
         );
 
@@ -148,7 +150,6 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
             BIG_INT_ZERO,       // flowRate
             increasedFlowRate,  // previousSenderFlowRate
             increasedFlowRate,  // previousReceiverFlowRate
-            true,               // isListed,
             ""                  // userData
         );
     });

--- a/packages/subgraph/tests/cfav1/hol/cfav1.hol.test.ts
+++ b/packages/subgraph/tests/cfav1/hol/cfav1.hol.test.ts
@@ -40,7 +40,6 @@ describe("ConstantFlowAgreementV1 Higher Order Level Entity Unit Tests", () => {
             initialFlowRate,    // flowRate
             BIG_INT_ZERO,       // previousSenderFlowRate
             BIG_INT_ZERO,       // previousReceiverFlowRate
-            true,               // isListed,
             "henlo"             // userData
         );
 

--- a/packages/subgraph/tests/idav1/event/idav1.event.test.ts
+++ b/packages/subgraph/tests/idav1/event/idav1.event.test.ts
@@ -57,8 +57,7 @@ describe("InstantDistributionV1 Event Entity Unit Tests", () => {
             DEFAULT_DECIMALS,
             ZERO_ADDRESS,
             maticXName,
-            maticXSymbol,
-            true
+            maticXSymbol
         );
 
         // getOrInitIndex(event) => getOrInitAccount(publisher) => host.try_getAppManifest(sender)

--- a/packages/subgraph/tests/mockedEntities.ts
+++ b/packages/subgraph/tests/mockedEntities.ts
@@ -5,8 +5,6 @@ import { getStreamID } from "../src/utils";
 
 /**
  * Creates a SuperToken entity
- * Note: this is needed otherwise we get a null error when we try
- *       run getIsListedToken and it tries to access token.symbol
  * @param tokenAddress the address of the token
  * @param block transaction block object
  * @param decimals number of decimals

--- a/packages/subgraph/tests/mockedFunctions.ts
+++ b/packages/subgraph/tests/mockedFunctions.ts
@@ -1,12 +1,11 @@
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { createMockedFunction } from "matchstick-as/assembly/index";
 import { FlowUpdated } from "../generated/ConstantFlowAgreementV1/IConstantFlowAgreementV1";
-import { BIG_INT_ZERO, ZERO_ADDRESS } from "../src/utils";
+import { BIG_INT_ZERO } from "../src/utils";
 import {
     FAKE_INITIAL_BALANCE,
     FAKE_SUPER_TOKEN_TOTAL_SUPPLY,
     hostAddress,
-    resolverAddress,
 } from "./constants";
 import {
     getETHAddress,
@@ -28,15 +27,13 @@ import {
  * @param underlyingAddress
  * @param tokenName
  * @param tokenSymbol
- * @param isListed
  */
 export function mockedHandleSuperTokenInitRPCCalls(
     superToken: string,
     decimals: i32,
     underlyingAddress: Address,
     tokenName: string,
-    tokenSymbol: string,
-    isListed: boolean
+    tokenSymbol: string
 ): void {
     // [START] getTokenInfoAndReturn =>
     // token.try_getUnderlyingToken()
@@ -48,13 +45,6 @@ export function mockedHandleSuperTokenInitRPCCalls(
     // token.try_decimals()
     mockedTokenDecimals(superToken, decimals);
     // [END] getTokenInfoAndReturn
-
-    // getIsListedToken(token, resolver) => resolver.try_get(key)
-    mockedResolverGet(
-        resolverAddress,
-        "supertokens.v1." + tokenSymbol,
-        isListed ? superToken : ZERO_ADDRESS.toHexString()
-    );
 
     // updateTotalSupplyForNativeSuperToken(token, tokenStatistic, tokenAddress)
     mockedTokenTotalSupply(superToken, FAKE_SUPER_TOKEN_TOTAL_SUPPLY);
@@ -70,7 +60,6 @@ export function mockedHandleSuperTokenInitRPCCalls(
  * @param underlyingAddress
  * @param expectedDeposit
  * @param expectedOwedDeposit
- * @param isListed
  */
 export function mockedHandleFlowUpdatedRPCCalls(
     flowUpdatedEvent: FlowUpdated,
@@ -80,8 +69,7 @@ export function mockedHandleFlowUpdatedRPCCalls(
     tokenSymbol: string,
     underlyingAddress: Address,
     expectedDeposit: BigInt,
-    expectedOwedDeposit: BigInt,
-    isListed: boolean
+    expectedOwedDeposit: BigInt
 ): void {
     const sender = flowUpdatedEvent.params.sender.toHex();
     const receiver = flowUpdatedEvent.params.receiver.toHex();
@@ -113,8 +101,7 @@ export function mockedHandleFlowUpdatedRPCCalls(
         decimals,
         underlyingAddress,
         tokenName,
-        tokenSymbol,
-        isListed
+        tokenSymbol
     );
     // [END] getOrInitStream(event) => getOrInitSuperToken(token, block) => handleTokenRPCCalls(token, resolverAddress)
 

--- a/packages/subgraph/tests/superToken/event/superToken.event.test.ts
+++ b/packages/subgraph/tests/superToken/event/superToken.event.test.ts
@@ -99,8 +99,7 @@ describe("SuperToken Mapper Unit Tests", () => {
                 DEFAULT_DECIMALS,
                 ZERO_ADDRESS,
                 maticXName,
-                maticXSymbol,
-                false
+                maticXSymbol
             );
 
             mockedRealtimeBalanceOf(
@@ -214,8 +213,7 @@ describe("SuperToken Mapper Unit Tests", () => {
                 DEFAULT_DECIMALS,
                 ZERO_ADDRESS,
                 maticXName,
-                maticXSymbol,
-                false
+                maticXSymbol
             );
 
             mockedRealtimeBalanceOf(

--- a/packages/subgraph/tests/superTokenFactory/superTokenFactory.test.ts
+++ b/packages/subgraph/tests/superTokenFactory/superTokenFactory.test.ts
@@ -55,8 +55,7 @@ describe("SuperTokenFactory Mapper Unit Tests", () => {
                 DEFAULT_DECIMALS,
                 ZERO_ADDRESS,
                 maticXName,
-                maticXSymbol,
-                false
+                maticXSymbol
             );
 
             handleSuperTokenCreated(SuperTokenCreatedEvent);
@@ -83,8 +82,7 @@ describe("SuperTokenFactory Mapper Unit Tests", () => {
                 DEFAULT_DECIMALS,
                 ZERO_ADDRESS,
                 maticXName,
-                maticXSymbol,
-                false
+                maticXSymbol
             );
 
             handleCustomSuperTokenCreated(CustomSuperTokenCreatedEvent);
@@ -138,8 +136,7 @@ describe("SuperTokenFactory Mapper Unit Tests", () => {
                 DEFAULT_DECIMALS,
                 ZERO_ADDRESS,
                 maticXName,
-                maticXSymbol,
-                false // isListed
+                maticXSymbol
             );
 
             handleSuperTokenCreated(SuperTokenCreatedEvent);
@@ -168,8 +165,7 @@ describe("SuperTokenFactory Mapper Unit Tests", () => {
                 DEFAULT_DECIMALS,
                 Address.fromString(daiAddress),
                 daiXName,
-                daiXSymbol,
-                false
+                daiXSymbol
             );
             // for getOrInitToken ((PoS) Dai Stablecoin (DAI))
             mockedHandleSuperTokenInitRPCCalls(
@@ -177,8 +173,7 @@ describe("SuperTokenFactory Mapper Unit Tests", () => {
                 DEFAULT_DECIMALS,
                 ZERO_ADDRESS,
                 daiName,
-                daiSymbol,
-                false
+                daiSymbol
             );
 
             handleSuperTokenCreated(SuperTokenCreatedEvent);
@@ -226,8 +221,7 @@ describe("SuperTokenFactory Mapper Unit Tests", () => {
                 DEFAULT_DECIMALS,
                 ZERO_ADDRESS,
                 maticXName,
-                maticXSymbol,
-                false // isListed
+                maticXSymbol
             );
 
             handleSuperTokenCreated(SuperTokenCreatedEvent);


### PR DESCRIPTION
This closes https://github.com/superfluid-finance/protocol-monorepo/issues/1725 by removing the `isListed` RPC call done at the subgraph level in favor of the resolver emitting the Set event for all tokens