### PR TITLE
[sdk-core][fix] lowecase subgraph argument when address

### DIFF
--- a/packages/sdk-core/src/subgraph/SubgraphClient.ts
+++ b/packages/sdk-core/src/subgraph/SubgraphClient.ts
@@ -22,7 +22,7 @@ export class SubgraphClient {
             variables: variables ? cleanVariables<V>(variables) : undefined,
             // TODO: explicit casting is semi-dirty and not recommended
             // but I am not sure how to fix this right now
-        } as RequestExtendedOptions<V, T>);
+        } as unknown as RequestExtendedOptions<V, T>);
     }
 }
 

--- a/packages/sdk-core/src/subgraph/subgraphQueryHandler.ts
+++ b/packages/sdk-core/src/subgraph/subgraphQueryHandler.ts
@@ -1,4 +1,5 @@
 import { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { ethers } from "ethers";
 import _ from "lodash";
 
 import { listAllResults } from "../Query";
@@ -224,7 +225,9 @@ export abstract class SubgraphQueryHandler<
 
         const response = await this.querySubgraph(subgraphClient, {
             where: {
-                id: query.id,
+                id: ethers.utils.isAddress(query.id)
+                    ? query.id.toLowerCase()
+                    : query.id,
             },
             skip: 0,
             take: 1,


### PR DESCRIPTION
Why?
The behaviour used to be `query.id.toLowerCase()` (removed only in the dev-branch) without the address check but that caused issues with some Subgraph IDs that had both lowercase and uppercase letter in the ID. When the ID is an address, that's always lowercase though.