### PR TITLE
[ETHEREUM-CONTRACTS] BeaconProxy verification for SuperfluidPool

### DIFF
--- a/packages/ethereum-contracts/ops-scripts/deploy-framework.js
+++ b/packages/ethereum-contracts/ops-scripts/deploy-framework.js
@@ -222,6 +222,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
         "SuperfluidPool",
         "SuperfluidPoolPlaceholder",
         "SuperfluidPoolDeployerLibrary",
+        "BeaconProxy",
         "ConstantOutflowNFT",
         "ConstantInflowNFT",
         "PoolAdminNFT",
@@ -261,6 +262,7 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
         SuperfluidPool,
         SuperfluidPoolPlaceholder,
         SuperfluidPoolDeployerLibrary,
+        BeaconProxy,
         ConstantOutflowNFT,
         ConstantInflowNFT,
         PoolAdminNFT,
@@ -585,6 +587,14 @@ module.exports = eval(`(${S.toString()})({skipArgv: true})`)(async function (
                 GeneralDistributionAgreementV1,
                 protocolReleaseVersion === "test" ? true : false
             );
+
+            // deploy a dummy BeaconProxy for verification
+            const beaconProxy = await web3tx(
+                BeaconProxy.new,
+                "BeaconProxy.new"
+            )(superfluidPoolBeaconAddr, "0x");
+            console.log("Dummy BeaconProxy address", beaconProxy.address);
+            output += `DUMMY_BEACON_PROXY=${beaconProxy.address}\n`;
 
             if (process.env.IS_HARDHAT) {
                 // this fails in test case deployment.test.js:ops-scripts/deploy-super-token.js

--- a/packages/ethereum-contracts/tasks/etherscan-verify-framework.sh
+++ b/packages/ethereum-contracts/tasks/etherscan-verify-framework.sh
@@ -158,6 +158,10 @@ if [ -n "$SUPERFLUID_POOL_DEPLOYER_LIBRARY" ]; then
     try_verify SuperfluidPoolDeployerLibrary@"${SUPERFLUID_POOL_DEPLOYER_LIBRARY}"
 fi
 
+if [ -n "$DUMMY_BEACON_PROXY" ]; then
+    try_verify BeaconProxy@"${DUMMY_BEACON_PROXY}"
+fi
+
 # this will fail with 'Library address is not prefixed with "0x"' if a library address is not set
 link_library "GeneralDistributionAgreementV1" "SlotsBitmapLibrary" "${SLOTS_BITMAP_LIBRARY}"
 link_library "GeneralDistributionAgreementV1" "SuperfluidPoolDeployerLibrary" "${SUPERFLUID_POOL_DEPLOYER_LIBRARY}"


### PR DESCRIPTION
The GDA related SuperfluidPool contracts are based on BeaconProxy, which is deployed by SuperfluidPoolDeployerLibrary.
Because of this, automatic constructor argument inference doesn't work (we had this before).

Mitigation in this PR: deploy-framework.js deploys a Dummy instance of BeaconProxy and includes it in the list of contracts to be verified. This automatically verifies all identical instances.