### PR TITLE
Aggregated improvements of solidity semantic money library

### DIFF
--- a/packages/solidity-semantic-money/src/SemanticMoney.sol
+++ b/packages/solidity-semantic-money/src/SemanticMoney.sol
@@ -69,9 +69,13 @@ pragma solidity ^0.8.19;
 type Time is uint32;
 function mt_t_eq(Time a, Time b) pure returns (bool) { return Time.unwrap(a) == Time.unwrap(b); }
 function mt_t_neq(Time a, Time b) pure returns (bool) { return Time.unwrap(a) != Time.unwrap(b); }
+function mt_t_le(Time a, Time b) pure returns (bool) { return Time.unwrap(a) < Time.unwrap(b); }
+function mt_t_lte(Time a, Time b) pure returns (bool) { return Time.unwrap(a) <= Time.unwrap(b); }
+function mt_t_gt(Time a, Time b) pure returns (bool) { return Time.unwrap(a) > Time.unwrap(b); }
+function mt_t_gte(Time a, Time b) pure returns (bool) { return Time.unwrap(a) >= Time.unwrap(b); }
 function mt_t_add_t(Time a, Time b) pure returns (Time) { return Time.wrap(Time.unwrap(a) + Time.unwrap(b)); }
 function mt_t_sub_t(Time a, Time b) pure returns (Time) { return Time.wrap(Time.unwrap(a) - Time.unwrap(b)); }
