### PR TITLE
[OPS-SCRIPTS] smol fixes done for 1.9.1 rollout

### DIFF
--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -835,16 +835,15 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
             agreementsToUpdate.push(idaNewLogicAddress);
         }
         // deploy new GDA logic
-        const gdaAddr = await (await UUPSProxiable.at(
-            await superfluid.getAgreementClass.call(GDAv1_TYPE)
-        )).getCodeAddress();
+        const gdaProxyAddr = await superfluid.getAgreementClass.call(GDAv1_TYPE);
+        const gdaLogicAddr = await (await UUPSProxiable.at(gdaProxyAddr)).getCodeAddress();
         const superfluidPoolBeaconAddr = await (
-            await GeneralDistributionAgreementV1.at(gdaAddr)
+            await GeneralDistributionAgreementV1.at(gdaProxyAddr)
         ).superfluidPoolBeacon.call();
         const gdaNewLogicAddress = await deployContractIfCodeChanged(
             web3,
             GeneralDistributionAgreementV1,
-            gdaAddr,
+            gdaLogicAddr,
             async () => (await deployGDAv1(superfluidPoolBeaconAddr)).address,
             [
                 superfluidConstructorParam,
@@ -1095,13 +1094,13 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                 const constantOutflowNFTLogic = await deployNFTContract(
                     ConstantOutflowNFT,
                     "ConstantOutflowNFT",
-                    "CONSTANT_OUTFLOW_NFT",
+                    "CONSTANT_OUTFLOW_NFT_LOGIC",
                     [superfluid.address, cfaAddr, gdaAddr, constantInflowNFTProxy.address]
                 );
                 const constantInflowNFTLogic = await deployNFTContract(
                     ConstantInflowNFT,
                     "ConstantInflowNFT",
-                    "CONSTANT_INFLOW_NFT",
+                    "CONSTANT_INFLOW_NFT_LOGIC",
                     [superfluid.address, cfaAddr, gdaAddr, constantOutflowNFTProxy.address]
                 );
 
@@ -1149,7 +1148,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                         const cofNFTLogic = await deployNFTContract(
                             ConstantOutflowNFT,
                             "ConstantOutflowNFT",
-                            "CONSTANT_OUTFLOW_NFT",
+                            "CONSTANT_OUTFLOW_NFT_LOGIC",
                             [superfluid.address, cfaAddr, gdaAddr, cifNFTProxyAddress]
                         );
                         // @note we set the cofNFTLogicAddress to be passed to SuperTokenFactoryLogic here
@@ -1168,7 +1167,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                         const cifNFTLogic = await deployNFTContract(
                             ConstantInflowNFT,
                             "ConstantInflowNFT",
-                            "CONSTANT_INFLOW_NFT",
+                            "CONSTANT_INFLOW_NFT_LOGIC",
                             [superfluid.address, cfaAddr, gdaAddr, cofNFTProxyAddress]
                         );
                         // @note we set the cifNFTLogicAddress to be passed to SuperTokenFactoryLogic here
@@ -1207,13 +1206,13 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                 const poolAdminNFTLogic = await deployNFTContract(
                     PoolAdminNFT,
                     "PoolAdminNFT",
-                    "POOL_ADMIN_NFT",
+                    "POOL_ADMIN_NFT_LOGIC",
                     [superfluid.address, gdaAddr]
                 );
                 const poolMemberNFTLogic = await deployNFTContract(
                     PoolMemberNFT,
                     "PoolMemberNFT",
-                    "POOL_MEMBER_NFT",
+                    "POOL_MEMBER_NFT_LOGIC",
                     [superfluid.address, gdaAddr]
                 );
 
@@ -1258,7 +1257,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                         const poolAdminNFTLogic = await deployNFTContract(
                             PoolAdminNFT,
                             "PoolAdminNFT",
-                            "POOL_ADMIN_NFT",
+                            "POOL_ADMIN_NFT_LOGIC",
                             [superfluid.address, gdaAddr]
                         );
                         // @note we set the poolAdminNFTLogicAddress to be passed to SuperTokenFactoryLogic here
@@ -1276,7 +1275,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                         const poolMemberNFTLogic = await deployNFTContract(
                             PoolMemberNFT,
                             "PoolMemberNFT",
-                            "POOL_MEMBER_NFT",
+                            "POOL_MEMBER_NFT_LOGIC",
                             [superfluid.address, gdaAddr]
                         );
                         // @note we set the poolMemberNFTLogicAddress to be passed to SuperTokenFactoryLogic here

--- a/packages/js-sdk/src/Framework.js
+++ b/packages/js-sdk/src/Framework.js
@@ -95,7 +95,7 @@ module.exports = class Framework {
             contractLoader: this._options.contractLoader,
             networkId: this.networkId,
             // copy of ethereum-contracts/ops-scripts/libs/common.js:getGasConfig()
-            gasConfig: (networkId) => {
+            gasConfig: ((networkId) => {
                 let gasConfig = {};
 
                 const networkConfig = Object.values(truffleConfig.networks)
@@ -123,7 +123,7 @@ module.exports = class Framework {
                 }
 
                 return gasConfig;
-            },
+            })(this.networkId),
         });
 
         const resolverAddress =

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -31,6 +31,7 @@
         "pretest": "yarn testenv:start",
         "test": "hardhat test --tsconfig \"tsconfig.test.json\"",
         "dev": "nodemon -e ts -x yarn test",
+        "clean": "rm -rf node_modules; rm -rf dist; rm -rf src/typechain-types; rm -rf src/typechain; rm -rf src/abi; find . -type f -name '*.generated.ts' -exec rm {} +",
         "test-coverage": "nyc --reporter=html --reporter=lcov --reporter=json yarn test",
         "posttest": "yarn testenv:stop",
         "check-updates": "ncu --target minor --dep prod,dev",


### PR DESCRIPTION
* deploy-framework: get beacon address via GDA proxy, fix names for verification
* update token script: support Safe, correct handing of logic override and admin override
* js-sdk: fix the gas config workaround for all ops-scripts (needed for polygon-mainnet)
* sdk-core: add npm script `clean`