### PR TITLE
[automations] Vesting Scheduler V2 final clean-up

### DIFF
--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -175,6 +175,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 totalDuration,
         uint32 startDate,
         uint32 cliffPeriod,
+        uint32 claimPeriod,
         bytes memory ctx
     ) external returns (bytes memory newCtx) {
         newCtx = _validateAndCreateVestingSchedule(
@@ -183,9 +184,9 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 receiver,
                 totalAmount,
                 totalDuration,
-                cliffPeriod,
                 startDate,
-                0 // claimPeriod
+                cliffPeriod,
+                claimPeriod
             ),
             ctx
         );
@@ -198,7 +199,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint256 totalAmount,
         uint32 totalDuration,
         uint32 startDate,
-        uint32 cliffPeriod
+        uint32 cliffPeriod,
+        uint32 claimPeriod
     ) external {
         _validateAndCreateVestingSchedule(
             getCreateVestingScheduleParamsFromAmountAndDuration(
@@ -206,9 +208,9 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 receiver,
                 totalAmount,
                 totalDuration,
-                cliffPeriod,
                 startDate,
-                0 // claimPeriod
+                cliffPeriod,
+                claimPeriod
             ),
             bytes("")
         );
@@ -220,7 +222,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 cliffPeriod
+        uint32 cliffPeriod,
+        uint32 claimPeriod
     ) external {
         _validateAndCreateVestingSchedule(
             getCreateVestingScheduleParamsFromAmountAndDuration(
@@ -228,9 +231,9 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 receiver,
                 totalAmount,
                 totalDuration,
-                cliffPeriod,
                 0, // startDate
-                0 // claimPeriod
+                cliffPeriod,
+                claimPeriod
             ),
             bytes("")
         );
@@ -241,7 +244,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         ISuperToken superToken,
         address receiver,
         uint256 totalAmount,
-        uint32 totalDuration
+        uint32 totalDuration,
+        uint32 claimPeriod
     ) external {
         _validateAndCreateVestingSchedule(
             getCreateVestingScheduleParamsFromAmountAndDuration(
@@ -249,9 +253,9 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 receiver,
                 totalAmount,
                 totalDuration,
-                0, // cliffPeriod
                 0, // startDate
-                0 // claimPeriod
+                0, // cliffPeriod
+                claimPeriod
             ),
             bytes("")
         );
@@ -304,8 +308,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 receiver,
                 totalAmount,
                 totalDuration,
-                0, // cliffPeriod
                 0, // startDate
+                0, // cliffPeriod
                 0 // claimValidityDate
             ),
             ctx
@@ -318,100 +322,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         assert(_executeCliffAndFlow(agg));
     }
 
-    /// @dev IVestingScheduler.createClaimableVestingScheduleFromAmountAndDuration implementation.
-    function createClaimableVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod,
-        uint32 cliffPeriod,
-        uint32 startDate,
-        bytes memory ctx
-    ) external returns (bytes memory newCtx) {
-        newCtx = _validateAndCreateVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
-                superToken,
-                receiver,
-                totalAmount,
-                totalDuration,
-                cliffPeriod,
-                startDate,
-                claimPeriod
-            ),
-            ctx
-        );
-    }
-
-    /// @dev IVestingScheduler.createClaimableVestingScheduleFromAmountAndDuration implementation.
-    function createClaimableVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod,
-        uint32 cliffPeriod,
-        uint32 startDate
-    ) external {
-        _validateAndCreateVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
-                superToken,
-                receiver,
-                totalAmount,
-                totalDuration,
-                cliffPeriod,
-                startDate,
-                claimPeriod
-            ),
-            bytes("")
-        );
-    }
-
-    /// @dev IVestingScheduler.createVestingScheduleFromAmountAndDuration implementation.
-    function createClaimableVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod,
-        uint32 cliffPeriod
-    ) external {
-        _validateAndCreateVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
-                superToken,
-                receiver,
-                totalAmount,
-                totalDuration,
-                cliffPeriod,
-                0, // startDate
-                claimPeriod
-            ),
-            bytes("")
-        );
-    }
-
-    /// @dev IVestingScheduler.createVestingScheduleFromAmountAndDuration implementation.
-    function createClaimableVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod
-    ) external {
-        _validateAndCreateVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
-                superToken,
-                receiver,
-                totalAmount,
-                totalDuration,
-                0, // cliffPeriod
-                0, // startDate
-                claimPeriod
-            ),
-            bytes("")
-        );
-    }
-
+    /// @dev IVestingScheduler.updateVestingSchedule implementation.
     function updateVestingSchedule(
         ISuperToken superToken,
         address receiver,
@@ -668,8 +579,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 cliffPeriod,
         uint32 startDate,
+        uint32 cliffPeriod,
         uint32 claimPeriod
     ) public view override returns (ScheduleCreationParams memory result) {
         // Default to current block timestamp if no start date is provided.

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -444,9 +444,9 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
             agg.sender,
             agg.receiver,
             schedule.cliffAndFlowDate,
-            0,
+            0, // flow rate
             schedule.cliffAmount,
-            0
+            0 // flow delay compensation
         );
 
         emit VestingEndExecuted(
@@ -454,7 +454,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
             agg.sender,
             agg.receiver,
             schedule.endDate,
-            totalVestedAmount,
+            0, // Early end compensation
             false
         );
 

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -11,8 +11,6 @@ import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
-    string public constant VERSION = "2.0.0-beta.0";
-
     using CFAv1Library for CFAv1Library.InitData;
     CFAv1Library.InitData public cfaV1;
     mapping(bytes32 => VestingSchedule) public vestingSchedules; // id = keccak(supertoken, sender, receiver)

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -60,6 +60,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         int96 flowRate,
         uint256 cliffAmount,
         uint32 endDate,
