### PR TITLE
[SUBGRAPH] remove unimplemented function from yaml

### DIFF
--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -358,12 +358,6 @@ templates:
         - event: Approval(indexed address,indexed address,uint256)
           handler: handleApproval
           receipt: true
-        - event: ConstantOutflowNFTCreated(indexed address)
-          handler: handleConstantOutflowNFTCreated
-          receipt: true
-        - event: ConstantInflowNFTCreated(indexed address)
-          handler: handleConstantInflowNFTCreated
-          receipt: true
   - kind: ethereum/contract
     name: SuperfluidGovernance
     network: {{ network }}


### PR DESCRIPTION
this was causing indexing errors: https://thegraph.com/hosted-service/subgraph/superfluid-finance/protocol-v1-mumbai?version=pending&selected=logs