### PR TITLE
fix: tiny double package reference fix in package.json

### DIFF
--- a/packages/automation-contracts/autowrap/package.json
+++ b/packages/automation-contracts/autowrap/package.json
@@ -15,7 +15,6 @@
     "devDependencies": {
         "@superfluid-finance/metadata": "^1.1.27",
         "@openzeppelin/contracts": "4.9.5",
-        "@superfluid-finance/ethereum-contracts": "1.9.0",
-        "@superfluid-finance/metadata": "1.1.27"
+        "@superfluid-finance/ethereum-contracts": "1.9.0"
     }
 }

--- a/packages/automation-contracts/scheduler/package.json
+++ b/packages/automation-contracts/scheduler/package.json
@@ -15,7 +15,6 @@
     "devDependencies": {
         "@superfluid-finance/metadata": "^1.1.27",
         "@openzeppelin/contracts": "4.9.5",
-        "@superfluid-finance/ethereum-contracts": "1.9.0",
-        "@superfluid-finance/metadata": "1.1.27"
+        "@superfluid-finance/ethereum-contracts": "1.9.0"
     }
 }


### PR DESCRIPTION
### Why?
Metadata was referenced twice in the package.json. I think it slipped in while merging.