### PR TITLE
[automations] VestingSchedulerV2 - added checks and logging

### DIFF
--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -464,9 +464,9 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         bytes32 configHash = keccak256(abi.encodePacked(superToken, sender, receiver));
         VestingSchedule memory schedule = vestingSchedules[configHash];
 
-        // TODO: It's possible that this changes the endDate to be less than the claimValidityDate
-
         if (endDate <= block.timestamp) revert TimeWindowInvalid();
+
+        // Note : Claimable schedules that has not been claimed cannot be updated
 
         // Only allow an update if 1. vesting exists 2. executeCliffAndFlow() has been called
         if (schedule.cliffAndFlowDate != 0 || schedule.endDate == 0) revert ScheduleNotFlowing();
@@ -610,8 +610,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         bytes32 configHash = keccak256(abi.encodePacked(superToken, sender, receiver));
         VestingSchedule memory schedule = vestingSchedules[configHash];
 
-        // TODO: check that it's claimed
-
+        if (schedule.claimValidityDate != 0) revert ScheduleNotClaimed();
         if (schedule.endDate == 0) revert AlreadyExecuted();
         if (schedule.endDate - END_DATE_VALID_BEFORE > block.timestamp)
             revert TimeWindowInvalid();

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -480,7 +480,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
             sender,
             receiver,
             schedule.endDate,
-            endDate
+            endDate,
+            vestingSchedules[configHash].remainderAmount
         );
     }
 

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -369,7 +369,8 @@ interface IVestingSchedulerV2 {
         address indexed sender,
         address indexed receiver,
         uint32 oldEndDate,
-        uint32 endDate
+        uint32 endDate,
+        uint96 remainderAmount
     );
 
     /**

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -17,6 +17,7 @@ interface IVestingSchedulerV2 {
     error ScheduleNotFlowing();
     error CannotClaimScheduleOnBehalf();
     error AlreadyExecuted();
+    error ScheduleNotClaimed();
 
     /**
      * @dev Vesting configuration provided by user.

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -1666,6 +1666,10 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             superToken, alice, bob, END_DATE, totalExpectedAmount, false
         );
 
+        IVestingSchedulerV2.VestingSchedule memory schedule = vestingScheduler.getVestingSchedule(address(superToken), alice, bob);
+        assertEq(vestingScheduler.getMaximumNeededTokenAllowance(schedule), totalExpectedAmount);
+        assertEq(vestingScheduler.getMaximumNeededTokenAllowance(address(superToken), alice, bob), totalExpectedAmount);
+
         vm.prank(bob);
         assertTrue(vestingScheduler.executeCliffAndFlow(superToken, alice, bob));
 

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -34,7 +34,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         address indexed sender,
         address indexed receiver,
         uint32 oldEndDate,
-        uint32 endDate
+        uint32 endDate,
+        uint96 remainderAmount
     );
 
     event VestingScheduleDeleted(
@@ -531,7 +532,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vm.stopPrank();
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit VestingScheduleUpdated(superToken, alice, bob, END_DATE, NEW_END_DATE);
+        emit VestingScheduleUpdated(superToken, alice, bob, END_DATE, NEW_END_DATE, 0);
         vestingScheduler.updateVestingSchedule(superToken, bob, NEW_END_DATE, EMPTY_CTX);
         uint256 finalTimestamp = block.timestamp + 10 days - 3600;
         vm.warp(finalTimestamp);


### PR DESCRIPTION
This PR intend to address comments on the [epic PR](https://github.com/superfluid-finance/protocol-monorepo/pull/1952) and improve code coverage. 

Items reviewed are : 
- checking if a claimable schedule has been claimed when executing `executeEndVesting`
- added `remainderAmount` in `VestingScheduleUpdated`
- increased test coverage for `getMaximumNeededTokenAllowance`
