### PR TITLE
[METADATA] remove nonexistent subgraph endpoint for scroll-sepolia

### DIFF
--- a/packages/metadata/CHANGELOG.md
+++ b/packages/metadata/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - removed eth-goerli and Görli based networks: optimism-goerli, arbitrun-goerli, base-goerli, polygon-zkevm-testnet
 ### Fixed
-- Removed subgraph hosted endpoint entries which don't exist / aren't deployed
+- Removed subgraph hosted endpoint entry for scroll-sepolia which doesn't exist
 
 ## [v1.1.27]
 ### Added

--- a/packages/metadata/CHANGELOG.md
+++ b/packages/metadata/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - toga and batchLiquidator for scroll-mainnet
 ### Changed
 - removed eth-goerli and Görli based networks: optimism-goerli, arbitrun-goerli, base-goerli, polygon-zkevm-testnet
+### Fixed
+- Removed subgraph hosted endpoint entries which don't exist / aren't deployed
 
 ## [v1.1.27]
 ### Added

--- a/packages/metadata/main/networks/list.cjs
+++ b/packages/metadata/main/networks/list.cjs
@@ -216,8 +216,7 @@ module.exports =
         "explorer": "https://sepolia.scrollscan.com/",
         "subgraphV1": {
             "cliName": "scroll-sepolia",
-            "name": "protocol-v1-scroll-sepolia",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-scroll-sepolia"
+            "name": "protocol-v1-scroll-sepolia"
         },
         "publicRPCs": ["https://sepolia-rpc.scroll.io"]
     },

--- a/packages/metadata/module/networks/list.js
+++ b/packages/metadata/module/networks/list.js
@@ -216,8 +216,7 @@ export default
         "explorer": "https://sepolia.scrollscan.com/",
         "subgraphV1": {
             "cliName": "scroll-sepolia",
-            "name": "protocol-v1-scroll-sepolia",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-scroll-sepolia"
+            "name": "protocol-v1-scroll-sepolia"
         },
         "publicRPCs": ["https://sepolia-rpc.scroll.io"]
     },

--- a/packages/metadata/networks.json
+++ b/packages/metadata/networks.json
@@ -214,8 +214,7 @@
         "explorer": "https://sepolia.scrollscan.com/",
         "subgraphV1": {
             "cliName": "scroll-sepolia",
-            "name": "protocol-v1-scroll-sepolia",
-            "hostedEndpoint": "https://api.thegraph.com/subgraphs/name/superfluid-finance/protocol-v1-scroll-sepolia"
+            "name": "protocol-v1-scroll-sepolia"
         },
         "publicRPCs": ["https://sepolia-rpc.scroll.io"]
     },


### PR DESCRIPTION
https://thegraph.com/docs/en/developing/supported-networks/ initially wrongly listed scroll-sepolia as supported on the hosted service, but it's not. Thus removing that endpoint from metadata.