### PR TITLE
[automations] Vesting Scheduler V2 refactoring after single-transfer feature

### DIFF
--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -11,6 +11,8 @@ import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
+    string public constant VERSION = "2.0.0-beta";
+
     using CFAv1Library for CFAv1Library.InitData;
     CFAv1Library.InitData public cfaV1;
     mapping(bytes32 => VestingSchedule) public vestingSchedules; // id = keccak(supertoken, sender, receiver)
@@ -583,7 +585,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         // Compensate for the fact that flow will almost always be executed slightly later than scheduled.
         uint256 flowDelayCompensation = 
             (block.timestamp - schedule.cliffAndFlowDate) * uint96(schedule.flowRate);
-
+        
         // If there's cliff or compensation then transfer that amount.
         if (schedule.cliffAmount != 0 || flowDelayCompensation != 0) {
             // Note: Super Tokens revert, not return false, i.e. we expect always true here.

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -534,7 +534,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         bytes32 configHash = keccak256(abi.encodePacked(superToken, sender, receiver));
         VestingSchedule memory schedule = vestingSchedules[configHash];
 
-        delete vestingSchedules[configHash]; // TODO: Add a good test.
+        delete vestingSchedules[configHash];
 
         uint256 totalVestedAmount = _getTotalVestedAmount(schedule);
 

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -491,7 +491,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
             receiver,
             schedule.endDate,
             endDate,
-            0
+            0 // remainderAmount
         );
     }
 

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -746,9 +746,9 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 receiver: receiver,
                 startDate: startDate,
                 claimValidityDate: claimValidityDate,
-                cliffDate: 0 /* cliffDate */,
+                cliffDate: 0,
                 flowRate: flowRate,
-                cliffAmount: 0 /* cliffAmount */,
+                cliffAmount: 0,
                 endDate: endDate,
                 remainderAmount: remainderAmount
             });

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -61,17 +61,17 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         bytes memory ctx
     ) external returns (bytes memory newCtx) {
         newCtx = _validateAndCreateVestingSchedule(
-            ScheduleCreationParams(
-                superToken,
-                receiver,
-                startDate,
-                0, // claimValidityDate
-                cliffDate,
-                flowRate,
-                cliffAmount,
-                endDate,
-                0 // remainderAmount
-            ),
+            ScheduleCreationParams({
+                superToken: superToken,
+                receiver: receiver,
+                startDate: startDate,
+                claimValidityDate: 0,
+                cliffDate: cliffDate,
+                flowRate: flowRate,
+                cliffAmount: cliffAmount,
+                endDate: endDate,
+                remainderAmount: 0
+            }),
             ctx
         );
     }
@@ -87,17 +87,17 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 endDate
     ) external {
         _validateAndCreateVestingSchedule(
-            ScheduleCreationParams(
-                superToken,
-                receiver,
-                startDate,
-                0, // claimValidityDate
-                cliffDate,
-                flowRate,
-                cliffAmount,
-                endDate,
-                0 // remainderAmount
-            ),
+            ScheduleCreationParams({
+                superToken: superToken,
+                receiver: receiver,
+                startDate: startDate,
+                claimValidityDate: 0,
+                cliffDate: cliffDate,
+                flowRate: flowRate,
+                cliffAmount: cliffAmount,
+                endDate: endDate,
+                remainderAmount: 0
+            }),
             bytes("")
         );
     }
@@ -140,14 +140,14 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         bytes32 id = keccak256(abi.encodePacked(params.superToken, sender, params.receiver));
         if (vestingSchedules[id].endDate != 0) revert ScheduleAlreadyExists();
 
-        vestingSchedules[id] = VestingSchedule(
-            cliffAndFlowDate,
-            params.endDate,
-            params.flowRate,
-            params.cliffAmount,
-            params.remainderAmount,
-            params.claimValidityDate
-        );
+        vestingSchedules[id] = VestingSchedule({
+            cliffAndFlowDate: cliffAndFlowDate,
+            endDate: params.endDate,
+            flowRate: params.flowRate,
+            cliffAmount: params.cliffAmount,
+            remainderAmount: params.remainderAmount,
+            claimValidityDate: params.claimValidityDate
+        });
 
         emit VestingScheduleCreated(
             params.superToken,
@@ -327,17 +327,17 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         bytes memory ctx
     ) external returns (bytes memory newCtx) {
         newCtx = _validateAndCreateVestingSchedule(
-            ScheduleCreationParams(
-                superToken,
-                receiver,
-                startDate,
-                claimValidityDate,
-                cliffDate,
-                flowRate,
-                cliffAmount,
-                endDate,
-                0 /* remainderAmount */
-            ),
+            ScheduleCreationParams({
+                superToken: superToken,
+                receiver: receiver,
+                startDate: startDate,
+                claimValidityDate: claimValidityDate,
+                cliffDate: cliffDate,
+                flowRate: flowRate,
+                cliffAmount: cliffAmount,
+                endDate: endDate,
+                remainderAmount: 0
+            }),
             ctx
         );
     }
@@ -354,17 +354,17 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 endDate
     ) external {
         _validateAndCreateVestingSchedule(
-            ScheduleCreationParams(
-                superToken,
-                receiver,
-                startDate,
-                claimValidityDate,
-                cliffDate,
-                flowRate,
-                cliffAmount,
-                endDate,
-                0 /* remainderAmount */
-            ),
+            ScheduleCreationParams({
+                superToken: superToken,
+                receiver: receiver,
+                startDate: startDate,
+                claimValidityDate: claimValidityDate,
+                cliffDate: cliffDate,
+                flowRate: flowRate,
+                cliffAmount: cliffAmount,
+                endDate: endDate,
+                remainderAmount: 0
+            }),
             bytes("")
         );
     }
