### PR TITLE
[SUBGRAPH] fix null from/to for flowNFTs

### DIFF
--- a/packages/subgraph/src/mappings/flowNFT.ts
+++ b/packages/subgraph/src/mappings/flowNFT.ts
@@ -10,6 +10,7 @@ import {
     MetadataUpdateEvent,
     TransferEvent,
 } from "../../generated/schema";
+import { getOrInitAccount } from "../mappingHelpers";
 import { BIG_INT_ONE, createEventID, initializeEventEntity } from "../utils";
 
 export function handleApproval(event: Approval): void {
@@ -51,6 +52,9 @@ export function handleTransfer(event: Transfer): void {
     ev.token = event.address;
 
     ev.save();
+
+    getOrInitAccount(event.params.to, event.block);
+    getOrInitAccount(event.params.from, event.block);
 }
 
 export function handleMetadataUpdate(event: MetadataUpdate): void {


### PR DESCRIPTION
My assumption is that the `from` and `to` fields from the `Transfer` event is not null, but rather that there is no associated `Account` entity created yet.

a response to: https://github.com/superfluid-finance/protocol-monorepo/issues/1794

see: https://github.com/superfluid-finance/protocol-monorepo/actions/runs/8450679391/job/23147375344
```
Error: Null value resolved for non-null field `from`: {"response":{"errors":[{"locations":
[{"line":261,"column":7}],"message":"Null value resolved for non-null field `from`"},{"locations":
[{"column":7,"line":258}],"message":"Null value resolved for non-null field `to`"}...
```
debugged the issue by going [here](https://thegraph.com/hosted-service/subgraph/superfluid-finance/protocol-dev-arbitrum-one) and running this query:

```
{
  transferEvents(where: {isNFTTransfer: true}) {
    from {
      id
    }
    to {
      id
    }
  }
}
```

however, this query works fine:


```
{
  transferEvents(where: {isNFTTransfer: false}) {
    from {
      id
    }
    to {
      id
    }
  }
}
```
