### PR TITLE
[ETHEREUM-CONTRACTS] improve CFASuperAppBase

### DIFF
--- a/packages/ethereum-contracts/contracts/mocks/CFASuperAppBaseTester.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CFASuperAppBaseTester.sol
@@ -18,15 +18,10 @@ contract CFASuperAppBaseTester is CFASuperAppBase {
     bool internal _restrictAcceptedSuperTokens;
 
     constructor(
-        ISuperfluid host,
-        bool activateOnCreated,
-        bool activateOnUpdated,
-        bool activateOnDeleted,
-        bool selfRegister
+        ISuperfluid host
     )
         CFASuperAppBase(host)
     {
-        _initialize(activateOnCreated, activateOnUpdated, activateOnDeleted, selfRegister);
         lastUpdateHolder = 0; // appeasing linter
     }
 

--- a/packages/ethereum-contracts/contracts/mocks/CrossStreamSuperApp.sol
+++ b/packages/ethereum-contracts/contracts/mocks/CrossStreamSuperApp.sol
@@ -18,7 +18,7 @@ contract CrossStreamSuperApp is CFASuperAppBase {
     int96 public prevFlowRate;
 
     constructor(ISuperfluid host_, address z_) CFASuperAppBase(host_) {
-        _initialize(true, true, true, true);
+        selfRegister(true, true, true);
         flowRecipient = z_;
     }
 

--- a/packages/ethereum-contracts/test/foundry/apps/SuperAppTester/FlowSplitter.sol
+++ b/packages/ethereum-contracts/test/foundry/apps/SuperAppTester/FlowSplitter.sol
@@ -37,7 +37,7 @@ contract FlowSplitter is CFASuperAppBase {
         ISuperToken _acceptedSuperToken,
         ISuperfluid _host
     ) CFASuperAppBase(_host) {
-        _initialize(true, true, true, true);
+        selfRegister(true, true, true);
         mainReceiver = _mainReceiver;
         sideReceiver = _sideReceiver;
         sideReceiverPortion = _sideReceiverPortion;


### PR DESCRIPTION
Previously `_initialize()`did nothing if `selfRegister` is false.
Since registration is all it does, there's now a dedicated method `selfRegister()` instead.
There's also a convenience function `getConfigWord()` for factories which need to call `host.registerApp()` themselves.