### PR TITLE
[subgraph][fix] explicitly build in the subgraph deploy script for Goldsky

### DIFF
--- a/.github/workflows/call.deploy-subgraph.yml
+++ b/.github/workflows/call.deploy-subgraph.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       vendor:
         required: true
-        description: "Where to deploy subgraph to; superfluid, graph, satsuma, goldsky, or satsuma"
+        description: "Where to deploy subgraph to; superfluid, graph, satsuma, or goldsky"
         type: string
       deployment_env:
         required: true

--- a/.github/workflows/call.deploy-subgraph.yml
+++ b/.github/workflows/call.deploy-subgraph.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       vendor:
         required: true
-        description: "Where to deploy subgraph to; superfluid, graph, or satsuma"
+        description: "Where to deploy subgraph to; superfluid, graph, satsuma, goldsky, or satsuma"
         type: string
       deployment_env:
         required: true

--- a/flake.nix
+++ b/flake.nix
@@ -132,17 +132,22 @@
         ++ whitehatInputs
         ++ specInputs;
     };
+
     # CI shells
+    ciInputs = with pkgs; [
+      # codecov requries gnupg binary
+      gnupg
+    ];
     devShells.ci-node18 = mkShell {
-      buildInputs = commonDevInputs ++ ethDevInputs ++ node18DevInputs;
+      buildInputs = ciInputs ++ commonDevInputs ++ ethDevInputs ++ node18DevInputs;
     };
     devShells.ci-node20 = mkShell {
-      buildInputs = commonDevInputs ++ ethDevInputs ++ node20DevInputs;
+      buildInputs = ciInputs ++ commonDevInputs ++ ethDevInputs ++ node20DevInputs;
     };
     devShells.ci-spec-ghc92 = ci-spec-with-ghc ghcVer92;
     devShells.ci-spec-ghc94 = ci-spec-with-ghc ghcVer94;
     devShells.ci-hot-fuzz = mkShell {
-      buildInputs = with pkgs; commonDevInputs ++ ethDevInputs ++ [
+      buildInputs = with pkgs; ciInputs ++ commonDevInputs ++ ethDevInputs ++ [
         slither-analyzer
         echidna
       ];

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,12 @@
     node18DevInputs = nodeDevInputsWith pkgs.nodejs_18;
     node20DevInputs = nodeDevInputsWith pkgs.nodejs_20;
 
+    # CI inputs
+    ciInputs = with pkgs; [
+      # codecov requries gnupg binary
+      gnupg
+    ];
+
     # minimem development shell
     minimumDevInputs = commonDevInputs ++ ethDevInputs ++ node18DevInputs;
 
@@ -134,10 +140,6 @@
     };
 
     # CI shells
-    ciInputs = with pkgs; [
-      # codecov requries gnupg binary
-      gnupg
-    ];
     devShells.ci-node18 = mkShell {
       buildInputs = ciInputs ++ commonDevInputs ++ ethDevInputs ++ node18DevInputs;
     };

--- a/packages/subgraph/tasks/deploy.sh
+++ b/packages/subgraph/tasks/deploy.sh
@@ -126,8 +126,8 @@ deploy_to_goldsky() {
     # TODO: use tagging?
     # TODO: how to handle versions?
 
-    cp subgraph.yaml ./build/subgraph.yaml
-    # TODO: not sure the cp is necessary
+    $GRAPH_CLI build
+    # Note: when using Graph CLI to deploy, it implicitly triggers build too, but Goldsky CLI doesn't.
 
     echo "********* Deploying $network subgraph $subgraphName to Goldsky. **********"
     $GOLDSKY_CLI subgraph deploy \


### PR DESCRIPTION
**Why? What?**
The `graph deploy` triggers `graph build` implicitly but `goldsky subgraph deploy` doesn't. When testing locally the `deploy.sh`, I made the assumption that the subgraph has been built earlier in the workflow chain, but it isn't.

**How?**
 Explicitly call `graph build` for the Goldsky step.