### PR TITLE
[AUTOMATIONS] VestingSchedulerV2 claim after end date

### DIFF
--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -28,7 +28,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
     * @param totalDuration The total duration of the vestingß
     * @param cliffPeriod The cliff period of the vesting
     * @param startDate Timestamp when the vesting should start
-    * @param claimValidityDate Date before which the claimable schedule must be claimed
+    * @param claimPeriod The claim availability period
     * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
     */
     struct ScheduleCreationFromAmountAndDurationParams {
@@ -38,7 +38,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 totalDuration;
         uint32 cliffPeriod;
         uint32 startDate;
-        uint32 claimValidityDate;
+        uint32 claimPeriod;
         bytes ctx;
     }
 
@@ -224,7 +224,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 totalDuration,
                 cliffPeriod,
                 startDate,
-                0, // claimValidityDate
+                0, // claimPeriod
                 ctx
             )
         );
@@ -247,7 +247,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 totalDuration,
                 cliffPeriod,
                 startDate,
-                0, // claimValidityDate
+                0, // claimPeriod
                 bytes("")
             )
         );
@@ -269,7 +269,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 totalDuration,
                 cliffPeriod,
                 0, // startDate
-                0, // claimValidityDate
+                0, // claimPeriod
                 bytes("")
             )
         );
@@ -290,7 +290,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 totalDuration,
                 0, // cliffPeriod
                 0, // startDate
-                0, // claimValidityDate
+                0, // claimPeriod
                 bytes("")
             )
         );
@@ -304,6 +304,10 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
             params.startDate = uint32(block.timestamp);
         }
 
+        uint32 claimValidityDate = params.claimPeriod != 0
+            ? params.startDate + params.claimPeriod
+            : 0;
+
         uint32 endDate = params.startDate + params.totalDuration;
         int96 flowRate = SafeCast.toInt96(SafeCast.toInt256(params.totalAmount / params.totalDuration));
         uint256 remainderAmount = params.totalAmount - (SafeCast.toUint256(flowRate) * params.totalDuration);
@@ -314,7 +318,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                     params.superToken, 
                     params.receiver, 
                     params.startDate, 
-                    params.claimValidityDate, 
+                    claimValidityDate, 
                     0 /* cliffDate */, 
                     flowRate, 
                     0 /* cliffAmount */, 
@@ -331,7 +335,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                     params.superToken, 
                     params.receiver, 
                     params.startDate,
-                    params.claimValidityDate, 
+                    claimValidityDate, 
                     cliffDate, 
                     flowRate, 
                     cliffAmount, 
@@ -462,7 +466,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 claimValidityDate,
+        uint32 claimPeriod,
         uint32 cliffPeriod,
         uint32 startDate,
         bytes memory ctx
@@ -475,7 +479,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 totalDuration,
                 cliffPeriod,
                 startDate,
-                claimValidityDate,
+                claimPeriod,
                 ctx
             )
         );
@@ -487,7 +491,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 claimValidityDate,
+        uint32 claimPeriod,
         uint32 cliffPeriod,
         uint32 startDate
     ) external {
@@ -499,7 +503,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 totalDuration,
                 cliffPeriod,
                 startDate,
-                claimValidityDate,
+                claimPeriod,
                 bytes("")
             )
         );
@@ -511,7 +515,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 claimValidityDate,
+        uint32 claimPeriod,
         uint32 cliffPeriod
     ) external {
         uint32 startDate = uint32(block.timestamp);
@@ -524,7 +528,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 totalDuration,
                 cliffPeriod,
                 startDate,
-                claimValidityDate,
+                claimPeriod,
                 bytes("")
             )
         );
@@ -536,7 +540,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 claimValidityDate
+        uint32 claimPeriod
     ) external {
         uint32 startDate = uint32(block.timestamp);
 
@@ -548,7 +552,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 totalDuration,
                 0, // cliffPeriod
                 startDate,
-                claimValidityDate,
+                claimPeriod,
                 bytes("")
             )
         );

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -635,6 +635,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 revert CannotClaimScheduleOnBehalf();
             }
             delete vestingSchedules[configHash].claimValidityDate;
