### PR TITLE
quickie: add gda v1 forwarder to metadata types

### DIFF
--- a/packages/metadata/module/networks/list.d.ts
+++ b/packages/metadata/module/networks/list.d.ts
@@ -9,7 +9,8 @@ interface ContractAddresses {
     readonly cfaV1: string;
     readonly cfaV1Forwarder: string;
     readonly idaV1: string;
-    readonly gdaV1: string;
+    readonly gdaV1?: string;
+    readonly gdaV1Forwarder?: string;
     readonly superTokenFactory: string;
     readonly constantOutflowNFT?: string;
     readonly constantInflowNFT?: string;


### PR DESCRIPTION
also made `gdaV1` optional until it's deployed everywhere