@@ -741,34 +741,34 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         );
 
         if (cliffPeriod == 0) {
-            result = ScheduleCreationParams(
-                superToken,
-                receiver,
-                startDate,
-                claimValidityDate,
-                0 /* cliffDate */,
-                flowRate,
-                0 /* cliffAmount */,
-                endDate,
-                remainderAmount
-            );
+            result = ScheduleCreationParams({
+                superToken: superToken,
+                receiver: receiver,
+                startDate: startDate,
+                claimValidityDate: claimValidityDate,
+                cliffDate: 0 /* cliffDate */,
+                flowRate: flowRate,
+                cliffAmount: 0 /* cliffAmount */,
+                endDate: endDate,
+                remainderAmount: remainderAmount
+            });
         } else {
             uint32 cliffDate = startDate + cliffPeriod;
             uint256 cliffAmount = SafeMath.mul(
                 cliffPeriod,
                 SafeCast.toUint256(flowRate)
             );
-            result = ScheduleCreationParams(
-                superToken,
-                receiver,
-                startDate,
-                claimValidityDate,
-                cliffDate,
-                flowRate,
-                cliffAmount,
-                endDate,
-                remainderAmount
-            );
+            result = ScheduleCreationParams({
+                superToken: superToken,
+                receiver: receiver,
+                startDate: startDate,
+                claimValidityDate: claimValidityDate,
+                cliffDate: cliffDate,
+                flowRate: flowRate,
+                cliffAmount: cliffAmount,
+                endDate: endDate,
+                remainderAmount: remainderAmount
+            });
         }
     }
 

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -87,7 +87,7 @@ interface IVestingSchedulerV2 {
         uint32 endDate,
         uint256 cliffAmount,
         uint32 claimValidityDate,
-        uint256 remainderAmount
+        uint96 remainderAmount
     );
 
     /**

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -985,7 +985,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             startDate = SafeCast.toUint32(bound(startDate, block.timestamp, 2524600800));
         }
 
-        totalDuration = SafeCast.toUint32(bound(totalDuration, vestingScheduler.MIN_VESTING_DURATION(), 18250 days));
+        totalDuration = SafeCast.toUint32(bound(totalDuration, vestingScheduler.MIN_VESTING_DURATION(), 9125 days));
         vm.assume(cliffPeriod <= totalDuration - vestingScheduler.MIN_VESTING_DURATION());
 
         BigTestData memory $;
@@ -1106,6 +1106,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         assertEq(actualSchedule.remainderAmount, expectedSchedule.remainderAmount, "schedule created: remainderAmount not expected");
 
         // Act
+        console.log("Executing cliff and flow.");
         vm.warp(expectedSchedule.cliffAndFlowDate + (vestingScheduler.START_DATE_VALID_AFTER() - (vestingScheduler.START_DATE_VALID_AFTER() / randomizer)));
         assertTrue(vestingScheduler.executeCliffAndFlow(superToken, alice, bob));
 
@@ -1123,6 +1124,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             // # Test end execution on time.
 
             // Act
+            console.log("Executing end vesting early.");
             vm.warp(expectedSchedule.endDate - (vestingScheduler.END_DATE_VALID_BEFORE() - (vestingScheduler.END_DATE_VALID_BEFORE() / randomizer)));
             assertTrue(vestingScheduler.executeEndVesting(superToken, alice, bob));
 
@@ -1136,7 +1138,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             // # Test end execution delayed.
 
             // Act
-            vm.warp(expectedSchedule.endDate + (totalDuration / randomizer * 3));
+            console.log("Executing end vesting late.");
+            vm.warp(expectedSchedule.endDate + (totalDuration / randomizer)); // There is some chance of overflow here.
             assertTrue(vestingScheduler.executeEndVesting(superToken, alice, bob));
 
             // Assert

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -203,7 +203,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         assertEq(schedule.claimValidityDate, deletedSchedule.claimValidityDate, "claimValidityDate mismatch");
     }
 
-        function _getExpectedSchedule(
+    function _getExpectedSchedule(
         uint32 startDate,
         uint32 cliffDate,
         int96 flowRate,


### PR DESCRIPTION
### Why?
The single-transfer feature for claiming after the end date created code duplication and made it hard to follow from bird's eye view what was happening, making bugs easy to miss and contract harder to audit.

### What?
Refactored to additional private functions to alleviate code duplication and to make it clearer at a glance what's happening.

### Notes
- explicit "_validate" private functions; if a private functions doesn't have "_validate" prefix then it expects validation to happen outside of it
- explicit `_getTotalVestedAmount`, `_maxDateToExecuteStartInclusive`, `_minDateToExecuteEndInclusive` private functions to reduce duplication and increase readabiliy
- `_getVestingScheduleAggregate` function and struct to move (vesting schedule, vesting schedule id, super token, sender, receiver) together in the private functions, and to reduce duplication
- improved test coverage a bit

Test version with smaller timeframes deployed here: https://sepolia-optimism.etherscan.io/address/0xF0789B3B229b00D81473935f84960E4435e430b4#code