### PR TITLE
[subgraph] configurable history pruning

### DIFF
--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.0.0]
+
+### Changed
+- Enabled history pruning which disables perfect time-travel queries.
+
 ## [1.7.1] - 2024-04-22
 
 ### Added

--- a/packages/subgraph/docker-compose.yml
+++ b/packages/subgraph/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.27.0
+    image: graphprotocol/graph-node:v0.35.0
     ports:
       - "8000:8000"
       - "8001:8001"

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -50,8 +50,8 @@
         "cloc": "cloc src"
     },
     "dependencies": {
-        "@graphprotocol/graph-cli": "0.69.1",
-        "@graphprotocol/graph-ts": "0.34.0",
+        "@graphprotocol/graph-cli": "0.73.0",
+        "@graphprotocol/graph-ts": "0.35.1",
         "@superfluid-finance/sdk-core": "^0.7.0",
         "mustache": "^4.2.0"
     },

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@superfluid-finance/subgraph",
-    "version": "1.7.1",
+    "version": "2.0.0",
     "description": "Subgraph for the Superfluid Ethereum contracts.",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/subgraph",
     "repository": {

--- a/packages/subgraph/scripts/buildNetworkConfig.ts
+++ b/packages/subgraph/scripts/buildNetworkConfig.ts
@@ -20,7 +20,7 @@ interface SubgraphConfig {
 const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000";
 
 const vendorCliNameExceptions: Record<string, Record<string, string>> = {
-    ["goldsky"]: {
+    "goldsky": {
         "xdai-mainnet": "xdai"
     }
 }

--- a/packages/subgraph/scripts/buildNetworkConfig.ts
+++ b/packages/subgraph/scripts/buildNetworkConfig.ts
@@ -14,7 +14,7 @@ interface SubgraphConfig {
     readonly nativeAssetSuperTokenAddress: string;
     readonly constantOutflowNFTAddress: string;
     readonly constantInflowNFTAddress: string;
-    readonly indexerHints_prune?: string;
+    readonly indexerHints_prune: string;
 }
 
 const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000";

--- a/packages/subgraph/scripts/buildNetworkConfig.ts
+++ b/packages/subgraph/scripts/buildNetworkConfig.ts
@@ -14,23 +14,34 @@ interface SubgraphConfig {
     readonly nativeAssetSuperTokenAddress: string;
     readonly constantOutflowNFTAddress: string;
     readonly constantInflowNFTAddress: string;
+    readonly indexerHints_prune?: string;
 }
 
 const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000";
 
-// script usage: npx ts-node ./scripts/buildNetworkConfig.ts <NETWORK_NAME>
+const vendorCliNameExceptions: Record<string, Record<string, string>> = {
+    ["goldsky"]: {
+        "xdai-mainnet": "xdai"
+    }
+}
+
+const vendorHistoryPruning: Record<string, string> = {
+    "goldsky": "auto"
+};
+
+// script usage: npx ts-node ./scripts/buildNetworkConfig.ts <NETWORK_NAME> <VENDOR_NAME?>
 function main() {
     const networkName = process.argv[2];
+    const vendorName = process.argv[3];
 
-    const networkMetadata = metadata.getNetworkByName(networkName);
+    const networkMetadata = metadata.getNetworkByName(networkName); 
 
     if (!networkMetadata) {
         throw new Error("No metadata found");
     }
 
     const subgraphConfig: SubgraphConfig = {
-        // cliName exists for networks supported by the hosted service
-        network: networkMetadata.subgraphV1.cliName || networkMetadata.shortName,
+        network: vendorCliNameExceptions[vendorName]?.[networkMetadata.name] || networkMetadata.subgraphV1.cliName || networkMetadata.shortName,
         hostStartBlock: networkMetadata.startBlockV1,
         hostAddress: networkMetadata.contractsV1.host,
         cfaAddress: networkMetadata.contractsV1.cfaV1,
@@ -41,6 +52,7 @@ function main() {
         nativeAssetSuperTokenAddress: networkMetadata.nativeTokenWrapper,
         constantOutflowNFTAddress: networkMetadata.contractsV1.constantOutflowNFT || ADDRESS_ZERO,
         constantInflowNFTAddress: networkMetadata.contractsV1.constantInflowNFT || ADDRESS_ZERO,
+        indexerHints_prune: vendorHistoryPruning[vendorName] || "never",
     };
 
     const writeToDir = join(__dirname, '..', `config/${networkName}.json`);

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -1,5 +1,5 @@
 specVersion: 1.0.0
-description: Subgraph for the Superfluid Ethereum contracts.
+description: Subgraph for the Superfluid Protocol V1 contracts.
 repository: https://github.com/superfluid-finance/protocol-monorepo
 schema:
     file: ./schema.graphql

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.5
+specVersion: 1.0.0
 description: Subgraph for the Superfluid Ethereum contracts.
 repository: https://github.com/superfluid-finance/protocol-monorepo
 schema:
@@ -13,7 +13,7 @@ dataSources:
           startBlock: {{ hostStartBlock }}
       mapping:
           kind: ethereum/events
-          apiVersion: 0.0.7
+          apiVersion: 0.0.8
           language: wasm/assemblyscript
           file: ./src/mappings/superTokenFactory.ts
           entities:
@@ -50,7 +50,7 @@ dataSources:
           startBlock: {{ hostStartBlock }}
       mapping:
           kind: ethereum/events
-          apiVersion: 0.0.7
+          apiVersion: 0.0.8
           language: wasm/assemblyscript
           file: ./src/mappings/host.ts
           entities:
@@ -96,7 +96,7 @@ dataSources:
           startBlock: {{ hostStartBlock }}
       mapping:
           kind: ethereum/events
-          apiVersion: 0.0.7
+          apiVersion: 0.0.8
           language: wasm/assemblyscript
           file: ./src/mappings/cfav1.ts
           entities:
@@ -139,7 +139,7 @@ dataSources:
         startBlock: {{ hostStartBlock }}
       mapping:
         kind: ethereum/events
-        apiVersion: 0.0.7
+        apiVersion: 0.0.8
         language: wasm/assemblyscript
         file: ./src/mappings/idav1.ts
         entities:
@@ -210,7 +210,7 @@ dataSources:
         startBlock: {{ hostStartBlock }}
       mapping:
         kind: ethereum/events
-        apiVersion: 0.0.7
+        apiVersion: 0.0.8
         language: wasm/assemblyscript
         file: ./src/mappings/gdav1.ts
         entities:
@@ -263,7 +263,7 @@ dataSources:
         startBlock: {{ hostStartBlock }}
       mapping:
         kind: ethereum/events
-        apiVersion: 0.0.7
+        apiVersion: 0.0.8
         language: wasm/assemblyscript
         file: ./src/mappings/resolver.ts
         entities:
@@ -298,7 +298,7 @@ dataSources:
         startBlock: {{ hostStartBlock }}
       mapping:
         kind: ethereum/events
-        apiVersion: 0.0.7
+        apiVersion: 0.0.8
         language: wasm/assemblyscript
         file: ./src/mappings/flowNFT.ts
         entities:
@@ -333,7 +333,7 @@ dataSources:
         startBlock: {{ hostStartBlock }}
       mapping:
         kind: ethereum/events
-        apiVersion: 0.0.7
+        apiVersion: 0.0.8
         language: wasm/assemblyscript
         file: ./src/mappings/flowNFT.ts
         entities:
@@ -367,7 +367,7 @@ templates:
       abi: ISuperToken
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.8
       language: wasm/assemblyscript
       file: ./src/mappings/superToken.ts
       entities:
@@ -426,7 +426,7 @@ templates:
       abi: SuperfluidGovernanceBase
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.8
       language: wasm/assemblyscript
       file: ./src/mappings/superfluidGovernance.ts
       entities:
@@ -466,7 +466,7 @@ templates:
       abi: TOGA
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.8
       language: wasm/assemblyscript
       file: ./src/mappings/toga.ts
       entities:
@@ -493,7 +493,7 @@ templates:
       abi: ISuperfluidPool
     mapping:
       kind: ethereum/events
-      apiVersion: 0.0.7
+      apiVersion: 0.0.8
       language: wasm/assemblyscript
       file: ./src/mappings/superfluidPool.ts
       entities:

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -3,6 +3,8 @@ description: Subgraph for the Superfluid Ethereum contracts.
 repository: https://github.com/superfluid-finance/protocol-monorepo
 schema:
     file: ./schema.graphql
+indexerHints:
+  prune: {{#indexerHints_prune}}{{ indexerHints_prune }}{{/indexerHints_prune}}{{^indexerHints_prune}}never{{/indexerHints_prune}}
 dataSources:
     - kind: ethereum/contract
       name: SuperTokenFactory

--- a/packages/subgraph/tasks/deploy.sh
+++ b/packages/subgraph/tasks/deploy.sh
@@ -177,7 +177,7 @@ deploy_to() {
         exit 1
     fi
 
-    npx ts-node ./scripts/buildNetworkConfig.ts "$network"
+    npx ts-node ./scripts/buildNetworkConfig.ts "$network" "$vendor"
 
     # prepare the manifest prior to deployment
     # this generates the subgraph.yaml and

--- a/packages/subgraph/tasks/deploy.sh
+++ b/packages/subgraph/tasks/deploy.sh
@@ -126,18 +126,12 @@ deploy_to_goldsky() {
     local network="$1"
     # TODO: use tagging?
 
-    # name mapping for godldsky legacy networks not using our cliNames
-    local -A legacyNetworkNames=(
-        ["xdai-mainnet"]="xdai"
-    )
+    local subgraphName="protocol-$DEPLOYMENT_ENV-$network/$VERSION_LABEL"
 
-    local goldskyNetwork="${legacyNetworkNames[$network]:-$network}"
-    local subgraphName="protocol-$DEPLOYMENT_ENV-$goldskyNetwork/$VERSION_LABEL"
-
+    # Note: when using Graph CLI to deploy, it implicitly triggers build too, but Goldsky CLI doesn't, so we do it explicitly.
     $GRAPH_CLI build
-    # Note: when using Graph CLI to deploy, it implicitly triggers build too, but Goldsky CLI doesn't.
 
-    echo "********* Deploying $goldskyNetwork subgraph $subgraphName to Goldsky. **********"
+    echo "********* Deploying $network subgraph $subgraphName to Goldsky. **********"
     $GOLDSKY_CLI subgraph deploy \
         "$subgraphName" \
         --path . \

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,10 +1499,10 @@
   optionalDependencies:
     "@trufflesuite/bigint-buffer" "1.1.9"
 
-"@graphprotocol/graph-cli@0.69.1":
-  version "0.69.1"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.69.1.tgz#2ea248fb1636b46afb6101236e3f387e9d2f3275"
-  integrity sha512-PekTli4hsBkF48y2NA2ufNjtdG/VL4N+E7GAavNXxFmSHM9VoCWbR4OBeJ93dAOpgHRGyx8yO1NE9DDT7yEZsg==
+"@graphprotocol/graph-cli@0.73.0":
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.73.0.tgz#ff4ab0a153b9fedad4ade3cddb52caf68f519c1b"
+  integrity sha512-g+EapDRvxhRjMccnUJE8gBRGDIF6mXqtv8g0tzzixVClw/BezBni8QXtXMHs4Gg0G2UnerJJLp5ZQgZqtHWnmg==
   dependencies:
     "@float-capital/float-subgraph-uncrashable" "^0.0.0-alpha.4"
     "@oclif/core" "2.8.6"
@@ -1524,6 +1524,7 @@
     ipfs-http-client "55.0.0"
     jayson "4.0.0"
     js-yaml "3.14.1"
+    open "8.4.2"
     prettier "3.0.3"
     semver "7.4.0"
     sync-request "6.1.0"
@@ -1532,10 +1533,10 @@
     which "2.0.2"
     yaml "1.10.2"
 
-"@graphprotocol/graph-ts@0.34.0":
-  version "0.34.0"
-  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.34.0.tgz#ca47398295b114f25b412faa364b98af31fa2bb7"
-  integrity sha512-gnhjai65AV4YMYe9QHGz+HP/jdzI54z/nOfEXZFfh6m987EP2iy3ycLXrTi+ahcogHH7vtoWFdXbUzZbE8bCAg==
+"@graphprotocol/graph-ts@0.35.1":
+  version "0.35.1"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-ts/-/graph-ts-0.35.1.tgz#1e1ecc36d8f7a727ef3a6f1fed4c5ce16de378c2"
+  integrity sha512-74CfuQmf7JI76/XCC34FTkMMKeaf+3Pn0FIV3m9KNeaOJ+OI3CvjMIVRhOZdKcJxsFCBGaCCl0eQjh47xTjxKA==
   dependencies:
     assemblyscript "0.19.10"
 
@@ -13668,34 +13669,7 @@ mnemonist@^0.38.0:
   dependencies:
     obliterator "^2.0.0"
 
-mocha@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.1.0.tgz#dbf1114b7c3f9d0ca5de3133906aea3dfc89ef7a"
-  integrity sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==
-  dependencies:
-    ansi-colors "4.1.1"
-    browser-stdout "1.3.1"
-    chokidar "3.5.3"
-    debug "4.3.4"
-    diff "5.0.0"
-    escape-string-regexp "4.0.0"
-    find-up "5.0.0"
-    glob "7.2.0"
-    he "1.2.0"
-    js-yaml "4.1.0"
-    log-symbols "4.1.0"
-    minimatch "5.0.1"
-    ms "2.1.3"
-    nanoid "3.3.3"
-    serialize-javascript "6.0.0"
-    strip-json-comments "3.1.1"
-    supports-color "8.1.1"
-    workerpool "6.2.1"
-    yargs "16.2.0"
-    yargs-parser "20.2.4"
-    yargs-unparser "2.0.0"
-
-mocha@^10.0.0, mocha@^10.2.0:
+mocha@10.1.0, mocha@^10.0.0, mocha@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
   integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
@@ -14603,7 +14577,7 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@^8.4.0:
+open@8.4.2, open@^8.4.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
   integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==


### PR DESCRIPTION
## Why?
We want to index subgraphs to Goldsky with less entities created in the database.

## How?
To do so, we will indroduce history pruning. 

## Other
Updated subgraph tooling and spec.

## Warning!
If you rely on time-travel queries then this will be a breaking change. Contact us if you need continued access to time-travel queries!

Example of a time-travel query:
```graphql
{
  challenges(block: { number: 8000000 }) {
    challenger
    outcome
    application {
      id
    }
  }
}
```

Read more:
- https://thegraph.com/docs/en/cookbook/pruning/
- https://thegraph.com/docs/en/querying/graphql-api/#time-travel-queries