### PR TITLE
[CI] [OPS-SCRIPTS] switch canary to optimism-sepolia

### DIFF
--- a/.github/workflows/ci.canary.yml
+++ b/.github/workflows/ci.canary.yml
@@ -281,7 +281,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        network: [avalanche-fuji]
+        network: [optimism-sepolia]
 
     defaults:
       run:
@@ -307,5 +307,5 @@ jobs:
           tasks/etherscan-verify-framework.sh ${{ matrix.network }} addresses.vars
         env:
           RELEASE_VERSION: canary
-          AVALANCHE_FUJI_MNEMONIC: ${{ secrets.BUILD_AGENT_MNEMONIC  }}
-          AVALANCHE_FUJI_PROVIDER_URL: ${{ secrets.AVALANCHE_FUJI_PROVIDER_URL }}
+          OPTIMISM_SEPOLIA_MNEMONIC: ${{ secrets.BUILD_AGENT_MNEMONIC }}
+          OPTIMISM_SEPOLIA_PROVIDER_URL: ${{ secrets.OPTIMISM_SEPOLIA_PROVIDER_URL }}

--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -326,7 +326,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
     let governance;
     if (!config.disableTestGovernance && !process.env.NO_NEW_GOVERNANCE) {
         const prevGovAddr = await resolver.get.call(`TestGovernance.${protocolReleaseVersion}`);
-        if (await codeChanged(web3, TestGovernance, prevGovAddr)) {
+        if (resetSuperfluidFramework || await codeChanged(web3, TestGovernance, prevGovAddr)) {
             console.log(`TestGovernance needs new deployment.`);
             const c = await web3tx(TestGovernance.new,"TestGovernance.new")();
             governance = await TestGovernance.at(c.address);

--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -332,6 +332,8 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
             governance = await TestGovernance.at(c.address);
             testGovernanceInitRequired = true;
             output += `SUPERFLUID_GOVERNANCE=${c.address}\n`;
+        } else {
+            governance = await TestGovernance.at(prevGovAddr);
         }
         // defer resolver update to after the initialization
         // this avoids testnet bricking in case script execution is interrupted

--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -442,8 +442,6 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
             `TestGovernance.${protocolReleaseVersion}`,
             governance.address
         );
-
-
     }
 
     // replace with new governance

--- a/packages/subgraph/README.md
+++ b/packages/subgraph/README.md
@@ -80,7 +80,7 @@ Open another terminal window and navigate to `packages/ethereum-contracts` and r
 yarn build
 ```
 
-Now go to to `packages/ethereum-contracts` and run the following command to deploy contracts:
+Now go to `packages/ethereum-contracts` and run the following command to deploy contracts:
 
 ```bash
 npx hardhat run dev-scripts/run-deploy-contracts-and-token.js


### PR DESCRIPTION
* fixes #1795 by switching to optimism-sepolia as new canary. There's also other minor advantages to this, e.g. availability of both an etherscan-based (Avalanche switched to routescan) and a [blockscout explorer](https://optimism-sepolia.blockscout.com/), also the optimism-sepolia RPC endpoints seems to be less susceptible to random timeouts (this assessment is based on a few local runs, no scientific statement).
* fixes: testnet deployments can be bricked if deploy script fails (e.g. due to RPC issue) between gov and host update
* fixes GDA code change detection