### PR TITLE
[SUBGRAPH] ALEPH total supply fix

### DIFF
--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -30,7 +30,6 @@ import {
     getStreamID,
     getStreamRevisionID,
     getSubscriptionID,
-    getInitialTotalSupplyForSuperToken,
     ZERO_ADDRESS,
     handleTokenRPCCalls,
     getPoolMemberID,
@@ -129,10 +128,6 @@ export function getOrInitSuperToken(
         // Note: we initialize and create tokenStatistic whenever we create a
         // token as well.
         let tokenStatistic = getOrInitTokenStatistic(tokenAddress, block);
-        tokenStatistic = getInitialTotalSupplyForSuperToken(
-            tokenStatistic,
-            tokenAddress
-        );
         tokenStatistic.save();
 
         // Per our TokenStatistic Invariant: whenever we create TokenStatistic, we must create TokenStatisticLog

--- a/packages/subgraph/src/utils.ts
+++ b/packages/subgraph/src/utils.ts
@@ -12,7 +12,6 @@ import { ISuperToken as SuperToken } from "../generated/templates/SuperToken/ISu
 import {
     IndexSubscription,
     Token,
-    TokenStatistic,
     PoolMember,
 } from "../generated/schema";
 
@@ -135,25 +134,6 @@ export function getTokenInfoAndReturn(token: Token): Token {
     token.decimals = decimalsResult.reverted ? 0 : decimalsResult.value;
 
     return token;
-}
-
-/**
- * Gets and sets the total supply for TokenStatistic of a SuperToken upon initial creation
- * @param tokenStatistic
- * @param tokenAddress
- * @returns TokenStatistic
- */
-export function getInitialTotalSupplyForSuperToken(
-    tokenStatistic: TokenStatistic,
-    tokenAddress: Address
-): TokenStatistic {
-    const tokenContract = SuperToken.bind(tokenAddress);
-    const totalSupplyResult = tokenContract.try_totalSupply();
-    if (totalSupplyResult.reverted) {
-        return tokenStatistic;
-    }
-    tokenStatistic.totalSupply = totalSupplyResult.value;
-    return tokenStatistic;
 }
 
 /**

--- a/packages/subgraph/tests/bugs/2024-02-29-aleph-total-supply.test.ts
+++ b/packages/subgraph/tests/bugs/2024-02-29-aleph-total-supply.test.ts
@@ -1,0 +1,50 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { assert, describe, test } from "matchstick-as";
+import { handleMinted } from "../../src/mappings/superToken";
+import { handleCustomSuperTokenCreated } from "../../src/mappings/superTokenFactory";
+import { ZERO_ADDRESS } from "../../src/utils";
+import { bob, alice } from "../constants";
+import { stringToBytes } from "../converters";
+import {
+    mockedGetHost,
+    mockedGetUnderlyingToken,
+    mockedTokenName,
+    mockedTokenSymbol,
+    mockedTokenDecimals,
+    mockedTokenTotalSupply,
+} from "../mockedFunctions";
+import { createMintedEvent } from "../superToken/superToken.helper";
+import { createCustomSuperTokenCreatedEvent } from "../superTokenFactory/superTokenFactory.helper";
+
+// Issue originally reported here: https://github.com/superfluid-finance/protocol-monorepo/issues/1815
+describe("ALEPH Total Supply Bug", () => {
+    test("superTokenFactory: handleCustomSuperTokenCreated() + handleMinted() - totalSupply", () => {
+        const superToken = bob;
+        const totalSupply = BigInt.fromI32(100);
+        const data = stringToBytes("");
+        const operatorData = stringToBytes("");
+
+        // necessary mock function calls for getOrInitSuperToken
+        mockedGetHost(superToken);
+        mockedGetUnderlyingToken(superToken, ZERO_ADDRESS.toHex());
+        mockedTokenName(superToken, "tokenName");
+        mockedTokenSymbol(superToken, "tokenSymbol");
+        mockedTokenDecimals(superToken, 18);
+        
+        // unused mocked function call after change in this commit (removing total supply RPC call in getOrInitSuperToken)
+        mockedTokenTotalSupply(superToken, totalSupply);
+
+        // create mock events
+        const customSuperTokenCreatedEvent = createCustomSuperTokenCreatedEvent(superToken);
+
+        const mintedEvent = createMintedEvent(bob, alice, totalSupply, data, operatorData);
+        // modify the minted event address to be the superToken address
+        mintedEvent.address = Address.fromString(superToken);
+
+        // handle mock events with handlers
+        handleCustomSuperTokenCreated(customSuperTokenCreatedEvent);
+        handleMinted(mintedEvent);
+
+        assert.fieldEquals("TokenStatistic", superToken, "totalSupply", totalSupply.toString());
+    });
+});

--- a/packages/subgraph/tests/superToken/event/superToken.event.test.ts
+++ b/packages/subgraph/tests/superToken/event/superToken.event.test.ts
@@ -289,7 +289,7 @@ describe("SuperToken Mapper Unit Tests", () => {
                 BIG_INT_ZERO, // totalCFAAmountStreamedUntilUpdatedAt
                 BIG_INT_ZERO, // totalAmountTransferredUntilUpdatedAt
                 BIG_INT_ZERO, // totalAmountDistributedUntilUpdatedAt
-                BigInt.fromI32(1000000), // totalSupply = 100
+                BIG_INT_ZERO, // totalSupply = 0
                 3, // totalNumberOfAccounts
                 3 // totalNumberOfHolders
             );
@@ -383,7 +383,7 @@ describe("SuperToken Mapper Unit Tests", () => {
                 BIG_INT_ZERO, // totalCFAAmountStreamedUntilUpdatedAt
                 value, // totalAmountTransferredUntilUpdatedAt
                 BIG_INT_ZERO, // totalAmountDistributedUntilUpdatedAt
-                BigInt.fromI32(1000000), // totalSupply = 100
+                BIG_INT_ZERO, // totalSupply = 0
                 2, // totalNumberOfAccounts,
                 2 // totalNumberOfHolders
             );
@@ -529,7 +529,7 @@ describe("SuperToken Mapper Unit Tests", () => {
                 BIG_INT_ZERO, // totalCFAAmountStreamedUntilUpdatedAt
                 value, // totalAmountTransferredUntilUpdatedAt
                 BIG_INT_ZERO, // totalAmountDistributedUntilUpdatedAt
-                BigInt.fromI32(1000000), // totalSupply = 100
+                BIG_INT_ZERO, // totalSupply = 0
                 2, // totalNumberOfAccounts,
                 2 // totalNumberOfHolders
             ); 
@@ -578,7 +578,7 @@ describe("SuperToken Mapper Unit Tests", () => {
                 BIG_INT_ZERO, // totalCFAAmountStreamedUntilUpdatedAt
                 value.times(BigInt.fromI32(2)), // totalAmountTransferredUntilUpdatedAt
                 BIG_INT_ZERO, // totalAmountDistributedUntilUpdatedAt
-                BigInt.fromI32(1000000), // totalSupply = 100
+                BIG_INT_ZERO, // totalSupply = 100
                 2, // totalNumberOfAccounts,
                 1 // totalNumberOfHolders
             );

--- a/packages/subgraph/tests/superTokenFactory/superTokenFactory.test.ts
+++ b/packages/subgraph/tests/superTokenFactory/superTokenFactory.test.ts
@@ -19,7 +19,6 @@ import {
     daiXName,
     daiXSymbol,
     DEFAULT_DECIMALS,
-    FAKE_SUPER_TOKEN_TOTAL_SUPPLY,
     FALSE,
     maticXAddress,
     maticXName,
@@ -233,7 +232,7 @@ describe("SuperTokenFactory Mapper Unit Tests", () => {
                 maticXAddress,
                 SuperTokenCreatedEvent.block.timestamp,
                 SuperTokenCreatedEvent.block.number,
-                FAKE_SUPER_TOKEN_TOTAL_SUPPLY  // totalSupply = 100
+                BIG_INT_ZERO  // totalSupply = 0
             );
 
         });


### PR DESCRIPTION
we remove the RPC call inside of `getInitialTotalSupplyForSuperToken` which was called in `getOrInitSuperToken` which doubled the total supply.

closes #1815