+        uint32 claimValidityDate,
         bytes memory ctx
     ) external returns (bytes memory newCtx) {
         newCtx = _validateAndCreateVestingSchedule(
@@ -67,7 +68,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 superToken: superToken,
                 receiver: receiver,
                 startDate: startDate,
-                claimValidityDate: 0,
+                claimValidityDate: claimValidityDate,
                 cliffDate: cliffDate,
                 flowRate: flowRate,
                 cliffAmount: cliffAmount,
@@ -86,14 +87,15 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         uint32 cliffDate,
         int96 flowRate,
         uint256 cliffAmount,
-        uint32 endDate
+        uint32 endDate,
+        uint32 claimValidityDate
     ) external {
         _validateAndCreateVestingSchedule(
             ScheduleCreationParams({
                 superToken: superToken,
                 receiver: receiver,
                 startDate: startDate,
-                claimValidityDate: 0,
+                claimValidityDate: claimValidityDate,
                 cliffDate: cliffDate,
                 flowRate: flowRate,
                 cliffAmount: cliffAmount,
@@ -314,61 +316,6 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
 
         _validateBeforeCliffAndFlow(agg.schedule, /* disableClaimCheck: */ false);
         assert(_executeCliffAndFlow(agg));
-    }
-
-    /// @dev IVestingScheduler.createClaimableVestingSchedule implementation.
-    function createClaimableVestingSchedule(
-        ISuperToken superToken,
-        address receiver,
-        uint32 startDate,
-        uint32 claimValidityDate,
-        uint32 cliffDate,
-        int96 flowRate,
-        uint256 cliffAmount,
-        uint32 endDate,
-        bytes memory ctx
-    ) external returns (bytes memory newCtx) {
-        newCtx = _validateAndCreateVestingSchedule(
-            ScheduleCreationParams({
-                superToken: superToken,
-                receiver: receiver,
-                startDate: startDate,
-                claimValidityDate: claimValidityDate,
-                cliffDate: cliffDate,
-                flowRate: flowRate,
-                cliffAmount: cliffAmount,
-                endDate: endDate,
-                remainderAmount: 0
-            }),
-            ctx
-        );
-    }
-
-    /// @dev IVestingScheduler.createClaimableVestingSchedule implementation.
-    function createClaimableVestingSchedule(
-        ISuperToken superToken,
-        address receiver,
-        uint32 startDate,
-        uint32 claimValidityDate,
-        uint32 cliffDate,
-        int96 flowRate,
-        uint256 cliffAmount,
-        uint32 endDate
-    ) external {
-        _validateAndCreateVestingSchedule(
-            ScheduleCreationParams({
-                superToken: superToken,
-                receiver: receiver,
-                startDate: startDate,
-                claimValidityDate: claimValidityDate,
-                cliffDate: cliffDate,
-                flowRate: flowRate,
-                cliffAmount: cliffAmount,
-                endDate: endDate,
-                remainderAmount: 0
-            }),
-            bytes("")
-        );
     }
 
     /// @dev IVestingScheduler.createClaimableVestingScheduleFromAmountAndDuration implementation.

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -222,6 +222,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
+        uint32 cliffPeriod,
         bytes memory ctx
     ) external returns (bytes memory newCtx) {
         newCtx = _validateAndCreateAndExecuteVestingScheduleFromAmountAndDuration(
@@ -229,6 +230,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
             receiver,
             totalAmount,
             totalDuration,
+            cliffPeriod,
             ctx
         );
     }
@@ -238,13 +240,15 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         ISuperToken superToken,
         address receiver,
         uint256 totalAmount,
-        uint32 totalDuration
+        uint32 totalDuration,
+        uint32 cliffPeriod
     ) external {
         _validateAndCreateAndExecuteVestingScheduleFromAmountAndDuration(
             superToken,
             receiver,
             totalAmount,
             totalDuration,
+            cliffPeriod,
             bytes("")
         );
     }
@@ -255,6 +259,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
+        uint32 cliffPeriod,
         bytes memory ctx
     ) private returns (bytes memory newCtx) {
         newCtx = _validateAndCreateVestingSchedule(
@@ -264,7 +269,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
                 totalAmount,
                 totalDuration,
                 0, // startDate
-                0, // cliffPeriod
+                cliffPeriod,
                 0 // claimValidityDate
             ),
             ctx

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -446,7 +446,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
             schedule.cliffAndFlowDate,
             0, // flow rate
             schedule.cliffAmount,
-            0 // flow delay compensation
+            totalVestedAmount - schedule.cliffAmount // flow delay compensation
         );
 
         emit VestingEndExecuted(
@@ -455,7 +455,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
             agg.receiver,
             schedule.endDate,
             0, // Early end compensation
-            false
+            false // Did end fail
         );
 
         return true;

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -173,8 +173,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 cliffPeriod,
         uint32 startDate,
+        uint32 cliffPeriod,
         bytes memory ctx
     ) external returns (bytes memory newCtx) {
         newCtx = _validateAndCreateVestingSchedule(
@@ -197,8 +197,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 cliffPeriod,
-        uint32 startDate
+        uint32 startDate,
+        uint32 cliffPeriod
     ) external {
         _validateAndCreateVestingSchedule(
             getCreateVestingScheduleParamsFromAmountAndDuration(

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -176,7 +176,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address sender = _getSender(ctx);
         
         _validateAndCreateVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
+            mapCreateVestingScheduleParams(
                 superToken,
                 sender,
                 receiver,
@@ -202,7 +202,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address sender = _getSender(bytes(""));
 
         _validateAndCreateVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
+            mapCreateVestingScheduleParams(
                 superToken,
                 sender,
                 receiver,
@@ -265,7 +265,7 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         address sender = _getSender(ctx);
 
         _validateAndCreateVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
+            mapCreateVestingScheduleParams(
                 superToken,
                 sender,
                 receiver,
@@ -559,8 +559,8 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         return startDate;
     }
 
-    /// @dev IVestingScheduler.getCreateVestingScheduleParamsFromAmountAndDuration implementation.
-    function getCreateVestingScheduleParamsFromAmountAndDuration(
+    /// @dev IVestingScheduler.mapCreateVestingScheduleParams implementation.
+    function mapCreateVestingScheduleParams(
         ISuperToken superToken,
         address sender,
         address receiver,

--- a/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/VestingSchedulerV2.sol
@@ -216,51 +216,6 @@ contract VestingSchedulerV2 is IVestingSchedulerV2, SuperAppBase {
         );
     }
 
-    /// @dev IVestingScheduler.createVestingScheduleFromAmountAndDuration implementation.
-    function createVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 cliffPeriod,
-        uint32 claimPeriod
-    ) external {
-        _validateAndCreateVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
-                superToken,
-                receiver,
-                totalAmount,
-                totalDuration,
-                0, // startDate
-                cliffPeriod,
-                claimPeriod
-            ),
-            bytes("")
-        );
-    }
-
-    /// @dev IVestingScheduler.createVestingScheduleFromAmountAndDuration implementation.
-    function createVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod
-    ) external {
-        _validateAndCreateVestingSchedule(
-            getCreateVestingScheduleParamsFromAmountAndDuration(
-                superToken,
-                receiver,
-                totalAmount,
-                totalDuration,
-                0, // startDate
-                0, // cliffPeriod
-                claimPeriod
-            ),
-            bytes("")
-        );
-    }
-
     /// @dev IVestingScheduler.createAndExecuteVestingScheduleFromAmountAndDuration.
     function createAndExecuteVestingScheduleFromAmountAndDuration(
         ISuperToken superToken,

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -54,6 +54,7 @@ interface IVestingSchedulerV2 {
      */
     struct ScheduleCreationParams {
         ISuperToken superToken;
+        address sender;
         address receiver;
         uint32 startDate;
         uint32 claimValidityDate;
@@ -180,6 +181,7 @@ interface IVestingSchedulerV2 {
      */
     function getCreateVestingScheduleParamsFromAmountAndDuration(
         ISuperToken superToken,
+        address sender,
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -140,6 +140,7 @@ interface IVestingSchedulerV2 {
      * @param totalDuration The total duration of the vestingß
      * @param startDate Timestamp when the vesting should start
      * @param cliffPeriod The cliff period of the vesting
+     * @param claimPeriod The claim availability period
      * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
      */
     function createVestingScheduleFromAmountAndDuration(
@@ -149,6 +150,7 @@ interface IVestingSchedulerV2 {
         uint32 totalDuration,
         uint32 startDate,
         uint32 cliffPeriod,
+        uint32 claimPeriod,
         bytes memory ctx
     ) external returns (bytes memory newCtx);
 
@@ -161,7 +163,8 @@ interface IVestingSchedulerV2 {
         uint256 totalAmount,
         uint32 totalDuration,
         uint32 startDate,
-        uint32 cliffPeriod
+        uint32 cliffPeriod,
+        uint32 claimPeriod
     ) external;
 
     /**
@@ -173,7 +176,8 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 cliffPeriod
+        uint32 cliffPeriod,
+        uint32 claimPeriod
     ) external;
 
     /**
@@ -185,7 +189,8 @@ interface IVestingSchedulerV2 {
         ISuperToken superToken,
         address receiver,
         uint256 totalAmount,
-        uint32 totalDuration
+        uint32 totalDuration,
+        uint32 claimPeriod
     ) external;
 
     /**
@@ -195,8 +200,8 @@ interface IVestingSchedulerV2 {
      * @param receiver Vesting receiver
      * @param totalAmount The total amount to be vested 
      * @param totalDuration The total duration of the vestingß
-     * @param cliffPeriod The cliff period of the vesting
      * @param startDate Timestamp when the vesting should start
+     * @param cliffPeriod The cliff period of the vesting
      * @param claimPeriod The claim availability period
      */
     function getCreateVestingScheduleParamsFromAmountAndDuration(
@@ -204,8 +209,8 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 cliffPeriod,
         uint32 startDate,
+        uint32 cliffPeriod,
         uint32 claimPeriod
     ) external returns (ScheduleCreationParams memory params);
 
@@ -255,69 +260,6 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration
-    ) external;
-
-    /**
-     * @dev Creates a new vesting schedule that needs to be claimed by the receiver to start flowing.
-     * @dev The function makes it more intuitive to create a vesting schedule compared to the original function.
-     * @dev The function calculates the endDate, cliffDate, cliffAmount, flowRate, etc, based on the input arguments.
-     * @param superToken SuperToken to be vested
-     * @param receiver Vesting receiver
-     * @param totalAmount The total amount to be vested
-     * @param totalDuration The total duration of the vesting
-     * @param claimPeriod The claim availability period
-     * @param cliffPeriod The cliff period of the vesting
-     * @param startDate Timestamp when the vesting should start
-     * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
-     */
-    function createClaimableVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod,
-        uint32 cliffPeriod,
-        uint32 startDate,
-        bytes memory ctx
-    ) external returns (bytes memory newCtx);
-
-    /**
-     * @dev See IVestingScheduler.createClaimableVestingScheduleFromAmountAndDuration overload for more details.
-     */
-    function createClaimableVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod,
-        uint32 cliffPeriod,
-        uint32 startDate
-    ) external;
-
-    /**
-     * @dev See IVestingScheduler.createClaimableVestingScheduleFromAmountAndDuration overload for more details.
-     * The startDate is set to current block timestamp.
-     */
-    function createClaimableVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod,
-        uint32 cliffPeriod
-    ) external;
-
-    /**
-     * @dev See IVestingScheduler.createClaimableVestingScheduleFromAmountAndDuration overload for more details.
-     * The startDate is set to current block timestamp.
-     * Cliff period is not applied.
-     */
-    function createClaimableVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod
     ) external;
 
     /**

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -138,8 +138,8 @@ interface IVestingSchedulerV2 {
      * @param receiver Vesting receiver
      * @param totalAmount The total amount to be vested 
      * @param totalDuration The total duration of the vestingß
-     * @param cliffPeriod The cliff period of the vesting
      * @param startDate Timestamp when the vesting should start
+     * @param cliffPeriod The cliff period of the vesting
      * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
      */
     function createVestingScheduleFromAmountAndDuration(
@@ -147,10 +147,46 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
-        uint32 cliffPeriod,
         uint32 startDate,
+        uint32 cliffPeriod,
         bytes memory ctx
     ) external returns (bytes memory newCtx);
+
+    /**
+     * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.
+     */
+    function createVestingScheduleFromAmountAndDuration(
+        ISuperToken superToken,
+        address receiver,
+        uint256 totalAmount,
+        uint32 totalDuration,
+        uint32 startDate,
+        uint32 cliffPeriod
+    ) external;
+
+    /**
+     * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.
+     * The startDate is set to current block timestamp.
+     */
+    function createVestingScheduleFromAmountAndDuration(
+        ISuperToken superToken,
+        address receiver,
+        uint256 totalAmount,
+        uint32 totalDuration,
+        uint32 cliffPeriod
+    ) external;
+
+    /**
+     * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.
+     * The startDate is set to current block timestamp.
+     * Cliff period is not applied.
+     */
+    function createVestingScheduleFromAmountAndDuration(
+        ISuperToken superToken,
+        address receiver,
+        uint256 totalAmount,
+        uint32 totalDuration
+    ) external;
 
     /**
      * @dev Returns all relevant information related to a new vesting schedule creation 
@@ -161,6 +197,7 @@ interface IVestingSchedulerV2 {
      * @param totalDuration The total duration of the vestingß
      * @param cliffPeriod The cliff period of the vesting
      * @param startDate Timestamp when the vesting should start
+     * @param claimPeriod The claim availability period
      */
     function getCreateVestingScheduleParamsFromAmountAndDuration(
         ISuperToken superToken,
@@ -190,42 +227,6 @@ interface IVestingSchedulerV2 {
     function getMaximumNeededTokenAllowance(
         address superToken, address sender, address receiver
     ) external returns (uint256);
-
-    /**
-     * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.
-     */
-    function createVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 cliffPeriod,
-        uint32 startDate
-    ) external;
-
-    /**
-     * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.
-     * The startDate is set to current block timestamp.
-     */
-    function createVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 cliffPeriod
-    ) external;
-
-    /**
-     * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.
-     * The startDate is set to current block timestamp.
-     * Cliff period is not applied.
-     */
-    function createVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration
-    ) external;
 
     /**
      * @dev Creates a new vesting schedule

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -198,16 +198,6 @@ interface IVestingSchedulerV2 {
     ) external returns (uint256);
 
     /**
-     * @dev Estimates maximum ERC-20 token allowance needed for an existing vesting schedule.
-     * @param superToken SuperToken to be vested
-     * @param sender Vesting sender
-     * @param receiver Vesting receiver
-     */
-    function getMaximumNeededTokenAllowance(
-        address superToken, address sender, address receiver
-    ) external returns (uint256);
-
-    /**
      * @dev Creates a new vesting schedule
      * @dev The function calculates the endDate, cliffDate, cliffAmount, flowRate, etc, based on the input arguments.
      * @dev The function creates the vesting schedule with start date set to current timestamp,

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -179,7 +179,7 @@ interface IVestingSchedulerV2 {
      * @param cliffPeriod The cliff period of the vesting
      * @param claimPeriod The claim availability period
      */
-    function getCreateVestingScheduleParamsFromAmountAndDuration(
+    function mapCreateVestingScheduleParams(
         ISuperToken superToken,
         address sender,
         address receiver,

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -215,7 +215,8 @@ interface IVestingSchedulerV2 {
      * @param superToken SuperToken to be vested
      * @param receiver Vesting receiver
      * @param totalAmount The total amount to be vested 
-     * @param totalDuration The total duration of the vestingß
+     * @param totalDuration The total duration of the vesting
+     * @param cliffPeriod The duration of the cliff period from the start date
      * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
      */
     function createAndExecuteVestingScheduleFromAmountAndDuration(
@@ -223,6 +224,7 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration,
+        uint32 cliffPeriod,
         bytes memory ctx
     ) external returns (bytes memory newCtx);
 
@@ -233,7 +235,8 @@ interface IVestingSchedulerV2 {
         ISuperToken superToken,
         address receiver,
         uint256 totalAmount,
-        uint32 totalDuration
+        uint32 totalDuration,
+        uint32 cliffPeriod
     ) external;
 
     /**

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -101,6 +101,7 @@ interface IVestingSchedulerV2 {
      * @param flowRate The flowRate for the stream
      * @param cliffAmount The amount to be transferred at the cliff
      * @param endDate The timestamp when the stream should stop.
+     * @param claimValidityDate Date before which the claimable schedule must be claimed
      * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
      */
     function createVestingSchedule(
@@ -111,6 +112,7 @@ interface IVestingSchedulerV2 {
         int96 flowRate,
         uint256 cliffAmount,
         uint32 endDate,
+        uint32 claimValidityDate,
         bytes memory ctx
     ) external returns (bytes memory newCtx);
 
@@ -124,7 +126,8 @@ interface IVestingSchedulerV2 {
         uint32 cliffDate,
         int96 flowRate,
         uint256 cliffAmount,
-        uint32 endDate
+        uint32 endDate,
+        uint32 claimValidityDate
     ) external;
 
     /**
@@ -251,46 +254,6 @@ interface IVestingSchedulerV2 {
         address receiver,
         uint256 totalAmount,
         uint32 totalDuration
-    ) external;
-
-    /**
-     * @dev Creates a new vesting schedule that needs to be claimed by the receiver to start flowing.
-     * @dev If a non-zero cliffDate is set, the startDate has no effect other than being logged in an event.
-     * @dev If cliffDate is set to zero, the startDate becomes the cliff (transfer cliffAmount and start stream).
-     * @param superToken SuperToken to be vested
-     * @param receiver Vesting receiver
-     * @param startDate Timestamp when the vesting should start
-     * @param claimValidityDate Date before which the claimable schedule must be claimed
-     * @param cliffDate Timestamp of cliff exectution - if 0, startDate acts as cliff
-     * @param flowRate The flowRate for the stream
-     * @param cliffAmount The amount to be transferred at the cliff
-     * @param endDate The timestamp when the stream should stop.
-     * @param ctx Superfluid context used when batching operations. (or bytes(0) if not SF batching)
-     */
-    function createClaimableVestingSchedule(
-        ISuperToken superToken,
-        address receiver,
-        uint32 startDate,
-        uint32 claimValidityDate,
-        uint32 cliffDate,
-        int96 flowRate,
-        uint256 cliffAmount,
-        uint32 endDate,
-        bytes memory ctx
-    ) external returns (bytes memory newCtx);
-
-    /**
-     * @dev See IVestingScheduler.createClaimableVestingSchedule overload for more details.
-     */
-    function createClaimableVestingSchedule(
-        ISuperToken superToken,
-        address receiver,
-        uint32 startDate,
-        uint32 claimValidityDate,
-        uint32 cliffDate,
-        int96 flowRate,
-        uint256 cliffAmount,
-        uint32 endDate
     ) external;
 
     /**

--- a/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
+++ b/packages/automation-contracts/scheduler/contracts/interface/IVestingSchedulerV2.sol
@@ -168,32 +168,6 @@ interface IVestingSchedulerV2 {
     ) external;
 
     /**
-     * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.
-     * The startDate is set to current block timestamp.
-     */
-    function createVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 cliffPeriod,
-        uint32 claimPeriod
-    ) external;
-
-    /**
-     * @dev See IVestingScheduler.createVestingScheduleFromAmountAndDuration overload for more details.
-     * The startDate is set to current block timestamp.
-     * Cliff period is not applied.
-     */
-    function createVestingScheduleFromAmountAndDuration(
-        ISuperToken superToken,
-        address receiver,
-        uint256 totalAmount,
-        uint32 totalDuration,
-        uint32 claimPeriod
-    ) external;
-
-    /**
      * @dev Returns all relevant information related to a new vesting schedule creation 
      * @dev based on the amounts and durations.
      * @param superToken SuperToken to be vested

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -142,6 +142,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            0,
             EMPTY_CTX
         );
         vm.stopPrank();
@@ -149,15 +150,15 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
     function _createClaimableVestingScheduleWithDefaultData(address sender, address receiver) private {
         vm.startPrank(sender);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
             superToken,
             receiver,
             START_DATE,
-            CLAIM_VALIDITY_DATE,
             CLIFF_DATE,
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            CLAIM_VALIDITY_DATE,
             EMPTY_CTX
         );
         vm.stopPrank();
@@ -165,15 +166,15 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         function _createClaimableVestingScheduleWithClaimDateAfterEndDate(address sender, address receiver, uint256 delayAfterEndDate) private {
         vm.startPrank(sender);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
             superToken,
             receiver,
             START_DATE,
-            END_DATE + uint32(delayAfterEndDate),
             CLIFF_DATE,
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            END_DATE + uint32(delayAfterEndDate),
             EMPTY_CTX
         );
         vm.stopPrank();
@@ -301,6 +302,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                0,
                 EMPTY_CTX
         );
 
@@ -314,6 +316,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                0,
                 EMPTY_CTX
         );
 
@@ -327,6 +330,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                0,
                 EMPTY_CTX
         );
 
@@ -340,6 +344,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 0,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                0,
                 EMPTY_CTX
         );
 
@@ -353,6 +358,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            0,
             EMPTY_CTX
         );
 
@@ -366,6 +372,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 0,
                 END_DATE,
+                0,
                 EMPTY_CTX
         );
 
@@ -378,6 +385,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
+                0,
                 0,
                 EMPTY_CTX
         );
@@ -392,6 +400,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 0,
                 END_DATE,
+                0,
                 EMPTY_CTX
         );
 
@@ -405,6 +414,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 CLIFF_DATE,
+                0,
                 EMPTY_CTX
         );
 
@@ -418,6 +428,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 CLIFF_DATE,
+                0,
                 EMPTY_CTX
         );
 
@@ -431,6 +442,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                0,
                 EMPTY_CTX
         );
 
@@ -445,6 +457,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 CLIFF_DATE + 2 days,
+                0,
                 EMPTY_CTX
         );
     }
@@ -587,6 +600,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 FLOW_RATE,
                 0,
                 END_DATE,
+                0,
                 EMPTY_CTX
         );
         superToken.increaseAllowance(address(vestingScheduler), type(uint256).max);
@@ -775,6 +789,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            0,
             EMPTY_CTX
         );
         // ---
@@ -1196,15 +1211,15 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             superToken, alice, bob, START_DATE, CLIFF_DATE, FLOW_RATE, END_DATE, CLIFF_TRANSFER_AMOUNT, CLAIM_VALIDITY_DATE, 0);
 
         vm.startPrank(alice);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
             superToken,
             bob,
             START_DATE,
-            CLAIM_VALIDITY_DATE,
             CLIFF_DATE,
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            CLAIM_VALIDITY_DATE,
             EMPTY_CTX
         );
         vm.stopPrank();
@@ -1225,15 +1240,15 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             superToken, alice, bob, START_DATE, CLIFF_DATE, FLOW_RATE, END_DATE, CLIFF_TRANSFER_AMOUNT, CLAIM_VALIDITY_DATE, 0);
 
         vm.startPrank(alice);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
             superToken,
             bob,
             START_DATE,
-            CLAIM_VALIDITY_DATE,
             CLIFF_DATE,
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            CLAIM_VALIDITY_DATE,
             EMPTY_CTX
         );
         vm.stopPrank();
@@ -1254,15 +1269,15 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             superToken, alice, bob, START_DATE, CLIFF_DATE, FLOW_RATE, END_DATE, CLIFF_TRANSFER_AMOUNT, CLAIM_VALIDITY_DATE, 0);
 
         vm.startPrank(alice);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
             superToken,
             bob,
             START_DATE,
-            CLAIM_VALIDITY_DATE,
             CLIFF_DATE,
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
-            END_DATE
+            END_DATE,
+            CLAIM_VALIDITY_DATE
         );
         vm.stopPrank();
 
@@ -1280,199 +1295,199 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vm.startPrank(alice);
         // revert with superToken = 0
         vm.expectRevert(IVestingSchedulerV2.ZeroAddress.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 ISuperToken(address(0)),
                 bob,
                 START_DATE,
-                0, // claimValidityDate
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with receivers = sender
         vm.expectRevert(IVestingSchedulerV2.AccountInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 alice,
                 START_DATE,
-                0, // claimValidityDate
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with receivers = address(0)
         vm.expectRevert(IVestingSchedulerV2.AccountInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 address(0),
                 START_DATE,
-                0, // claimValidityDate
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with flowRate = 0
         vm.expectRevert(IVestingSchedulerV2.FlowRateInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 bob,
                 START_DATE,
-                0, // claimValidityDate
                 CLIFF_DATE,
                 0,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with cliffDate = 0 but cliffAmount != 0
         vm.expectRevert(IVestingSchedulerV2.CliffInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
             superToken,
             bob,
             0,
-            0, // claimValidityDate
             0,
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            CLAIM_VALIDITY_DATE,
             EMPTY_CTX
         );
 
         // revert with startDate < block.timestamp && cliffDate = 0
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 bob,
                 uint32(block.timestamp - 1),
-                0, // claimValidityDate
                 0,
                 FLOW_RATE,
                 0,
                 END_DATE,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with endDate = 0
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 bob,
                 START_DATE,
-                0, // claimValidityDate
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 0,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with cliffAndFlowDate < block.timestamp
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 bob,
                 0,
-                0, // claimValidityDate
                 uint32(block.timestamp) - 1,
                 FLOW_RATE,
                 0,
                 END_DATE,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with cliffAndFlowDate >= endDate
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 bob,
                 START_DATE,
-                0, // claimValidityDate
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 CLIFF_DATE,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with cliffAndFlowDate + startDateValidFor >= endDate - endDateValidBefore
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 bob,
                 START_DATE,
-                0, // claimValidityDate
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 CLIFF_DATE,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with startDate > cliffDate
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 bob,
                 CLIFF_DATE + 1,
-                0, // claimValidityDate
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
 
         // revert with vesting duration < 7 days
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 bob,
                 START_DATE,
-                0, // claimValidityDate
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 CLIFF_DATE + 2 days,
+                CLAIM_VALIDITY_DATE,
                 EMPTY_CTX
         );
 
         // revert with invalid claim validity date (before schedule/cliff start)
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
                 superToken,
                 bob,
                 START_DATE,
-                CLIFF_DATE - 1,
                 CLIFF_DATE,
                 FLOW_RATE,
                 CLIFF_TRANSFER_AMOUNT,
                 END_DATE,
+                CLIFF_DATE - 1,
                 EMPTY_CTX
         );
     }
 
     function test_createClaimableVestingSchedule_dataExists() public {
         vm.startPrank(alice);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
             superToken,
             bob,
             START_DATE,
-            0, // claimValidityDate
             CLIFF_DATE,
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            CLAIM_VALIDITY_DATE,
             EMPTY_CTX
         );
         vm.stopPrank();
@@ -1480,15 +1495,15 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vm.expectRevert(IVestingSchedulerV2.ScheduleAlreadyExists.selector);
 
         vm.startPrank(alice);
-        vestingScheduler.createClaimableVestingSchedule(
+        vestingScheduler.createVestingSchedule(
             superToken,
             bob,
             START_DATE,
-            0, // claimValidityDate  
             CLIFF_DATE,
             FLOW_RATE,
             CLIFF_TRANSFER_AMOUNT,
             END_DATE,
+            CLAIM_VALIDITY_DATE,
             EMPTY_CTX
         );
         vm.stopPrank();

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -1075,7 +1075,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         superToken.approve(address(vestingScheduler), vestingScheduler.getMaximumNeededTokenAllowance(expectedSchedule));
         vm.stopPrank();
 
-        // Intermediary `getCreateVestingScheduleParamsFromAmountAndDuration` test
+        // Intermediary `mapCreateVestingScheduleParams` test
         assertAreScheduleCreationParamsEqual(
             IVestingSchedulerV2.ScheduleCreationParams(
                 superToken,
@@ -1089,7 +1089,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 expectedSchedule.endDate,
                 expectedSchedule.remainderAmount
             ), 
-            vestingScheduler.getCreateVestingScheduleParamsFromAmountAndDuration(superToken, alice, bob, totalAmount, totalDuration, $.expectedStartDate, cliffPeriod, 0));
+            vestingScheduler.mapCreateVestingScheduleParams(superToken, alice, bob, totalAmount, totalDuration, $.expectedStartDate, cliffPeriod, 0));
 
         vm.expectEmit();
         emit VestingScheduleCreated(superToken, alice, bob, $.expectedStartDate, $.expectedCliffDate, expectedSchedule.flowRate, expectedSchedule.endDate, expectedSchedule.cliffAmount, 0, expectedSchedule.remainderAmount);

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -1824,7 +1824,6 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         IVestingSchedulerV2.VestingSchedule memory schedule = vestingScheduler.getVestingSchedule(address(superToken), alice, bob);
         assertEq(vestingScheduler.getMaximumNeededTokenAllowance(schedule), totalExpectedAmount);
-        assertEq(vestingScheduler.getMaximumNeededTokenAllowance(address(superToken), alice, bob), totalExpectedAmount);
 
         vm.prank(claimer);
         assertTrue(vestingScheduler.executeCliffAndFlow(superToken, alice, bob));
@@ -1994,9 +1993,6 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         );
         vm.stopPrank();
 
-        // Assert
-        assertEq(vestingScheduler.getMaximumNeededTokenAllowance(expectedSchedule), vestingScheduler.getMaximumNeededTokenAllowance(address(superToken), alice, bob), "The overloads don't return same values");
-
         // Act
         vm.warp(expectedSchedule.cliffAndFlowDate + (vestingScheduler.START_DATE_VALID_AFTER()));
         assertTrue(vestingScheduler.executeCliffAndFlow(superToken, alice, bob));
@@ -2004,7 +2000,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         if (randomizer % 2 == 0) {
             // Let's set the allowance again half-way through.
             vm.startPrank(alice);
-            superToken.approve(address(vestingScheduler), vestingScheduler.getMaximumNeededTokenAllowance(address(superToken), alice, bob));
+            superToken.approve(address(vestingScheduler), vestingScheduler.getMaximumNeededTokenAllowance(vestingScheduler.getVestingSchedule(address(superToken), alice, bob)));
             vm.stopPrank();
         }
 
@@ -2092,9 +2088,6 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         );
         vm.stopPrank();
 
-        // Assert
-        assertEq(vestingScheduler.getMaximumNeededTokenAllowance(expectedSchedule), vestingScheduler.getMaximumNeededTokenAllowance(address(superToken), alice, bob), "The overloads don't return same values");
-
         // Act
         vm.warp(expectedSchedule.claimValidityDate);
         vm.startPrank(randomizer % 3 == 0 ? alice : bob); // Both sender and receiver can execute
@@ -2104,7 +2097,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         if (randomizer % 2 == 0) {
             // Let's set the allowance again half-way through.
             vm.startPrank(alice);
-            superToken.approve(address(vestingScheduler), vestingScheduler.getMaximumNeededTokenAllowance(address(superToken), alice, bob));
+            superToken.approve(address(vestingScheduler), vestingScheduler.getMaximumNeededTokenAllowance(vestingScheduler.getVestingSchedule(address(superToken), alice, bob)));
             vm.stopPrank();
         }
 

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -846,10 +846,10 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            0,
-            1209600,
-            604800,
-            uint32(block.timestamp),
+            0, // amount
+            1209600, // duration
+            uint32(block.timestamp), // startDate
+            604800, // cliffPeriod
             EMPTY_CTX
         );
 
@@ -858,10 +858,10 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            1 ether,
-            1209600,
-            0,
-            uint32(block.timestamp - 1),
+            1 ether, // amount
+            1209600, // duration
+            uint32(block.timestamp - 1), // startDate
+            0, // cliffPeriod
             EMPTY_CTX
         );
 
@@ -870,10 +870,10 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            type(uint256).max,
-            1209600,
-            0,
-            uint32(block.timestamp),
+            type(uint256).max, // amount
+            1209600, // duration
+            uint32(block.timestamp), // startDate
+            0, // cliffPeriod
             EMPTY_CTX
         );
 
@@ -882,10 +882,10 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            1 ether,
-            type(uint32).max,
-            0,
-            uint32(block.timestamp),
+            1 ether, // amount
+            type(uint32).max, // duration
+            uint32(block.timestamp), // startDate
+            0, // cliffPeriod
             EMPTY_CTX
         );
 
@@ -894,10 +894,10 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            1 ether,
-            1209600,
-            604800,
-            uint32(block.timestamp - 1),
+            1 ether, // amount
+            1209600, // duration
+            uint32(block.timestamp - 1), // startDate
+            604800, // cliffPeriod
             EMPTY_CTX
         );
     }
@@ -926,8 +926,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                0,
-                startDate,
+                startDate, 
+                0, // cliffPeriod
                 EMPTY_CTX
             );
         } else {
@@ -936,8 +936,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                0,
-                startDate
+                startDate,
+                0 // cliffPeriod
             );
         }
         vm.stopPrank();
@@ -971,8 +971,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                cliffPeriod,
                 startDate,
+                cliffPeriod,
                 EMPTY_CTX
             );
         } else {
@@ -981,8 +981,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                cliffPeriod,
-                startDate
+                startDate,
+                cliffPeriod
             );
         }
         vm.stopPrank();
@@ -1103,8 +1103,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                     bob,
                     totalAmount,
                     totalDuration,
-                    cliffPeriod,
-                    startDate
+                    startDate,
+                    cliffPeriod
                 );
             } else {
                 console.log("Using the overload with superfluid context.");
@@ -1113,8 +1113,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                     bob,
                     totalAmount,
                     totalDuration,
-                    cliffPeriod,
                     startDate,
+                    cliffPeriod,
                     EMPTY_CTX
                 );
             }
@@ -1984,8 +1984,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             totalAmount,
             totalDuration,
-            cliffPeriod,
             startDate,
+            cliffPeriod,
             EMPTY_CTX
         );
         vm.stopPrank();

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -1079,6 +1079,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         assertAreScheduleCreationParamsEqual(
             IVestingSchedulerV2.ScheduleCreationParams(
                 superToken,
+                alice,
                 bob,
                 $.expectedStartDate,
                 expectedSchedule.claimValidityDate,
@@ -1088,7 +1089,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 expectedSchedule.endDate,
                 expectedSchedule.remainderAmount
             ), 
-            vestingScheduler.getCreateVestingScheduleParamsFromAmountAndDuration(superToken, bob, totalAmount, totalDuration, $.expectedStartDate, cliffPeriod, 0));
+            vestingScheduler.getCreateVestingScheduleParamsFromAmountAndDuration(superToken, alice, bob, totalAmount, totalDuration, $.expectedStartDate, cliffPeriod, 0));
 
         vm.expectEmit();
         emit VestingScheduleCreated(superToken, alice, bob, $.expectedStartDate, $.expectedCliffDate, expectedSchedule.flowRate, expectedSchedule.endDate, expectedSchedule.cliffAmount, 0, expectedSchedule.remainderAmount);

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -1088,7 +1088,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 expectedSchedule.endDate,
                 expectedSchedule.remainderAmount
             ), 
-            vestingScheduler.getCreateVestingScheduleParamsFromAmountAndDuration(superToken, bob, totalAmount, totalDuration, startDate, cliffPeriod, 0));
+            vestingScheduler.getCreateVestingScheduleParamsFromAmountAndDuration(superToken, bob, totalAmount, totalDuration, $.expectedStartDate, cliffPeriod, 0));
 
         vm.expectEmit();
         emit VestingScheduleCreated(superToken, alice, bob, $.expectedStartDate, $.expectedCliffDate, expectedSchedule.flowRate, expectedSchedule.endDate, expectedSchedule.cliffAmount, 0, expectedSchedule.remainderAmount);

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -850,6 +850,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             1209600, // duration
             uint32(block.timestamp), // startDate
             604800, // cliffPeriod
+            0, // claimPeriod
             EMPTY_CTX
         );
 
@@ -862,6 +863,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             1209600, // duration
             uint32(block.timestamp - 1), // startDate
             0, // cliffPeriod
+            0, // claimPeriod
             EMPTY_CTX
         );
 
@@ -874,6 +876,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             1209600, // duration
             uint32(block.timestamp), // startDate
             0, // cliffPeriod
+            0, // claimPeriod
             EMPTY_CTX
         );
 
@@ -886,6 +889,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             type(uint32).max, // duration
             uint32(block.timestamp), // startDate
             0, // cliffPeriod
+            0, // claimPeriod
             EMPTY_CTX
         );
 
@@ -898,6 +902,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             1209600, // duration
             uint32(block.timestamp - 1), // startDate
             604800, // cliffPeriod
+            0, // claimPeriod
             EMPTY_CTX
         );
     }
@@ -928,6 +933,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 vestingDuration,
                 startDate, 
                 0, // cliffPeriod
+                0, // claimPeriod
                 EMPTY_CTX
             );
         } else {
@@ -937,7 +943,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 totalVestedAmount,
                 vestingDuration,
                 startDate,
-                0 // cliffPeriod
+                0, // cliffPeriod
+                0 // claimPeriod
             );
         }
         vm.stopPrank();
@@ -973,6 +980,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 vestingDuration,
                 startDate,
                 cliffPeriod,
+                0,
                 EMPTY_CTX
             );
         } else {
@@ -982,7 +990,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 totalVestedAmount,
                 vestingDuration,
                 startDate,
-                cliffPeriod
+                cliffPeriod,
+                0
             );
         }
         vm.stopPrank();
@@ -1079,7 +1088,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 expectedSchedule.endDate,
                 expectedSchedule.remainderAmount
             ), 
-            vestingScheduler.getCreateVestingScheduleParamsFromAmountAndDuration(superToken, bob, totalAmount, totalDuration, cliffPeriod, startDate, 0));
+            vestingScheduler.getCreateVestingScheduleParamsFromAmountAndDuration(superToken, bob, totalAmount, totalDuration, startDate, cliffPeriod, 0));
 
         vm.expectEmit();
         emit VestingScheduleCreated(superToken, alice, bob, $.expectedStartDate, $.expectedCliffDate, expectedSchedule.flowRate, expectedSchedule.endDate, expectedSchedule.cliffAmount, 0, expectedSchedule.remainderAmount);
@@ -1093,7 +1102,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 bob,
                 totalAmount,
                 totalDuration,
-                cliffPeriod
+                cliffPeriod,
+                0
             );
         } else {
             if (randomizer % 3 == 0) {
@@ -1104,7 +1114,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                     totalAmount,
                     totalDuration,
                     startDate,
-                    cliffPeriod
+                    cliffPeriod,
+                    0
                 );
             } else {
                 console.log("Using the overload with superfluid context.");
@@ -1115,6 +1126,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                     totalDuration,
                     startDate,
                     cliffPeriod,
+                    0,
                     EMPTY_CTX
                 );
             }
@@ -1529,25 +1541,25 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vm.startPrank(alice);
         bool useCtx = randomizer % 2 == 0;
         if (useCtx) {
-            vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+            vestingScheduler.createVestingScheduleFromAmountAndDuration(
                 superToken,
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                claimPeriod,
-                0,
                 startDate,
+                0, // cliffPeriod
+                claimPeriod,
                 EMPTY_CTX
             );
         } else {
-            vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+            vestingScheduler.createVestingScheduleFromAmountAndDuration(
                 superToken,
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                claimPeriod,
-                0,
-                startDate
+                startDate,
+                0, // cliffPeriod
+                claimPeriod
             );
         }
         vm.stopPrank();
@@ -1582,7 +1594,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         vm.startPrank(alice);
 
-        vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+        vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
             totalVestedAmount,
@@ -1613,25 +1625,25 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         vm.startPrank(alice);
         bool useCtx = randomizer % 2 == 0;
         if (useCtx) {
-            vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+            vestingScheduler.createVestingScheduleFromAmountAndDuration(
                 superToken,
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                claimPeriod,
-                cliffPeriod,
                 startDate,
+                cliffPeriod,
+                claimPeriod,
                 EMPTY_CTX
             );
         } else {
-            vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+            vestingScheduler.createVestingScheduleFromAmountAndDuration(
                 superToken,
                 bob,
                 totalVestedAmount,
                 vestingDuration,
-                claimPeriod,
+                startDate,
                 cliffPeriod,
-                startDate
+                claimPeriod
             );
         }
         vm.stopPrank();
@@ -1659,13 +1671,13 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         vm.startPrank(alice);
 
-        vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+        vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
             totalVestedAmount,
             vestingDuration,
-            claimPeriod,
-            cliffPeriod
+            cliffPeriod,
+            claimPeriod
         );
 
         vm.stopPrank();
@@ -1676,66 +1688,66 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         superToken.increaseAllowance(address(vestingScheduler), type(uint256).max);
 
         vm.expectRevert(IVestingSchedulerV2.FlowRateInvalid.selector);
-        vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+        vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            0,
-            1209600,
-            15 days,
-            604800,
-            uint32(block.timestamp),
+            0, // amount 
+            1209600, // duration
+            uint32(block.timestamp), // startDate
+            604800, // cliffPeriod
+            15 days, // claimPeriod
             EMPTY_CTX
         );
 
         console.log("Revert with cliff and start in history.");
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+        vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            1 ether,
-            1209600,
-            15 days,
-            0,
-            uint32(block.timestamp - 1),
+            1 ether, // amount
+            1209600, // duration
+            uint32(block.timestamp - 1), // startDate
+            0, // cliffPeriod
+            15 days, // claimPeriod
             EMPTY_CTX
         );
 
         console.log("Revert with overflow.");
         vm.expectRevert("SafeCast: value doesn't fit in 96 bits"); 
-        vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+        vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            type(uint256).max,
-            1209600,
-            15 days,
-            0,
-            uint32(block.timestamp),
+            type(uint256).max, // amount
+            1209600, // duration
+            uint32(block.timestamp), // startDate
+            0, // cliffPeriod
+            15 days, // claimPeriod
             EMPTY_CTX
         );
 
         console.log("Revert with underflow/overflow.");
         vm.expectRevert(); // todo: the right error
-        vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+        vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            1 ether,
-            type(uint32).max,
-            15 days,
-            0,
-            uint32(block.timestamp),
+            1 ether, // amount
+            type(uint32).max, // duration
+            uint32(block.timestamp), // startDate
+            0, // cliffPeriod
+            15 days, // claimPeriod
             EMPTY_CTX
         );
 
         console.log("Revert with start date in history.");
         vm.expectRevert(IVestingSchedulerV2.TimeWindowInvalid.selector);
-        vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+        vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
-            1 ether,
-            1209600,
-            15 days,
-            604800,
-            uint32(block.timestamp - 1),
+            1 ether, // amount
+            1209600, // duration
+            uint32(block.timestamp - 1), // startDate
+            604800, // cliffPeriod
+            15 days, // claimPeriod
             EMPTY_CTX
         );
     }
@@ -1986,6 +1998,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             totalDuration,
             startDate,
             cliffPeriod,
+            0,
             EMPTY_CTX
         );
         vm.stopPrank();
@@ -2076,14 +2089,14 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         // Act
         vm.startPrank(alice);
-        vestingScheduler.createClaimableVestingScheduleFromAmountAndDuration(
+        vestingScheduler.createVestingScheduleFromAmountAndDuration(
             superToken,
             bob,
             totalAmount,
             totalDuration,
-            claimPeriod,
-            cliffPeriod,
             startDate,
+            cliffPeriod,
+            claimPeriod,
             EMPTY_CTX
         );
         vm.stopPrank();

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -764,7 +764,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         assertTrue(success, "executeCloseVesting should return true");
     }
 
-    // # Vesting Scheduler 1.2 tests
+    // # Vesting Scheduler V2 tests
 
     function testCreateAndExecuteImmediately() public {
         uint256 aliceInitialBalance = superToken.balanceOf(alice);
@@ -1002,13 +1002,16 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         uint256 beforeReceiverBalance;
         uint32 expectedCliffDate;
         uint32 expectedStartDate;
+        address claimer;
     }
 
-    function test_createScheduleFromAmountAndDuration_executeCliffAndFlow_executeEndVesting_withoutClaim(
+    // Claimable Vesting Schedules tests
+    function test_createScheduleFromAmountAndDuration_executeCliffAndFlow_executeEndVesting_withClaim(
         uint256 totalAmount,
         uint32 totalDuration,
         uint32 cliffPeriod,
         uint32 startDate,
+        uint32 claimPeriod,
         uint8 randomizer
     ) public {
         // Assume
@@ -1020,6 +1023,10 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         totalDuration = SafeCast.toUint32(bound(totalDuration, vestingScheduler.MIN_VESTING_DURATION(), 9125 days));
         vm.assume(cliffPeriod <= totalDuration - vestingScheduler.MIN_VESTING_DURATION());
+
+        claimPeriod = SafeCast.toUint32(bound(claimPeriod, 1, 9125 days));
+        vm.assume(claimPeriod > (cliffPeriod > 0 ? startDate + cliffPeriod : startDate));
+        vm.assume(claimPeriod < totalDuration - vestingScheduler.END_DATE_VALID_BEFORE());
 
         BigTestData memory $;
 
@@ -1038,7 +1045,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             totalDuration,
             cliffPeriod,
             startDate,
-            0
+            claimPeriod
         );
         $.expectedCliffDate = cliffPeriod == 0 ? 0 : expectedSchedule.cliffAndFlowDate;
         $.expectedStartDate = startDate == 0 ? uint32(block.timestamp) : startDate;
@@ -1049,9 +1056,11 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         console.log("Total amount: %s", totalAmount);
         console.log("Total duration: %s", totalDuration);
         console.log("Cliff period: %s", cliffPeriod);
+        console.log("Claim period: %s", claimPeriod);
         console.log("Start date: %s", startDate);
         console.log("Randomizer: %s", randomizer);
         console.log("Expected start date: %s", $.expectedStartDate);
+        console.log("Expected claim date: %s", expectedSchedule.claimValidityDate);
         console.log("Expected cliff date: %s", $.expectedCliffDate);
         console.log("Expected cliff & flow date: %s", expectedSchedule.cliffAndFlowDate);
         console.log("Expected end date: %s", expectedSchedule.endDate);
@@ -1089,10 +1098,10 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 expectedSchedule.endDate,
                 expectedSchedule.remainderAmount
             ), 
-            vestingScheduler.mapCreateVestingScheduleParams(superToken, alice, bob, totalAmount, totalDuration, $.expectedStartDate, cliffPeriod, 0));
+            vestingScheduler.mapCreateVestingScheduleParams(superToken, alice, bob, totalAmount, totalDuration, $.expectedStartDate, cliffPeriod, claimPeriod));
 
         vm.expectEmit();
-        emit VestingScheduleCreated(superToken, alice, bob, $.expectedStartDate, $.expectedCliffDate, expectedSchedule.flowRate, expectedSchedule.endDate, expectedSchedule.cliffAmount, 0, expectedSchedule.remainderAmount);
+        emit VestingScheduleCreated(superToken, alice, bob, $.expectedStartDate, $.expectedCliffDate, expectedSchedule.flowRate, expectedSchedule.endDate, expectedSchedule.cliffAmount, expectedSchedule.claimValidityDate, expectedSchedule.remainderAmount);
 
         // Act
         vm.startPrank(alice);
@@ -1105,7 +1114,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 totalDuration,
                 startDate,
                 cliffPeriod,
-                0
+                claimPeriod
             );
         } else {
             console.log("Using the overload with superfluid context.");
@@ -1116,7 +1125,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
                 totalDuration,
                 startDate,
                 cliffPeriod,
-                0,
+                claimPeriod,
                 EMPTY_CTX
             );
         }
@@ -1129,14 +1138,24 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         assertEq(actualSchedule.cliffAmount, expectedSchedule.cliffAmount, "schedule created: cliffAmount not expected");
         assertEq(actualSchedule.endDate, expectedSchedule.endDate, "schedule created: endDate not expected");
         assertEq(actualSchedule.remainderAmount, expectedSchedule.remainderAmount, "schedule created: remainderAmount not expected");
+        assertEq(actualSchedule.claimValidityDate, expectedSchedule.claimValidityDate, "schedule created: claimValidityDate not expected");
 
         // Act
         console.log("Executing cliff and flow.");
-        uint32 randomFlowDelay = (vestingScheduler.START_DATE_VALID_AFTER() - (vestingScheduler.START_DATE_VALID_AFTER() / randomizer));
+        uint32 randomFlowDelay = (expectedSchedule.claimValidityDate - expectedSchedule.cliffAndFlowDate);
         vm.warp(expectedSchedule.cliffAndFlowDate + randomFlowDelay);
+
+        $.claimer = randomizer % 2 == 0 ? bob : alice;
+
+        vm.prank($.claimer);
         vm.expectEmit();
-        emit VestingCliffAndFlowExecuted(superToken, alice, bob, expectedSchedule.cliffAndFlowDate, expectedSchedule.flowRate, expectedSchedule.cliffAmount,  randomFlowDelay * SafeCast.toUint256(expectedSchedule.flowRate));
+        emit VestingClaimed(
+            superToken, alice, bob, $.claimer
+        );
+        vm.expectEmit();
+        emit VestingCliffAndFlowExecuted(superToken, alice, bob, expectedSchedule.cliffAndFlowDate, expectedSchedule.flowRate, expectedSchedule.cliffAmount, randomFlowDelay * SafeCast.toUint256(expectedSchedule.flowRate));
         assertTrue(vestingScheduler.executeCliffAndFlow(superToken, alice, bob));
+        vm.stopPrank();
 
         // Assert
         actualSchedule = vestingScheduler.getVestingSchedule(address(superToken), alice, bob);
@@ -1203,7 +1222,172 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
         assertEq(afterSenderBalance, superToken.balanceOf(alice), "After the schedule has ended, the sender's balance should never change.");
     }
 
-    // Claimable Vesting Schedules tests
+    function test_createScheduleFromAmountAndDuration_executeCliffAndFlow_executeEndVesting_withClaim_withSingleTransfer(
+        uint256 totalAmount,
+        uint32 totalDuration,
+        uint32 cliffPeriod,
+        uint32 startDate,
+        uint32 claimPeriod,
+        uint8 randomizer
+    ) public {
+        // Assume
+        randomizer = SafeCast.toUint8(bound(randomizer, 1, type(uint8).max));
+        
+        if (startDate != 0) {
+            startDate = SafeCast.toUint32(bound(startDate, block.timestamp, 2524600800));
+        }
+
+        totalDuration = SafeCast.toUint32(bound(totalDuration, vestingScheduler.MIN_VESTING_DURATION(), 9125 days));
+        vm.assume(cliffPeriod <= totalDuration - vestingScheduler.MIN_VESTING_DURATION());
+
+        claimPeriod = SafeCast.toUint32(bound(claimPeriod, 1, 9125 days));
+        vm.assume(claimPeriod > (startDate + totalDuration - vestingScheduler.END_DATE_VALID_BEFORE()));
+
+        BigTestData memory $;
+
+        $.beforeSenderBalance = superToken.balanceOf(alice);
+        $.beforeReceiverBalance = superToken.balanceOf(bob);
+
+        totalAmount = bound(totalAmount, 1, $.beforeSenderBalance);
+        vm.assume(totalAmount >= totalDuration);
+        vm.assume(totalAmount / totalDuration <= SafeCast.toUint256(type(int96).max));
+
+        assertTrue(vestingScheduler.getVestingSchedule(address(superToken), alice, bob).endDate == 0, "Schedule should not exist");
+
+        // Arrange
+        IVestingSchedulerV2.VestingSchedule memory expectedSchedule = _getExpectedScheduleFromAmountAndDuration(
+            totalAmount,
+            totalDuration,
+            cliffPeriod,
+            startDate,
+            claimPeriod
+        );
+        $.expectedCliffDate = cliffPeriod == 0 ? 0 : expectedSchedule.cliffAndFlowDate;
+        $.expectedStartDate = startDate == 0 ? uint32(block.timestamp) : startDate;
+
+        // Assume we're not getting liquidated at the end:
+        vm.assume($.beforeSenderBalance >= totalAmount + vestingScheduler.END_DATE_VALID_BEFORE() * SafeCast.toUint256(expectedSchedule.flowRate));
+
+        console.log("Total amount: %s", totalAmount);
+        console.log("Total duration: %s", totalDuration);
+        console.log("Cliff period: %s", cliffPeriod);
+        console.log("Claim period: %s", claimPeriod);
+        console.log("Start date: %s", startDate);
+        console.log("Randomizer: %s", randomizer);
+        console.log("Expected start date: %s", $.expectedStartDate);
+        console.log("Expected claim date: %s", expectedSchedule.claimValidityDate);
+        console.log("Expected cliff date: %s", $.expectedCliffDate);
+        console.log("Expected cliff & flow date: %s", expectedSchedule.cliffAndFlowDate);
+        console.log("Expected end date: %s", expectedSchedule.endDate);
+        console.log("Expected flow rate: %s", SafeCast.toUint256(expectedSchedule.flowRate));
+        console.log("Expected cliff amount: %s", expectedSchedule.cliffAmount);
+        console.log("Expected remainder amount: %s", expectedSchedule.remainderAmount);
+        console.log("Sender balance: %s", $.beforeSenderBalance);
+
+        // Arrange allowance
+        assertTrue(superToken.allowance(alice, address(vestingScheduler)) == 0, "Let's start without any allowance");
+
+        vm.startPrank(alice);
+        superToken.revokeFlowPermissions(address(vestingScheduler));
+        superToken.setFlowPermissions(
+            address(vestingScheduler),
+            true, // allowCreate
+            false, // allowUpdate
+            true, // allowDelete,
+            expectedSchedule.flowRate
+        );
+        superToken.approve(address(vestingScheduler), vestingScheduler.getMaximumNeededTokenAllowance(expectedSchedule));
+        vm.stopPrank();
+
+        // Intermediary `mapCreateVestingScheduleParams` test
+        assertAreScheduleCreationParamsEqual(
+            IVestingSchedulerV2.ScheduleCreationParams(
+                superToken,
+                alice,
+                bob,
+                $.expectedStartDate,
+                expectedSchedule.claimValidityDate,
+                $.expectedCliffDate,
+                expectedSchedule.flowRate,
+                expectedSchedule.cliffAmount,
+                expectedSchedule.endDate,
+                expectedSchedule.remainderAmount
+            ), 
+            vestingScheduler.mapCreateVestingScheduleParams(superToken, alice, bob, totalAmount, totalDuration, $.expectedStartDate, cliffPeriod, claimPeriod));
+
+        vm.expectEmit();
+        emit VestingScheduleCreated(superToken, alice, bob, $.expectedStartDate, $.expectedCliffDate, expectedSchedule.flowRate, expectedSchedule.endDate, expectedSchedule.cliffAmount, expectedSchedule.claimValidityDate, expectedSchedule.remainderAmount);
+
+        // Act
+        vm.startPrank(alice);
+        if (randomizer % 3 == 0) {
+            console.log("Using the overload without superfluid context.");
+            vestingScheduler.createVestingScheduleFromAmountAndDuration(
+                superToken,
+                bob,
+                totalAmount,
+                totalDuration,
+                startDate,
+                cliffPeriod,
+                claimPeriod
+            );
+        } else {
+            console.log("Using the overload with superfluid context.");
+            vestingScheduler.createVestingScheduleFromAmountAndDuration(
+                superToken,
+                bob,
+                totalAmount,
+                totalDuration,
+                startDate,
+                cliffPeriod,
+                claimPeriod,
+                EMPTY_CTX
+            );
+        }
+        vm.stopPrank();
+
+        // Assert
+        IVestingSchedulerV2.VestingSchedule memory actualSchedule = vestingScheduler.getVestingSchedule(address(superToken), alice, bob);
+        assertEq(actualSchedule.cliffAndFlowDate, expectedSchedule.cliffAndFlowDate, "schedule created: cliffAndFlowDate not expected");
+        assertEq(actualSchedule.flowRate, expectedSchedule.flowRate, "schedule created: flowRate not expected");
+        assertEq(actualSchedule.cliffAmount, expectedSchedule.cliffAmount, "schedule created: cliffAmount not expected");
+        assertEq(actualSchedule.endDate, expectedSchedule.endDate, "schedule created: endDate not expected");
+        assertEq(actualSchedule.remainderAmount, expectedSchedule.remainderAmount, "schedule created: remainderAmount not expected");
+        assertEq(actualSchedule.claimValidityDate, expectedSchedule.claimValidityDate, "schedule created: claimValidityDate not expected");
+
+        // Act
+        console.log("Executing cliff and flow.");
+        uint32 randomDelay = (expectedSchedule.claimValidityDate - (expectedSchedule.endDate - vestingScheduler.END_DATE_VALID_BEFORE())) / randomizer;
+        vm.warp(expectedSchedule.endDate - vestingScheduler.END_DATE_VALID_BEFORE() + randomDelay);
+
+        $.claimer = randomizer % 2 == 0 ? bob : alice;
+
+        vm.prank($.claimer);
+
+        vm.expectEmit();
+        emit VestingClaimed(
+            superToken, alice, bob, $.claimer
+        );
+        vm.expectEmit();
+        emit VestingCliffAndFlowExecuted(superToken, alice, bob, expectedSchedule.cliffAndFlowDate, 0, expectedSchedule.cliffAmount, 0);
+
+        vm.expectEmit();
+        emit VestingEndExecuted(superToken, alice, bob, expectedSchedule.endDate, 0, false);
+
+        assertTrue(vestingScheduler.executeCliffAndFlow(superToken, alice, bob));
+        vm.stopPrank();
+
+        uint256 afterSenderBalance = superToken.balanceOf(alice);
+        uint256 afterReceiverBalance = superToken.balanceOf(bob);
+
+        assertEq(afterSenderBalance, $.beforeSenderBalance - totalAmount, "Sender balance should decrease by totalAmount");
+        assertEq(afterReceiverBalance, $.beforeReceiverBalance + totalAmount, "Receiver balance should increase by totalAmount");
+
+        testAssertScheduleDoesNotExist(address(superToken), alice, bob);
+
+        vm.warp(type(uint32).max);
+        assertEq(afterSenderBalance, superToken.balanceOf(alice), "After the schedule has ended, the sender's balance should never change.");
+    }
  
     function test_createClaimableVestingSchedule() public {
 
@@ -1820,7 +2004,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         vm.expectEmit(true, true, true, true);
         emit VestingEndExecuted(
-            superToken, alice, bob, END_DATE, totalExpectedAmount, false
+            superToken, alice, bob, END_DATE, 0, false
         );
 
         IVestingSchedulerV2.VestingSchedule memory schedule = vestingScheduler.getVestingSchedule(address(superToken), alice, bob);

--- a/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
+++ b/packages/automation-contracts/scheduler/test/VestingSchedulerV2.t.sol
@@ -1095,41 +1095,29 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
 
         // Act
         vm.startPrank(alice);
-        if (startDate == 0 && randomizer % 2 == 0) {
-            console.log("Using the overload without start date.");
+        if (randomizer % 3 == 0) {
+            console.log("Using the overload without superfluid context.");
             vestingScheduler.createVestingScheduleFromAmountAndDuration(
                 superToken,
                 bob,
                 totalAmount,
                 totalDuration,
+                startDate,
                 cliffPeriod,
                 0
             );
         } else {
-            if (randomizer % 3 == 0) {
-                console.log("Using the overload without superfluid context.");
-                vestingScheduler.createVestingScheduleFromAmountAndDuration(
-                    superToken,
-                    bob,
-                    totalAmount,
-                    totalDuration,
-                    startDate,
-                    cliffPeriod,
-                    0
-                );
-            } else {
-                console.log("Using the overload with superfluid context.");
-                vestingScheduler.createVestingScheduleFromAmountAndDuration(
-                    superToken,
-                    bob,
-                    totalAmount,
-                    totalDuration,
-                    startDate,
-                    cliffPeriod,
-                    0,
-                    EMPTY_CTX
-                );
-            }
+            console.log("Using the overload with superfluid context.");
+            vestingScheduler.createVestingScheduleFromAmountAndDuration(
+                superToken,
+                bob,
+                totalAmount,
+                totalDuration,
+                startDate,
+                cliffPeriod,
+                0,
+                EMPTY_CTX
+            );
         }
         vm.stopPrank();
 
@@ -1599,6 +1587,8 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             totalVestedAmount,
             vestingDuration,
+            0,
+            0,
             claimPeriod
         );
         vm.stopPrank();
@@ -1676,6 +1666,7 @@ contract VestingSchedulerV2Tests is FoundrySuperfluidTester {
             bob,
             totalVestedAmount,
             vestingDuration,
+            0,
             cliffPeriod,
             claimPeriod
         );


### PR DESCRIPTION
- remove a confusing overload
- add `cliffPeriod` to `createAndExecute` function for completeness sake
- unify & restrict visibility modifiers
- slight refactor with start date normalization to achieve pure mapper function
- slightly change log event semantics when doing single transfer for a claim
- some renamings
- more tests
- instead of `ctx`, pass `sender`
- reduce duplication with `_getId `