### PR TITLE
[sdk-core][sdk-redux][chore] prepare package release

### DIFF
--- a/packages/sdk-core/CHANGELOG.md
+++ b/packages/sdk-core/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
+### Changed
+### Fixed
+
+## [0.6.13] - 2023-04-30
+
+### Added
 
 -   Added Degen chain support
 -   Added `getTotalAmountReceivedByMember`

--- a/packages/sdk-redux/CHANGELOG.md
+++ b/packages/sdk-redux/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the SDK-redux will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+### Changed
+### Fixed
+
+## [0.5.2] - 2023-04-30
+
 ### Changed
 
 - Node dependency updates

--- a/packages/sdk-redux/package.json
+++ b/packages/sdk-redux/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/sdk-redux",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "SDK Redux for streamlined front-end application development with Superfluid Protocol",
     "homepage": "https://docs.superfluid.finance/",
     "repository": {


### PR DESCRIPTION
Why?
It's time to get `0.6.13` and `0.5.2` out the door.