### PR TITLE
[ETHEREUM-CONTRACTS] CFASuperAppBase renamed, made compatible with factory and proxy patterns

### DIFF
--- a/packages/ethereum-contracts/.solcover.js
+++ b/packages/ethereum-contracts/.solcover.js
@@ -9,7 +9,7 @@ module.exports = {
         // we skip the coverage for the SuperAppBase contracts because
         // we override the functions in child contracts
         "apps/SuperAppBase.sol",
-        "apps/SuperAppBaseFlow.sol",
+        "apps/CFASuperAppBase.sol",
         "apps/SuperfluidLoaderLibrary.sol",
 
         // we skip the coverage for these contracts because they are

--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Initialization is now split between constructor and a method `_initialize`, with self-registration
 made optional.
 This allows the contract to be used with a SuperApp factory pattern (disable self-registration on networks with permissioned SuperApps) and for logic contracts in the context of the proxy pattern.
+Note: this will NOT break any deployed contracts, only affects undeployed Super Apps in case the ethereum-contracts dependency is updated.
 
 ### Added
 

--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Breaking
+
+- The abstract base contract was`SuperAppBaseFlow´ was renamed to `CFASuperAppBase`.
+Initialization is now split between constructor and a method `_initialize`, with self-registration
+made optional.
+This allows the contract to be used with a SuperApp factory pattern (disable self-registration on networks with permissioned SuperApps) and for logic contracts in the context of the proxy pattern.
+
 ### Added
 
 - New utility: MacroForwarder - a trusted forwarder extensible with permission-less macro contracts.

--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Breaking
 
-- The abstract base contract was`SuperAppBaseFlow´ was renamed to `CFASuperAppBase`.
+- The abstract base contract`SuperAppBaseFlow` was renamed to `CFASuperAppBase`.
 Initialization is now split between constructor and a method `_initialize`, with self-registration
 made optional.
 This allows the contract to be used with a SuperApp factory pattern (disable self-registration on networks with permissioned SuperApps) and for logic contracts in the context of the proxy pattern.

--- a/packages/ethereum-contracts/contracts/mocks/CFASuperAppBaseTester.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFASuperAppBaseTester.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.23;
 
 import { ISuperfluid, ISuperToken } from "../interfaces/superfluid/ISuperfluid.sol";
-import { SuperAppBaseFlow } from "../apps/SuperAppBaseFlow.sol";
+import { CFASuperAppBase } from "../apps/CFASuperAppBase.sol";
 import { SuperTokenV1Library } from "../apps/SuperTokenV1Library.sol";
 
-contract SuperAppBaseFlowTester is SuperAppBaseFlow {
+contract CFASuperAppBaseTester is CFASuperAppBase {
     using SuperTokenV1Library for ISuperToken;
 
     int96 public oldFlowRateHolder;
@@ -17,9 +17,16 @@ contract SuperAppBaseFlowTester is SuperAppBaseFlow {
     // irreversibly set to true once the setter is invoked
     bool internal _restrictAcceptedSuperTokens;
 
-    constructor(ISuperfluid host, bool activateOnCreated, bool activateOnUpdated, bool activateOnDeleted)
-        SuperAppBaseFlow(host, activateOnCreated, activateOnUpdated, activateOnDeleted, "")
+    constructor(
+        ISuperfluid host,
+        bool activateOnCreated,
+        bool activateOnUpdated,
+        bool activateOnDeleted,
+        bool selfRegister
+    )
+        CFASuperAppBase(host)
     {
+        _initialize(activateOnCreated, activateOnUpdated, activateOnDeleted, selfRegister);
         lastUpdateHolder = 0; // appeasing linter
     }
 

--- a/packages/ethereum-contracts/contracts/mocks/CrossStreamSuperApp.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CrossStreamSuperApp.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 import { ISuperfluid, ISuperToken } from "../interfaces/superfluid/ISuperfluid.sol";
-import { SuperAppBaseFlow } from "../apps/SuperAppBaseFlow.sol";
+import { CFASuperAppBase } from "../apps/CFASuperAppBase.sol";
 import { SuperTokenV1Library } from "../apps/SuperTokenV1Library.sol";
 
 using SuperTokenV1Library for ISuperToken;
@@ -12,12 +12,13 @@ using SuperTokenV1Library for ISuperToken;
 /// @dev A super app used for testing "cross-stream" flows in callbacks
 /// and its behavior surrounding the internal protocol accounting.
 /// That is, two senders sending a flow to the super app
-contract CrossStreamSuperApp is SuperAppBaseFlow {
+contract CrossStreamSuperApp is CFASuperAppBase {
     address public flowRecipient;
     address public prevSender;
     int96 public prevFlowRate;
 
-    constructor(ISuperfluid host_, address z_) SuperAppBaseFlow(host_, true, true, true, "") {
+    constructor(ISuperfluid host_, address z_) CFASuperAppBase(host_) {
+        _initialize(true, true, true, true);
         flowRecipient = z_;
     }
 

--- a/packages/ethereum-contracts/ops-scripts/gov-authorize-app-deployer.js
+++ b/packages/ethereum-contracts/ops-scripts/gov-authorize-app-deployer.js
@@ -43,8 +43,9 @@ module.exports = eval(`(${S.toString()})({
         console.log("Expiration timestamp", expirationTs);
         console.log("Expiration date", new Date(expirationTs * 1000)); // print human readable
     }
-    // for historical reasons, we have "registration keys" and now hardcode those to "k1"
-    const registrationKey = "k1";
+    // for historical reasons, we have "registration keys" and now hardcode those to "k1" by default
+    const registrationKey = process.env.REGISTRATION_KEY !== undefined ? process.env.REGISTRATION_KEY : "k1";
+    console.log("Registration key", registrationKey);
     const deployer = args.pop();
     console.log("Deployer", deployer);
 

--- a/packages/ethereum-contracts/test/foundry/apps/CFASuperAppBase.t.sol
+++ b/packages/ethereum-contracts/test/foundry/apps/CFASuperAppBase.t.sol
@@ -73,6 +73,7 @@ contract CFASuperAppBaseTest is FoundrySuperfluidTester {
         (CFASuperAppBaseTester mySuperApp, uint256 configWord) =
             _deploySuperAppAndGetConfig(activateOnCreated, activateOnUpdated, activateOnDeleted, selfRegister);
         if (!selfRegister) {
+            // this would revert if already registered
             sf.host.registerApp(mySuperApp, configWord);
         }
         (bool isSuperApp,, uint256 noopMask) = sf.host.getAppManifest(ISuperApp(mySuperApp));

--- a/packages/ethereum-contracts/test/foundry/apps/SuperAppTester/FlowSplitter.sol
+++ b/packages/ethereum-contracts/test/foundry/apps/SuperAppTester/FlowSplitter.sol
@@ -8,13 +8,13 @@ pragma solidity 0.8.23;
 // import "hardhat/console.sol";
 
 import { SuperTokenV1Library } from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperTokenV1Library.sol";
-import { SuperAppBaseFlow } from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperAppBaseFlow.sol";
+import { CFASuperAppBase } from "@superfluid-finance/ethereum-contracts/contracts/apps/CFASuperAppBase.sol";
 import {
     ISuperfluid,
     ISuperToken
 } from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
 
-contract FlowSplitter is SuperAppBaseFlow {
+contract FlowSplitter is CFASuperAppBase {
     using SuperTokenV1Library for ISuperToken;
 
     /// @dev Account that ought to be routed the majority of the inflows
@@ -36,7 +36,8 @@ contract FlowSplitter is SuperAppBaseFlow {
         int96 _sideReceiverPortion,
         ISuperToken _acceptedSuperToken,
         ISuperfluid _host
-    ) SuperAppBaseFlow(_host, true, true, true, "") {
+    ) CFASuperAppBase(_host) {
+        _initialize(true, true, true, true);
         mainReceiver = _mainReceiver;
         sideReceiver = _sideReceiver;
         sideReceiverPortion = _sideReceiverPortion;


### PR DESCRIPTION
The previous name was misleading, as the base contract is specifically about the CFA.

The previous version assumed SuperApps to be deployed by a whitelisted EOA, using the now deprecated `host.registerAppWithKey`. Now self-registration is optional, so it can also be used with a factory pattern (whitelisted deployer contract).

The previous version wouldn't work for logic contracts in the context of a proxy pattern, thus initialization was split between constructor (just setting an immutable host) and an initialize function doing the rest.