+            emit VestingClaimed(superToken, sender, receiver, msg.sender);
         }
         
         // Ensure that that the claming date is after the cliff/flow date and before the early end of the schedule

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -16,6 +16,7 @@ interface IVestingSchedulerV2 {
     error ScheduleDoesNotExist();
     error ScheduleNotFlowing();
     error CannotClaimScheduleOnBehalf();
+    error AlreadyExecuted();
 
     /**
      * @dev Vesting configuration provided by user.
@@ -233,7 +234,7 @@ interface IVestingSchedulerV2 {
      * @param receiver Vesting receiver
      * @param totalAmount The total amount to be vested
      * @param totalDuration The total duration of the vesting
-     * @param claimValidityDate Date before which the claimable schedule must be claimed
+     * @param claimPeriod The claim availability period
      * @param cliffPeriod The cliff period of the vesting
      * @param startDate Timestamp when the vesting should start
      * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
@@ -243,7 +244,7 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 claimValidityDate,
+        uint32 claimPeriod,
         uint32 cliffPeriod,
         uint32 startDate,
         bytes memory ctx
@@ -257,7 +258,7 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 claimValidityDate,
+        uint32 claimPeriod,
         uint32 cliffPeriod,
         uint32 startDate
     ) external;
@@ -271,7 +272,7 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 claimValidityDate,
+        uint32 claimPeriod,
         uint32 cliffPeriod
     ) external;
 
@@ -285,7 +286,7 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 claimValidityDate
+        uint32 claimPeriod
     ) external;
 
     /**

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -367,6 +367,20 @@ interface IVestingSchedulerV2 {
     );
 
     /**
+     * @dev Emitted when a claimable vesting schedule is claimed
+     * @param superToken The superToken to be vested
+     * @param sender Vesting sender
+     * @param receiver Vesting receiver
+     * @param claimer Account that claimed the vesting (can only be sender or receiver)
+     */
+    event VestingClaimed(
+        ISuperToken indexed superToken,
+        address indexed sender,
+        address indexed receiver,
+        address claimer
+    );
+
+    /**
      * @dev Executes a cliff (transfer and stream start)
      * @notice Intended to be invoked by a backend service
      * @param superToken SuperToken to be streamed

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -1307,13 +1307,12 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         uint32 startDate = uint32(block.timestamp);
         uint256 totalVestedAmount = 105_840_000; // a value perfectly divisible by a week
         uint32 vestingDuration = 1 weeks;
-        uint32 claimValidityDate = startDate + 1 days;
+        uint32 claimPeriod = 1 days;
         int96 expectedFlowRate = 175; // totalVestedAmount / vestingDuration
         uint32 expectedEndDate = startDate + vestingDuration;
 
         vm.expectEmit();
-        emit VestingScheduleCreated(superToken, alice, bob, startDate, 0, expectedFlowRate, expectedEndDate, 0, claimValidityDate, 0);
-
+        emit VestingScheduleCreated(superToken, alice, bob, startDate, 0, expectedFlowRate, expectedEndDate, 0, startDate + claimPeriod, 0);
         vm.startPrank(alice);
         bool useCtx = randomizer % 2 == 0;
         if (useCtx) {
@@ -1322,7 +1321,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                claimValidityDate,
+                claimPeriod,
                 0,
                 startDate,
                 EMPTY_CTX
@@ -1333,7 +1332,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                claimValidityDate,
+                claimPeriod,
                 0,
                 startDate
             );
@@ -1350,12 +1349,23 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         uint256 totalVestedAmount = 105_840_000; // a value perfectly divisible by a week
         uint32 vestingDuration = 1 weeks;
-        uint32 claimValidityDate = uint32(block.timestamp) + 2 days;
+        uint32 claimPeriod = 2 days;
         int96 expectedFlowRate = 175; // totalVestedAmount / vestingDuration
         uint32 expectedEndDate = uint32(block.timestamp) + vestingDuration;
 
         vm.expectEmit();
-        emit VestingScheduleCreated(superToken, alice, bob, uint32(block.timestamp), 0, expectedFlowRate, expectedEndDate, 0, claimValidityDate, 0);
+        emit VestingScheduleCreated(
+            superToken, 
+            alice, 
+            bob, 
+            uint32(block.timestamp), 
+            0, 
+            expectedFlowRate, 
+            expectedEndDate, 
+            0, 
+            uint32(block.timestamp) + claimPeriod, 
+            0
+        );
 
         vm.startPrank(alice);
 
@@ -1364,7 +1374,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             totalVestedAmount,
             vestingDuration,
-            claimValidityDate
+            claimPeriod
         );
         vm.stopPrank();
     }
@@ -1380,13 +1390,12 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         uint256 totalVestedAmount = 103_680_000; // a value perfectly divisible
         uint32 vestingDuration = 1 weeks + 1 days;
         uint32 cliffPeriod = 1 days;
-        uint32 claimValidityDate = startDate + cliffPeriod + 1 days;
+        uint32 claimPeriod = cliffPeriod + 1 days;
 
         int96 expectedFlowRate = 150; // (totalVestedAmount - cliffAmount) / (vestingDuration - cliffPeriod)
-        uint256 expectedCliffAmount = 12960000;
 
         vm.expectEmit();
-        emit VestingScheduleCreated(superToken, alice, bob, startDate, startDate + cliffPeriod, expectedFlowRate, startDate + vestingDuration, expectedCliffAmount, claimValidityDate, 0);
+        emit VestingScheduleCreated(superToken, alice, bob, startDate, startDate + cliffPeriod, expectedFlowRate, startDate + vestingDuration, 12960000, startDate + claimPeriod, 0);
 
         vm.startPrank(alice);
         bool useCtx = randomizer % 2 == 0;
@@ -1396,7 +1405,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                claimValidityDate,
+                claimPeriod,
                 cliffPeriod,
                 startDate,
                 EMPTY_CTX
@@ -1407,7 +1416,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                claimValidityDate,
+                claimPeriod,
                 cliffPeriod,
                 startDate
             );
@@ -1429,11 +1438,11 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         int96 expectedFlowRate = 150; // (totalVestedAmount - cliffAmount) / (vestingDuration - cliffPeriod)
         uint256 expectedCliffAmount = 12960000;
         uint32 expectedCliffDate = uint32(block.timestamp) + cliffPeriod;
-        uint32 claimValidityDate = expectedCliffDate + 1 days;
+        uint32 claimPeriod = expectedCliffDate + 1 days;
         uint32 expectedEndDate = uint32(block.timestamp) + vestingDuration;
 
         vm.expectEmit();
-        emit VestingScheduleCreated(superToken, alice, bob, uint32(block.timestamp), expectedCliffDate, expectedFlowRate, expectedEndDate, expectedCliffAmount, claimValidityDate, 0);
+        emit VestingScheduleCreated(superToken, alice, bob, uint32(block.timestamp), expectedCliffDate, expectedFlowRate, expectedEndDate, expectedCliffAmount, uint32(block.timestamp) + claimPeriod, 0);
 
         vm.startPrank(alice);
 
@@ -1442,7 +1451,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             totalVestedAmount,
             vestingDuration,
-            claimValidityDate,
+            claimPeriod,
             cliffPeriod
         );
 
@@ -1459,7 +1468,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             0,
             1209600,
-            CLAIM_VALIDITY_DATE,
+            15 days,
             604800,
             uint32(block.timestamp),
             EMPTY_CTX
@@ -1472,7 +1481,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             1 ether,
             1209600,
-            CLAIM_VALIDITY_DATE,
+            15 days,
             0,
             uint32(block.timestamp - 1),
             EMPTY_CTX
@@ -1485,7 +1494,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             type(uint256).max,
             1209600,
-            CLAIM_VALIDITY_DATE,
+            15 days,
             0,
             uint32(block.timestamp),
             EMPTY_CTX
@@ -1498,7 +1507,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             1 ether,
             type(uint32).max,
-            CLAIM_VALIDITY_DATE,
+            15 days,
             0,
             uint32(block.timestamp),
             EMPTY_CTX
@@ -1511,7 +1520,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             1 ether,
             1209600,
-            CLAIM_VALIDITY_DATE,
+            15 days,
             604800,
             uint32(block.timestamp - 1),
             EMPTY_CTX

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -1654,6 +1654,9 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vm.warp(claimDate);
 
         vm.expectEmit(true, true, true, true);
+        emit Transfer(alice, bob, totalExpectedAmount);
+
+        vm.expectEmit(true, true, true, true);
         emit VestingCliffAndFlowExecuted(
             superToken, alice, bob, CLIFF_DATE, 0, CLIFF_TRANSFER_AMOUNT, 0
         );
@@ -1663,11 +1666,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             superToken, alice, bob, END_DATE, totalExpectedAmount, false
         );
 
-        vm.expectEmit(true, true, true, true);
-        emit Transfer(alice, bob, totalExpectedAmount);
-
         vm.prank(bob);
-        vestingScheduler.executeCliffAndFlow(superToken, alice, bob);
+        assertTrue(vestingScheduler.executeCliffAndFlow(superToken, alice, bob));
 
         assertEq(superToken.balanceOf(alice), aliceInitialBalance - totalExpectedAmount);
         assertEq(superToken.balanceOf(bob), bobInitialBalance + totalExpectedAmount);

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -465,6 +465,10 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         uint256 aliceShouldStream = (END_DATE-CLIFF_DATE) * uint96(FLOW_RATE) + CLIFF_TRANSFER_AMOUNT ;
         assertEq(aliceInitialBalance - aliceFinalBalance, aliceShouldStream, "(sender) wrong final balance");
         assertEq(bobFinalBalance, bobInitialBalance + aliceShouldStream, "(receiver) wrong final balance");
+
+        vm.expectRevert(IVestingSchedulerV2.AlreadyExecuted.selector);
+        success = vestingScheduler.executeEndVesting(superToken, alice, bob);
+
     }
 
     function testExecuteCliffAndFlowWithoutCliffAmountOrAdjustment() public {


### PR DESCRIPTION
This PR intend to propose improvement to the latest version of VestingSchedulerV2.
The changes includes :

- Possibility to have the `claimValidityDate` after the `endDate` of a vesting schedule
- Refactored `executeCliffAndFlow` to decouple the claim logic with the flow creation logic