### PR TITLE
[automations] VestingSchedulerV2 add helpful view functions

### DIFF
--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -704,6 +704,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         return flowRate != 0;
     }
 
+
+    /// @dev IVestingScheduler.getCreateVestingScheduleParamsFromAmountAndDuration implementation.
     function getCreateVestingScheduleParamsFromAmountAndDuration(
         ISuperToken superToken,
         address receiver,
@@ -762,6 +764,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         }
     }
 
+    /// @dev IVestingScheduler.getMaximumNeededTokenAllowance implementation.
     function getMaximumNeededTokenAllowance(
         address superToken,
         address sender,
@@ -775,6 +778,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         return getMaximumNeededTokenAllowance(vestingSchedule);
     }
 
+    /// @dev IVestingScheduler.getMaximumNeededTokenAllowance implementation.
     function getMaximumNeededTokenAllowance(
         VestingSchedule memory schedule
     ) public pure override returns (uint256) {
@@ -794,6 +798,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
               + maxFlowDelayCompensationAmount 
               + maxEarlyEndCompensationAmount;
         } else if (schedule.claimValidityDate > schedule.endDate) {
+            // TODO: Test this once claiming after end date is merged.   
             uint256 totalVestedAmount = 
                 schedule.cliffAmount
                 + schedule.remainderAmount

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -19,27 +19,6 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
     uint32 public constant START_DATE_VALID_AFTER = 3 days;
     uint32 public constant END_DATE_VALID_BEFORE = 1 days;
 
-    /**
-     * @dev Parameters used to create claimable vesting schedules
-     * @param superToken SuperToken to be vested
-     * @param receiver Vesting receiver
-     * @param totalAmount The total amount to be vested
-     * @param totalDuration The total duration of the vestingß
-     * @param cliffPeriod The cliff period of the vesting
-     * @param startDate Timestamp when the vesting should start
-     * @param claimPeriod The claim availability period
-     * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
-     */
-    struct ScheduleCreationFromAmountAndDurationParams {
-        ISuperToken superToken;
-        address receiver;
-        uint256 totalAmount;
-        uint32 totalDuration;
-        uint32 cliffPeriod;
-        uint32 startDate;
-        uint32 claimPeriod;
-    }
-
     constructor(ISuperfluid host) {
         cfaV1 = CFAv1Library.InitData(
             host,
@@ -202,8 +181,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 startDate,
         bytes memory ctx
     ) external returns (bytes memory newCtx) {
-        newCtx = _createVestingScheduleFromAmountAndDuration(
-            ScheduleCreationFromAmountAndDurationParams(
+        newCtx = _createVestingSchedule(
+            getCreateVestingScheduleParamsFromAmountAndDuration(
                 superToken,
                 receiver,
                 totalAmount,
@@ -225,8 +204,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 cliffPeriod,
         uint32 startDate
     ) external {
-        _createVestingScheduleFromAmountAndDuration(
-            ScheduleCreationFromAmountAndDurationParams(
+        _createVestingSchedule(
+            getCreateVestingScheduleParamsFromAmountAndDuration(
                 superToken,
                 receiver,
                 totalAmount,
@@ -247,8 +226,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 totalDuration,
         uint32 cliffPeriod
     ) external {
-        _createVestingScheduleFromAmountAndDuration(
-            ScheduleCreationFromAmountAndDurationParams(
+        _createVestingSchedule(
+            getCreateVestingScheduleParamsFromAmountAndDuration(
                 superToken,
                 receiver,
                 totalAmount,
@@ -268,8 +247,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint256 totalAmount,
         uint32 totalDuration
     ) external {
-        _createVestingScheduleFromAmountAndDuration(
-            ScheduleCreationFromAmountAndDurationParams(
+        _createVestingSchedule(
+            getCreateVestingScheduleParamsFromAmountAndDuration(
                 superToken,
                 receiver,
                 totalAmount,
@@ -279,24 +258,6 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 0 // claimPeriod
             ),
             bytes("")
-        );
-    }
-
-    function _createVestingScheduleFromAmountAndDuration(
-        ScheduleCreationFromAmountAndDurationParams memory params,
-        bytes memory ctx
-    ) private returns (bytes memory newCtx) {
-        newCtx = _createVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
-                params.superToken,
-                params.receiver,
-                params.totalAmount,
-                params.totalDuration,
-                params.cliffPeriod,
-                params.startDate,
-                params.claimPeriod
-            ),
-            ctx
         );
     }
 
@@ -341,8 +302,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 totalDuration,
         bytes memory ctx
     ) private returns (bytes memory newCtx) {
-        newCtx = _createVestingScheduleFromAmountAndDuration(
-            ScheduleCreationFromAmountAndDurationParams(
+        newCtx = _createVestingSchedule(
+            getCreateVestingScheduleParamsFromAmountAndDuration(
                 superToken,
                 receiver,
                 totalAmount,
@@ -351,7 +312,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 0, // startDate
                 0 // claimValidityDate
             ),
-            ctx
+            bytes("")
         );
 
         address sender = _getSender(ctx);
@@ -424,8 +385,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 startDate,
         bytes memory ctx
     ) external returns (bytes memory newCtx) {
-        newCtx = _createVestingScheduleFromAmountAndDuration(
-            ScheduleCreationFromAmountAndDurationParams(
+        newCtx = _createVestingSchedule(
+            getCreateVestingScheduleParamsFromAmountAndDuration(
                 superToken,
                 receiver,
                 totalAmount,
@@ -448,8 +409,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 cliffPeriod,
         uint32 startDate
     ) external {
-        _createVestingScheduleFromAmountAndDuration(
-            ScheduleCreationFromAmountAndDurationParams(
+        _createVestingSchedule(
+            getCreateVestingScheduleParamsFromAmountAndDuration(
                 superToken,
                 receiver,
                 totalAmount,
@@ -471,16 +432,14 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 claimPeriod,
         uint32 cliffPeriod
     ) external {
-        uint32 startDate = uint32(block.timestamp);
-
-        _createVestingScheduleFromAmountAndDuration(
-            ScheduleCreationFromAmountAndDurationParams(
+        _createVestingSchedule(
+            getCreateVestingScheduleParamsFromAmountAndDuration(
                 superToken,
                 receiver,
                 totalAmount,
                 totalDuration,
                 cliffPeriod,
-                startDate,
+                0, // startDate
                 claimPeriod
             ),
             bytes("")
@@ -495,8 +454,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 totalDuration,
         uint32 claimPeriod
     ) external {
-        _createVestingScheduleFromAmountAndDuration(
-            ScheduleCreationFromAmountAndDurationParams(
+        _createVestingSchedule(
+            getCreateVestingScheduleParamsFromAmountAndDuration(
                 superToken,
                 receiver,
                 totalAmount,

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -25,9 +25,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
             IConstantFlowAgreementV1(
                 address(
                     host.getAgreementClass(
-                        keccak256(
-                            "org.superfluid-finance.agreements.ConstantFlowAgreement.v1"
-                        )
+                        keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1")
                     )
                 )
             )
@@ -121,8 +119,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
 
         uint32 cliffAndFlowDate = params.cliffDate == 0 ? params.startDate : params.cliffDate;
         // Note: Vesting Scheduler V2 allows cliff and flow to be in the schedule creation block, V1 didn't.
-        if (
-            cliffAndFlowDate < block.timestamp ||
+        if (cliffAndFlowDate < block.timestamp ||
             cliffAndFlowDate >= params.endDate ||
             cliffAndFlowDate + START_DATE_VALID_AFTER >= params.endDate - END_DATE_VALID_BEFORE ||
             params.endDate - cliffAndFlowDate < MIN_VESTING_DURATION
@@ -130,17 +127,14 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
 
         // NOTE : claimable schedule created with a claim validity date equal to 0 is considered regular schedule
         if (params.claimValidityDate != 0) {
-            if (
-                params.claimValidityDate < cliffAndFlowDate ||
+            if (params.claimValidityDate < cliffAndFlowDate ||
                 params.claimValidityDate > params.endDate - END_DATE_VALID_BEFORE
             ) revert TimeWindowInvalid();
         }
 
-        bytes32 hashConfig = keccak256(
-            abi.encodePacked(params.superToken, sender, params.receiver)
-        );
-        if (vestingSchedules[hashConfig].endDate != 0)
-            revert ScheduleAlreadyExists();
+        bytes32 hashConfig = keccak256(abi.encodePacked(params.superToken, sender, params.receiver));
+        if (vestingSchedules[hashConfig].endDate != 0) revert ScheduleAlreadyExists();
+
         vestingSchedules[hashConfig] = VestingSchedule(
             cliffAndFlowDate,
             params.endDate,
@@ -478,8 +472,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         if (endDate <= block.timestamp) revert TimeWindowInvalid();
 
         // Only allow an update if 1. vesting exists 2. executeCliffAndFlow() has been called
-        if (schedule.cliffAndFlowDate != 0 || schedule.endDate == 0)
-            revert ScheduleNotFlowing();
+        if (schedule.cliffAndFlowDate != 0 || schedule.endDate == 0) revert ScheduleNotFlowing();
 
         vestingSchedules[configHash].endDate = endDate;
         // Note: Nullify the remainder amount when complexity of updates is introduced.

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -30,10 +30,12 @@ interface IVestingSchedulerV2 {
     struct VestingSchedule {
         uint32 cliffAndFlowDate;
         uint32 endDate;
-        uint32 claimValidityDate;
         int96 flowRate;
+
         uint256 cliffAmount;
-        uint256 remainderAmount; // TODO: consider packing
+
+        uint96 remainderAmount;
+        uint32 claimValidityDate;
     }
 
     /**
@@ -120,6 +122,24 @@ interface IVestingSchedulerV2 {
         uint32 startDate,
         bytes memory ctx
     ) external returns (bytes memory newCtx);
+
+    // function getExpectedVestingScheduleFromAmountAndDuration(
+    //     ISuperToken superToken,
+    //     address receiver,
+    //     uint256 totalAmount,
+    //     uint32 totalDuration,
+    //     uint32 cliffPeriod,
+    //     uint32 startDate,
+    //     uint32 claimPeriod
+    // ) external returns (bytes memory VestingSchedule);
+
+    // function getMaximumNeededTokenAllowance(
+    //     VestingSchedule memory vestingSchedule
+    // ) external returns (uint256);
+
+    // function getMaximumNeededTokenAllowance(
+    //     address superToken, address sender, address receiver
+    // ) external returns (uint256);
 
     /**
      * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -38,6 +38,31 @@ interface IVestingSchedulerV2 {
         uint32 claimValidityDate;
     }
 
+        /**
+     * @dev Parameters used to create vesting schedules
+     * @param superToken SuperToken to be vested
+     * @param receiver Vesting receiver
+     * @param startDate Timestamp when the vesting should start
+     * @param claimValidityDate Date before which the claimable schedule must be claimed
+     * @param cliffDate Timestamp of cliff exectution - if 0, startDate acts as cliff
+     * @param flowRate The flowRate for the stream
+     * @param cliffAmount The amount to be transferred at the cliff
+     * @param endDate The timestamp when the stream should stop.
+     * @param remainderAmount Amount transferred during early end to achieve an accurate "total vested amount"
+     * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
+     */
+    struct ScheduleCreationParams {
+        ISuperToken superToken;
+        address receiver;
+        uint32 startDate;
+        uint32 claimValidityDate;
+        uint32 cliffDate;
+        int96 flowRate;
+        uint256 cliffAmount;
+        uint32 endDate;
+        uint96 remainderAmount;
+    }
+
     /**
      * @dev Event emitted on creation of a new vesting schedule
      * @param superToken SuperToken to be vested
@@ -123,23 +148,23 @@ interface IVestingSchedulerV2 {
         bytes memory ctx
     ) external returns (bytes memory newCtx);
 
-    // function getExpectedVestingScheduleFromAmountAndDuration(
-    //     ISuperToken superToken,
-    //     address receiver,
-    //     uint256 totalAmount,
-    //     uint32 totalDuration,
-    //     uint32 cliffPeriod,
-    //     uint32 startDate,
-    //     uint32 claimPeriod
-    // ) external returns (bytes memory VestingSchedule);
+    function getCreateVestingScheduleParamsFromAmountAndDuration(
+        ISuperToken superToken,
+        address receiver,
+        uint256 totalAmount,
+        uint32 totalDuration,
+        uint32 cliffPeriod,
+        uint32 startDate,
+        uint32 claimPeriod
+    ) external returns (ScheduleCreationParams memory params);
 
-    // function getMaximumNeededTokenAllowance(
-    //     VestingSchedule memory vestingSchedule
-    // ) external returns (uint256);
+    function getMaximumNeededTokenAllowance(
+        VestingSchedule memory vestingSchedule
+    ) external returns (uint256);
 
-    // function getMaximumNeededTokenAllowance(
-    //     address superToken, address sender, address receiver
-    // ) external returns (uint256);
+    function getMaximumNeededTokenAllowance(
+        address superToken, address sender, address receiver
+    ) external returns (uint256);
 
     /**
      * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -148,6 +148,16 @@ interface IVestingSchedulerV2 {
         bytes memory ctx
     ) external returns (bytes memory newCtx);
 
+    /**
+     * @dev Returns all relevant information related to a new vesting schedule creation 
+     * @dev based on the amounts and durations.
+     * @param superToken SuperToken to be vested
+     * @param receiver Vesting receiver
+     * @param totalAmount The total amount to be vested 
+     * @param totalDuration The total duration of the vestingß
+     * @param cliffPeriod The cliff period of the vesting
+     * @param startDate Timestamp when the vesting should start
+     */
     function getCreateVestingScheduleParamsFromAmountAndDuration(
         ISuperToken superToken,
         address receiver,
@@ -158,10 +168,21 @@ interface IVestingSchedulerV2 {
         uint32 claimPeriod
     ) external returns (ScheduleCreationParams memory params);
 
+    /**
+     * @dev Estimates the maximum possible ERC-20 token allowance needed for the vesting schedule 
+     * @dev to work properly under all circumstances.
+     * @param vestingSchedule A vesting schedule (doesn't have to exist)
+     */
     function getMaximumNeededTokenAllowance(
         VestingSchedule memory vestingSchedule
     ) external returns (uint256);
 
+    /**
+     * @dev Estimates maximum ERC-20 token allowance needed for an existing vesting schedule.
+     * @param superToken SuperToken to be vested
+     * @param sender Vesting sender
+     * @param receiver Vesting receiver
+     */
     function getMaximumNeededTokenAllowance(
         address superToken, address sender, address receiver
     ) external returns (uint256);

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -1696,7 +1696,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         uint32 endDate = startDate + totalDuration;
 
-        uint256 remainderAmount = totalAmount - SafeCast.toUint256(flowRate) * totalDuration;
+        uint96 remainderAmount = SafeCast.toUint96(totalAmount - SafeCast.toUint256(flowRate) * totalDuration);
 
         expectedSchedule = IVestingSchedulerV2.VestingSchedule({
             cliffAndFlowDate: cliffAndFlowDate,

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -126,16 +126,16 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
     function _createVestingScheduleWithDefaultData(address sender, address receiver) private {
         vm.startPrank(sender);
-    vestingScheduler.createVestingSchedule(
-        superToken,
-        receiver,
-        START_DATE,
-        CLIFF_DATE,
-        FLOW_RATE,
-        CLIFF_TRANSFER_AMOUNT,
-        END_DATE,
-        EMPTY_CTX
-    );
+        vestingScheduler.createVestingSchedule(
+            superToken,
+            receiver,
+            START_DATE,
+            CLIFF_DATE,
+            FLOW_RATE,
+            CLIFF_TRANSFER_AMOUNT,
+            END_DATE,
+            EMPTY_CTX
+        );
         vm.stopPrank();
     }
 


### PR DESCRIPTION
### Added and exposed `getCreateVestingScheduleParamsFromAmountAndDuration`

The view function can be used to know up front what will be the stored `VestingSchedule` values. Useful for UI-s. It's effectively the previous `_createVestingScheduleFromAmountAndDuration` exposed as a view function without any logic changed.

### Exposed `ScheduleCreationParams`

The struct holds all relevant values to a vesting schedule in addition to just the ones being stored. Useful for UI-s. Separated "superfluid context" out of it as it's a technical requirement of the smart contract to enable batching transaction, not necessarily relevant to the core data of the vesting schedule.

### Deleted `ScheduleCreationFromAmountAndDurationParams`

Less is more.

### Added and exposed `getMaximumNeededTokenAllowance`

Added a helpful utility function to calculate what is the maximum needed ERC-20 allowance for the vesting schedule to execute successfully under all conditions. Not used by the core contract logic as allowance is meant to be handled outside, so no added risk, but useful for UI-s (that otherwise would need to calculate all of this on their own).

### Used `uint96` for `remainderAmount`

Initially I used `uint256` for simplicity sake but `uint96` is plenty enough.

### Re-ordered `VestingSchedule` packing

As there's no difference in the storage size used, I opted to order it in a more backwards compatible way to V1 vesting scheduler.

### Added more tests