-using { mt_t_eq as ==, mt_t_neq as !=,
+using { mt_t_eq as ==, mt_t_neq as !=, mt_t_le as <, mt_t_lte as <=, mt_t_gt as >, mt_t_gte as >=,
         mt_t_add_t as +, mt_t_sub_t as - } for Time global;
 
 /**
@@ -79,26 +83,43 @@ using { mt_t_eq as ==, mt_t_neq as !=,
  */
 type Value is int256;
 function mt_v_eq(Value a, Value b) pure returns (bool) { return Value.unwrap(a) == Value.unwrap(b); }
+function mt_v_neq(Value a, Value b) pure returns (bool) { return Value.unwrap(a) != Value.unwrap(b); }
+function mt_v_le(Value a, Value b) pure returns (bool) { return Value.unwrap(a) < Value.unwrap(b); }
+function mt_v_lte(Value a, Value b) pure returns (bool) { return Value.unwrap(a) <= Value.unwrap(b); }
+function mt_v_gt(Value a, Value b) pure returns (bool) { return Value.unwrap(a) > Value.unwrap(b); }
+function mt_v_gte(Value a, Value b) pure returns (bool) { return Value.unwrap(a) >= Value.unwrap(b); }
 function mt_v_add_v(Value a, Value b) pure returns (Value) { return Value.wrap(Value.unwrap(a) + Value.unwrap(b)); }
 function mt_v_sub_v(Value a, Value b) pure returns (Value) { return Value.wrap(Value.unwrap(a) - Value.unwrap(b)); }
 function mt_v_inv(Value a) pure returns (Value) { return Value.wrap(-Value.unwrap(a)); }
-using { mt_v_eq as ==, mt_v_add_v as +, mt_v_sub_v as -, mt_v_inv as - } for Value global;
+using { mt_v_eq as ==, mt_v_neq as !=, mt_v_le as <, mt_v_lte as <=, mt_v_gt as >, mt_v_gte as >=,
+        mt_v_add_v as +, mt_v_sub_v as -, mt_v_inv as - } for Value global;
 
 /**
  * @title Number of units represented with half the size of `Value`.
  */
 type Unit is int128;
 function mt_u_eq(Unit a, Unit b) pure returns (bool) { return Unit.unwrap(a) == Unit.unwrap(b); }
+function mt_u_neq(Unit a, Unit b) pure returns (bool) { return Unit.unwrap(a) != Unit.unwrap(b); }
+function mt_u_le(Unit a, Unit b) pure returns (bool) { return Unit.unwrap(a) < Unit.unwrap(b); }
+function mt_u_lte(Unit a, Unit b) pure returns (bool) { return Unit.unwrap(a) <= Unit.unwrap(b); }
+function mt_u_gt(Unit a, Unit b) pure returns (bool) { return Unit.unwrap(a) > Unit.unwrap(b); }
+function mt_u_gte(Unit a, Unit b) pure returns (bool) { return Unit.unwrap(a) >= Unit.unwrap(b); }
 function mt_u_add_u(Unit a, Unit b) pure returns (Unit) { return Unit.wrap(Unit.unwrap(a) + Unit.unwrap(b)); }
 function mt_u_sub_u(Unit a, Unit b) pure returns (Unit) { return Unit.wrap(Unit.unwrap(a) - Unit.unwrap(b)); }
 function mt_u_inv(Unit a) pure returns (Unit) { return Unit.wrap(-Unit.unwrap(a)); }
-using { mt_u_eq as ==, mt_u_add_u as +, mt_u_sub_u as -, mt_u_inv as - } for Unit global;
+using { mt_u_eq as ==, mt_u_neq as !=, mt_u_le as <, mt_u_lte as <=, mt_u_gt as >, mt_u_gte as >=,
+        mt_u_add_u as +, mt_u_sub_u as -, mt_u_inv as - } for Unit global;
 
 /**
  * @title FlowRate value represented with half the size of `Value`.
  */
 type FlowRate is int128;
 function mt_r_eq(FlowRate a, FlowRate b) pure returns (bool) { return FlowRate.unwrap(a) == FlowRate.unwrap(b); }
+function mt_r_neq(FlowRate a, FlowRate b) pure returns (bool) { return FlowRate.unwrap(a) != FlowRate.unwrap(b); }
+function mt_r_le(FlowRate a, FlowRate b) pure returns (bool) { return FlowRate.unwrap(a) < FlowRate.unwrap(b); }
+function mt_r_lte(FlowRate a, FlowRate b) pure returns (bool) { return FlowRate.unwrap(a) <= FlowRate.unwrap(b); }
+function mt_r_gt(FlowRate a, FlowRate b) pure returns (bool) { return FlowRate.unwrap(a) > FlowRate.unwrap(b); }
+function mt_r_gte(FlowRate a, FlowRate b) pure returns (bool) { return FlowRate.unwrap(a) >= FlowRate.unwrap(b); }
 function mt_r_add_r(FlowRate a, FlowRate b) pure returns (FlowRate) {
     return FlowRate.wrap(FlowRate.unwrap(a) + FlowRate.unwrap(b));
 }
@@ -106,7 +127,8 @@ function mt_r_sub_r(FlowRate a, FlowRate b) pure returns (FlowRate) {
     return FlowRate.wrap(FlowRate.unwrap(a) - FlowRate.unwrap(b));
 }
 function mt_r_inv(FlowRate a) pure returns (FlowRate) { return FlowRate.wrap(-FlowRate.unwrap(a)); }
-using { mt_r_eq as ==, mt_r_add_r as +, mt_r_sub_r as -, mt_r_inv as - } for FlowRate global;
+using { mt_r_eq as ==, mt_r_neq as !=, mt_r_le as <, mt_r_lte as <=, mt_r_gt as >, mt_r_gte as >=,
+        mt_r_add_r as +, mt_r_sub_r as -, mt_r_inv as - } for FlowRate global;
 
 /**
  * @dev Additional helper functions for the monetary types
@@ -116,19 +138,34 @@ using { mt_r_eq as ==, mt_r_add_r as +, mt_r_sub_r as -, mt_r_inv as - } for Flo
  * Read more at: https://github.com/ethereum/solidity/issues/11969#issuecomment-1448445474
  */
 library AdditionalMonetaryTypeHelpers {
+    // Additional Time operators
+    //
+    function quotrem(Time a, Time b) internal pure returns (uint256 quot, uint256 rem) {
+        quot = Time.unwrap(a) / Time.unwrap(b);
+        rem = Time.unwrap(a) - quot * Time.unwrap(b);
+    }
+
     // Additional Value operators
     //
+    function quotrem(Value a, Value b) internal pure returns (int256 quot, int256 rem) {
+        quot = Value.unwrap(a) / Value.unwrap(b);
+        rem = Value.unwrap(a) - quot * Value.unwrap(b);
+    }
     function mul(Value a, Unit b) internal pure returns (Value) {
-        return Value.wrap(Value.unwrap(a) * int256(Unit.unwrap(b)));
+        return Value.wrap(Value.unwrap(a) * Unit.unwrap(b));
     }
     function div(Value a, Unit b) internal pure returns (Value) {
-        return Value.wrap(Value.unwrap(a) / int256(Unit.unwrap(b)));
+        return Value.wrap(Value.unwrap(a) / Unit.unwrap(b));
     }
 
     // Additional FlowRate operators
     //
+    function quotrem(FlowRate a, FlowRate b) internal pure returns (int256 quot, int256 rem) {
+        quot = FlowRate.unwrap(a) / FlowRate.unwrap(b);
+        rem = FlowRate.unwrap(a) - quot * FlowRate.unwrap(b);
+    }
     function mul(FlowRate r, Time t) internal pure returns (Value) {
-        return Value.wrap(int256(FlowRate.unwrap(r)) * int256(uint256(Time.unwrap(t))));
+        return Value.wrap(FlowRate.unwrap(r) * int256(uint256(Time.unwrap(t))));
     }
     function mul(FlowRate r, Unit u) internal pure returns (FlowRate) {
         return FlowRate.wrap(FlowRate.unwrap(r) * Unit.unwrap(u));
@@ -143,6 +180,13 @@ library AdditionalMonetaryTypeHelpers {
     }
     function mul_quotrem(FlowRate r, Unit u1, Unit u2) internal pure returns (FlowRate nr, FlowRate er) {
         return r.mul(u1).quotrem(u2);
+    }
+
+    // Additional Unit operators
+    //
+    function quotrem(Unit a, Unit b) internal pure returns (int256 quot, int256 rem) {
+        quot = Unit.unwrap(a) / Unit.unwrap(b);
+        rem = Unit.unwrap(a) - quot * Unit.unwrap(b);
     }
 }
 using AdditionalMonetaryTypeHelpers for Time global;

--- a/packages/solidity-semantic-money/src/SemanticMoney.sol
+++ b/packages/solidity-semantic-money/src/SemanticMoney.sol
@@ -435,7 +435,7 @@ library SemanticMoney {
         BasicParticle memory mempty;
         BasicParticle memory b1;
         BasicParticle memory b2;
-        FlowRate r = b.flow_rate();
+        FlowRate r = a.flow_rate();
         ( , b1) = a.flow2(mempty, r, t);
         (m, b2) = a.flow2(mempty, r.inv() + dr, t);
         n = b.mappend(b1).mappend(b2);

--- a/packages/solidity-semantic-money/src/TokenEff.sol
+++ b/packages/solidity-semantic-money/src/TokenEff.sol
@@ -91,7 +91,7 @@ library TokenEffLib {
         FlowRate flowRateDelta = flowRate - eff.getFlowRate(flowHash);
         BasicParticle memory a = eff.getUIndex(from);
         BasicParticle memory b = eff.getUIndex(to);
-        (a, b) = a.shift_flow2a(b, flowRateDelta, t);
+        (a, b) = a.shift_flow2b(b, flowRateDelta, t);
         return eff.setUIndex(from, a)
             .setUIndex(to, b)
             .setFlowInfo(eff, flowHash, from, to, flowRate);

--- a/packages/solidity-semantic-money/src/TokenMonad.sol
+++ b/packages/solidity-semantic-money/src/TokenMonad.sol
@@ -122,7 +122,7 @@ abstract contract TokenMonad {
                 vars.newAdjustmentFlowRate = FlowRate.wrap(0);
             } else {
                 // previous adjustment flow still needed
-                vars.newAdjustmentFlowRate = newActualFlowRate.inv();
+                vars.newAdjustmentFlowRate = -newActualFlowRate;
                 newActualFlowRate = FlowRate.wrap(0);
             }
 

--- a/packages/solidity-semantic-money/test/SemanticMoney.t.sol
+++ b/packages/solidity-semantic-money/test/SemanticMoney.t.sol
@@ -85,6 +85,76 @@ contract SemanticMoneyTest is Test {
     function test_operators() external {
         assertTrue(Time.wrap(0) == Time.wrap(0));
         assertTrue(Time.wrap(0) != Time.wrap(1));
+        assertTrue(Time.wrap(0) < Time.wrap(1));
+        assertFalse(Time.wrap(1) < Time.wrap(1));
+        assertTrue(Time.wrap(0) <= Time.wrap(1));
+        assertTrue(Time.wrap(1) <= Time.wrap(1));
+        assertTrue(Time.wrap(1) > Time.wrap(0));
+        assertFalse(Time.wrap(1) > Time.wrap(1));
+        assertTrue(Time.wrap(1) >= Time.wrap(0));
+        assertTrue(Time.wrap(1) >= Time.wrap(1));
+        {
+            (uint256 quot, uint256 rem) = Time.wrap(5).quotrem(Time.wrap(2));
+            assertEq(quot, 2);
+            assertEq(rem, 1);
+        }
+
+        assertTrue(FlowRate.wrap(0) == FlowRate.wrap(0));
+        assertTrue(FlowRate.wrap(0) != FlowRate.wrap(1));
+        assertTrue(FlowRate.wrap(0) < FlowRate.wrap(1));
+        assertFalse(FlowRate.wrap(1) < FlowRate.wrap(1));
+        assertTrue(FlowRate.wrap(0) <= FlowRate.wrap(1));
+        assertTrue(FlowRate.wrap(1) <= FlowRate.wrap(1));
+        assertTrue(FlowRate.wrap(1) > FlowRate.wrap(0));
+        assertFalse(FlowRate.wrap(1) > FlowRate.wrap(1));
+        assertTrue(FlowRate.wrap(1) >= FlowRate.wrap(0));
+        assertTrue(FlowRate.wrap(1) >= FlowRate.wrap(1));
+        {
+            (int256 quot, int256 rem) = FlowRate.wrap(5).quotrem(FlowRate.wrap(2));
+            assertEq(quot, 2);
+            assertEq(rem, 1);
+            (quot, rem) = FlowRate.wrap(-5).quotrem(FlowRate.wrap(2));
+            assertEq(quot, -2);
+            assertEq(rem, -1);
+            (quot, rem) = FlowRate.wrap(5).quotrem(FlowRate.wrap(-2));
+            assertEq(quot, -2);
+            assertEq(rem, 1);
+            (quot, rem) = FlowRate.wrap(-5).quotrem(FlowRate.wrap(-2));
+            assertEq(quot, 2);
+            assertEq(rem, -1);
+        }
+
+        assertTrue(Value.wrap(0) == Value.wrap(0));
+        assertTrue(Value.wrap(0) != Value.wrap(1));
+        assertTrue(Value.wrap(0) < Value.wrap(1));
+        assertFalse(Value.wrap(1) < Value.wrap(1));
+        assertTrue(Value.wrap(0) <= Value.wrap(1));
+        assertTrue(Value.wrap(1) <= Value.wrap(1));
+        assertTrue(Value.wrap(1) > Value.wrap(0));
+        assertFalse(Value.wrap(1) > Value.wrap(1));
+        assertTrue(Value.wrap(1) >= Value.wrap(0));
+        assertTrue(Value.wrap(1) >= Value.wrap(1));
+        {
+            (int256 quot, int256 rem) = Value.wrap(5).quotrem(Value.wrap(2));
+            assertEq(quot, 2);
+            assertEq(rem, 1);
+        }
+
+        assertTrue(Unit.wrap(0) == Unit.wrap(0));
+        assertTrue(Unit.wrap(0) != Unit.wrap(1));
+        assertTrue(Unit.wrap(0) < Unit.wrap(1));
+        assertFalse(Unit.wrap(1) < Unit.wrap(1));
+        assertTrue(Unit.wrap(0) <= Unit.wrap(1));
+        assertTrue(Unit.wrap(1) <= Unit.wrap(1));
+        assertTrue(Unit.wrap(1) > Unit.wrap(0));
+        assertFalse(Unit.wrap(1) > Unit.wrap(1));
+        assertTrue(Unit.wrap(1) >= Unit.wrap(0));
+        assertTrue(Unit.wrap(1) >= Unit.wrap(1));
+        {
+            (int256 quot, int256 rem) = Unit.wrap(5).quotrem(Unit.wrap(2));
+            assertEq(quot, 2);
+            assertEq(rem, 1);
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/packages/solidity-semantic-money/test/SemanticMoney.t.sol
+++ b/packages/solidity-semantic-money/test/SemanticMoney.t.sol
@@ -82,6 +82,11 @@ contract SemanticMoneyTest is Test {
         assertEq(q.mul(u) + e, r, "e1");
     }
 
+    function test_operators() external {
+        assertTrue(Time.wrap(0) == Time.wrap(0));
+        assertTrue(Time.wrap(0) != Time.wrap(1));
+    }
+
     ////////////////////////////////////////////////////////////////////////////////
     // Particle/Universal Index Properties: Monoidal Laws & Monetary Unit Laws
     ////////////////////////////////////////////////////////////////////////////////

--- a/packages/solidity-semantic-money/test/SemanticMoney.t.sol
+++ b/packages/solidity-semantic-money/test/SemanticMoney.t.sol
@@ -176,8 +176,38 @@ contract SemanticMoneyTest is Test {
         (d.a, d.b) = d.a.flow2(d.b, FlowRate.wrap(r1), d.t1);
         (d.a, d.b) = d.a.flow2(d.b, FlowRate.wrap(r2), d.t2);
 
+        assertEq(Value.unwrap(-d.a.rtb(d.t3)), Value.unwrap(d.b.rtb(d.t3)));
         assertEq(Value.unwrap(d.b.rtb(d.t3)),
                  int256(r1) * int256(uint256(m2)) + int256(r2) * int256(uint256(m3)));
+    }
+    function test_uu_shift_flow2b(uint16 m1, int64 r1, uint16 m2, int64 r2, uint16 m3) external {
+        UUTestVars memory d;
+        d.t1 = Time.wrap(m1);
+        d.t2 = d.t1 + Time.wrap(m2);
+        d.t3 = d.t2 + Time.wrap(m3);
+
+        (d.a, d.b) = d.a.shift_flow2b(d.b, FlowRate.wrap(r1), d.t1);
+        (d.a, d.b) = d.a.shift_flow2b(d.b, FlowRate.wrap(r2), d.t2);
+
+        assertEq(Value.unwrap(-d.a.rtb(d.t3)), Value.unwrap(d.b.rtb(d.t3)));
+        assertEq(Value.unwrap(d.b.rtb(d.t3)),
+                 int256(r1) * int256(uint256(m2)) + (int256(r1) + int256(r2)) * int256(uint256(m3)));
+    }
+    function test_uu_shift_flow2ab_equiv(int64 r1, uint16 m1, int64 r2, uint16 m2) external {
+        Time t1 = Time.wrap(m1);
+        Time t2 = Time.wrap(m1) + Time.wrap(m2);
+        BasicParticle memory a0;
+        BasicParticle memory b0;
+
+        (BasicParticle memory a1a, BasicParticle memory b1a) = a0.shift_flow2a(b0, FlowRate.wrap(r1), t1);
+        (BasicParticle memory a1b, BasicParticle memory b1b) = a0.shift_flow2b(b0, FlowRate.wrap(r1), t1);
+        assertEq(a1a, a1b, "a1");
+        assertEq(b1a, b1b, "b1");
+
+        (BasicParticle memory a2a, BasicParticle memory b2a) = a1a.shift_flow2a(b1a, FlowRate.wrap(r2), t2);
+        (BasicParticle memory a2b, BasicParticle memory b2b) = a1b.shift_flow2b(b1b, FlowRate.wrap(r2), t2);
+        assertEq(a2a, a2b, "a2");
+        assertEq(b2a, b2b, "b2");
     }
 
     // Universal Index to Proportional Distribution Pool

--- a/packages/solidity-semantic-money/test/ref-impl/ToySuperToken.t.sol
+++ b/packages/solidity-semantic-money/test/ref-impl/ToySuperToken.t.sol
@@ -117,7 +117,7 @@ contract ToySuperTokenTest is Test {
         vm.startPrank(alice);
         token.flow(alice, bob, FlowId.wrap(0), rr1);
         vm.stopPrank();
-        assertEq(token.getNetFlowRate(alice), rr1.inv(), "e1.1");
+        assertEq(token.getNetFlowRate(alice), -rr1, "e1.1");
         assertEq(token.getNetFlowRate(bob), rr1, "e1.2");
         assertEq(token.getFlowRate(alice, bob, FlowId.wrap(0)), rr1, "e1.3");
 
@@ -126,7 +126,7 @@ contract ToySuperTokenTest is Test {
         vm.startPrank(alice);
         token.flow(alice, bob, FlowId.wrap(0), rr2);
         vm.stopPrank();
-        assertEq(token.getNetFlowRate(alice), rr2.inv(), "e2.1");
+        assertEq(token.getNetFlowRate(alice), -rr2, "e2.1");
         assertEq(token.getNetFlowRate(bob), rr2, "e2.2");
         assertEq(token.getFlowRate(alice, bob, FlowId.wrap(0)), rr2, "e2.3");
 
@@ -162,7 +162,7 @@ contract ToySuperTokenTest is Test {
         assertEq(token.getFlowRate(alice, bob, FlowId.wrap(0)), rr1, "e1.1");
         assertEq(token.getFlowRate(alice, carol, FlowId.wrap(0)), rr2, "e1.2");
         assertEq(token.getFlowRate(bob, carol, FlowId.wrap(0)), FlowRate.wrap(0), "e1.3");
-        assertEq(token.getNetFlowRate(alice).inv(),
+        assertEq(-token.getNetFlowRate(alice),
                  token.getNetFlowRate(bob) + token.getNetFlowRate(carol), "e2");
         assertEq(a1 - a2, k2 + (uint256(r1) + uint256(r2)) * uint256(dt1), "e3.1");
         assertEq(a1 - a2, k2 + b2 - b1 + c2 - c1, "e3.2");
@@ -197,7 +197,7 @@ contract ToySuperTokenTest is Test {
         assertEq(token.getFlowRate(bob, carol, FlowId.wrap(0)), rr2, "e1.2");
         assertEq(token.getFlowRate(alice, bob, FlowId.wrap(0)), FlowRate.wrap(0), "e1.3");
         assertEq(token.getNetFlowRate(alice) + token.getNetFlowRate(bob),
-                 token.getNetFlowRate(carol).inv(), "e2");
+                 -token.getNetFlowRate(carol), "e2");
         assertEq(a1 - a2, k1 + uint256(r1) * uint256(t2), "e3.1");
         assertEq(b1 - b2, k2 + uint256(r2) * uint256(t2), "e3.2");
         assertEq(a1 - a2 + b1 - b2, k1 + k2 + c2 - c1, "e3.3");
@@ -309,11 +309,11 @@ contract ToySuperTokenTest is Test {
             emit log_named_int("cnr1", FlowRate.unwrap(cnr1));
 
             assertEq(pdr, pdr1, "e4.1");
-            assertEq(anr1, ar.inv() + ajr1, "e4.2");
+            assertEq(anr1, -ar + ajr1, "e4.2");
             assertEq(pdr, rrr1, "e4.3");
-            assertEq(anr1, rrr1.inv() + ajr1, "e4.4");
+            assertEq(anr1, -rrr1 + ajr1, "e4.4");
             assertEq(bnr1 + cnr1, rrr1, "e4.5");
-            assertEq(pnr1, ajr1.inv(), "e4.6");
+            assertEq(pnr1, -ajr1, "e4.6");
             assertEq(anr1 + bnr1 + cnr1 + pnr1, FlowRate.wrap(0), "e4.7");
         }
 
@@ -340,11 +340,11 @@ contract ToySuperTokenTest is Test {
             emit log_named_int("cnr2", FlowRate.unwrap(cnr2));
 
             assertEq(pdr, pdr2, "e5.1");
-            assertEq(ar.inv() + ajr2, anr2, "e5.2");
+            assertEq(-ar + ajr2, anr2, "e5.2");
             assertEq(pdr, rrr2, "e5.3");
-            assertEq(rrr2.inv() + ajr2, anr2, "e5.4");
+            assertEq(-rrr2 + ajr2, anr2, "e5.4");
             assertEq(bnr2 + cnr2, rrr2, "e5.5");
-            assertEq(pnr2, ajr2.inv(), "e5.6");
+            assertEq(pnr2, -ajr2, "e5.6");
             assertEq(anr2 + bnr2 + cnr2 + pnr2, FlowRate.wrap(0), "e5.7");
         }
         {
@@ -424,7 +424,7 @@ contract ToySuperTokenTest is Test {
             FlowRate pr2 = token.getNetFlowRate(address(pl));
 
             assertEq(pl.getConnectedFlowRate(), rrr, "e4.1");
-            assertEq(ar2, rrr.inv(), "e4.2");
+            assertEq(ar2, -rrr, "e4.2");
             assertEq(br2 + pl.getDisconnectedFlowRate(), rrr, "e4.3");
             assertEq(pr2, pl.getDisconnectedFlowRate(), "e4.4");
             assertEq(ar2 + br2 + cr2 + pr2, FlowRate.wrap(0), "e4.5");
@@ -505,7 +505,7 @@ contract ToySuperTokenTest is Test {
             emit log_named_int("pnr4", FlowRate.unwrap(pnr4));
 
             assertEq(pl.getConnectedFlowRate(), rrr, "e3.1");
-            assertEq(anr4, rrr.inv(), "e3.2");
+            assertEq(anr4, -rrr, "e3.2");
             assertEq(bnr4 + pl.getDisconnectedFlowRate(), rrr, "e3.3");
             assertEq(pnr4, pl.getDisconnectedFlowRate(), "e3.4");
             assertEq(anr4 + bnr4 + pnr4, FlowRate.wrap(0), "e3.5");
@@ -619,8 +619,8 @@ contract ToySuperTokenTest is Test {
             assertEq(pr2, FlowRate.wrap(0), "e4.5");
             assertEq(ar2 + br2 + cr2 + pr2, FlowRate.wrap(0), "e4.6");
             assertEq(pdr2, pdr, "e4.7");
-            assertEq(ar2.inv(), ar, "e4.8");
-            assertEq(br2.inv(), br, "e4.9");
+            assertEq(-ar2, ar, "e4.8");
+            assertEq(-br2, br, "e4.9");
         }
 
         {

--- a/tasks/check-changeset.sh
+++ b/tasks/check-changeset.sh
@@ -48,6 +48,12 @@ if [ -n "$GITHUB_ENV" ];then
         echo "Root package.json changed."
         setBuildAll
     fi
+    # if specified solidity-semantic-money folders and files changed
+    if grep -E "^packages/solidity-semantic-money/(src/|test/|foundry\.toml|Makefile|package\.json)" changed-files.list;then
+        BUILD_SOLIDITY_SEMANTIC_MONEY=1
+        BUILD_ETHEREUM_CONTRACTS=1
+        echo Solidity semantic money will be tested.
+    fi
     # if specified ethereum-contracts folders and files changed
     if grep -E "^packages/ethereum-contracts/(contracts/|scripts/|test/|truffle-config\.js|package\.json)" changed-files.list;then
         BUILD_ETHEREUM_CONTRACTS=1
@@ -92,11 +98,6 @@ if [ -n "$GITHUB_ENV" ];then
     if grep -E "^packages/automation-contracts/autowrap/(contracts/|scripts/|test/|truffle-config\.js|package\.json)" changed-files.list;then
         BUILD_AUTOMATION_CONTRACTS=1
         echo Automation Contracts will be tested.
-    fi
-    # if specified solidity-semantic-money folders and files changed
-    if grep -E "^packages/solidity-semantic-money/(src/|test/|foundry\.toml|Makefile|package\.json)" changed-files.list;then
-        BUILD_SOLIDITY_SEMANTIC_MONEY=1
-        echo Solidity semantic money will be tested.
     fi
 
     if [ "$BUILD_ETHEREUM_CONTRACTS" == 1 ] || [ "$BUILD_SDK_CORE" == 1 ] || [ "$BUILD_SDK_REDUX" == 1 ];then


### PR DESCRIPTION
- [x] Fix a big of `shift_flow2a(BasicParticle, BasicParticle)`, thanks @kobuta23.
- [x] (Breaking) Replace `inv()` with unary '-' operator.
- [x] Adding more user-defined operators for semantic money custom types.