### PR TITLE
[SUBGRAPH] use correct version when deploying to goldsky

### DIFF
--- a/packages/subgraph/tasks/deploy.sh
+++ b/packages/subgraph/tasks/deploy.sh
@@ -125,7 +125,6 @@ deploy_to_superfluid() {
 deploy_to_goldsky() {
     local network="$1"
     # TODO: use tagging?
-    # TODO: how to handle versions?
 
     # name mapping for godldsky legacy networks not using our cliNames
     local -A legacyNetworkNames=(
@@ -133,7 +132,7 @@ deploy_to_goldsky() {
     )
 
     local goldskyNetwork="${legacyNetworkNames[$network]:-$network}"
-    local subgraphName="protocol-$DEPLOYMENT_ENV-$goldskyNetwork/1.0.0"
+    local subgraphName="protocol-$DEPLOYMENT_ENV-$goldskyNetwork/$VERSION_LABEL"
 
     $GRAPH_CLI build
     # Note: when using Graph CLI to deploy, it implicitly triggers build too, but Goldsky CLI doesn't.


### PR DESCRIPTION
Was hardcoded to 1.0.0.

![image](https://github.com/superfluid-finance/protocol-monorepo/assets/5479136/669e83ae-5599-43ba-82d6-8b358c1a2d1c)
