### PR TITLE
[ETHEREUM-CONTRACTS] payable macro forwarder

### DIFF
--- a/packages/automation-contracts/autowrap/package.json
+++ b/packages/automation-contracts/autowrap/package.json
@@ -4,8 +4,8 @@
     "version": "0.3.0",
     "devDependencies": {
         "@openzeppelin/contracts": "^4.9.6",
-        "@superfluid-finance/ethereum-contracts": "^1.11.0",
-        "@superfluid-finance/metadata": "^1.5.1"
+        "@superfluid-finance/ethereum-contracts": "^1.11.1",
+        "@superfluid-finance/metadata": "^1.5.2"
     },
     "license": "MIT",
     "scripts": {

--- a/packages/automation-contracts/scheduler/package.json
+++ b/packages/automation-contracts/scheduler/package.json
@@ -4,8 +4,8 @@
     "version": "1.2.0",
     "devDependencies": {
         "@openzeppelin/contracts": "^4.9.6",
-        "@superfluid-finance/ethereum-contracts": "^1.11.0",
-        "@superfluid-finance/metadata": "^1.5.1"
+        "@superfluid-finance/ethereum-contracts": "^1.11.1",
+        "@superfluid-finance/metadata": "^1.5.2"
     },
     "license": "MIT",
     "scripts": {

--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the ethereum-contracts will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.11.1]
 
 ### Changed
 

--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+* `MacroForwarder` made payable.
 * `IUserDefinedMacro`: added a method `postCheck()` which allows to verify state changes after running the macro.
 * `SuperfluidFrameworkDeployer` now also deploys and `MacroForwarder` and enables it as trusted forwarder.
 * `deploy-test-environment.js` now deploys fUSDC (the underlying) with 6 decimals (instead of 18) to better resemble the actual USDC.

--- a/packages/ethereum-contracts/contracts/interfaces/utils/IUserDefinedMacro.sol
+++ b/packages/ethereum-contracts/contracts/interfaces/utils/IUserDefinedMacro.sol
@@ -31,23 +31,16 @@ interface IUserDefinedMacro {
     function postCheck(ISuperfluid host, bytes memory params, address msgSender) external view;
 
     /*
-     * Additional to the required interface, we recommend to implement the following function:
-     * `function getParams(...) external view returns (bytes memory);`
+     * Additional to the required interface, we recommend to implement one or multiple view functions
+     * which take operation specific typed arguments and return the abi encoded bytes.
+     * As a convention, the name of those functions shall start with `params`.
      *
-     * It shall return abi encoded params as required as second argument of `MacroForwarder.runMacro()`.
-     *
-     * The function name shall be `getParams` and the return type shall be `bytes memory`.
-     * The number, type and name of arguments are free to choose such that they best fit the macro use case.
-     *
-     * In conjunction with the name of the Macro contract, the signature should be as self-explanatory as possible.
-     *
-     * Example for a contract `MultiFlowDeleteMacro` which lets a user delete multiple flows in one transaction:
-     * `function getParams(ISuperToken superToken, address[] memory receivers) external view returns (bytes memory)`
-     *
-     *
-     * Implementing this view function has several advantages:
+     * Implementing this view function(s) has several advantages:
+     * - Allows to build more complex macros with internally encapsulated dispatching logic
      * - Allows to use generic tooling like Explorers to interact with the macro
      * - Allows to build auto-generated UIs based on the contract ABI
      * - Makes it easier to interface with the macro from Dapps
+     *
+     * You can consult the related test code in `MacroForwarderTest.t.sol` for examples.
      */
 }

--- a/packages/ethereum-contracts/contracts/utils/ForwarderBase.sol
+++ b/packages/ethereum-contracts/contracts/utils/ForwarderBase.sol
@@ -25,10 +25,13 @@ abstract contract ForwarderBase {
     }
 
     function _forwardBatchCall(ISuperfluid.Operation[] memory ops) internal returns (bool) {
-        return _forwardBatchCall(ops, 0);
+        return _forwardBatchCallWithValue(ops, 0);
     }
 
-    function _forwardBatchCall(ISuperfluid.Operation[] memory ops, uint256 valueToForward) internal returns (bool) {
+    function _forwardBatchCallWithValue(ISuperfluid.Operation[] memory ops, uint256 valueToForward)
+        internal
+        returns (bool)
+    {
         bytes memory fwBatchCallData = abi.encodeCall(_host.forwardBatchCall, (ops));
 
         // https://eips.ethereum.org/EIPS/eip-2771

--- a/packages/ethereum-contracts/contracts/utils/ForwarderBase.sol
+++ b/packages/ethereum-contracts/contracts/utils/ForwarderBase.sol
@@ -25,12 +25,17 @@ abstract contract ForwarderBase {
     }
 
     function _forwardBatchCall(ISuperfluid.Operation[] memory ops) internal returns (bool) {
+        return _forwardBatchCall(ops, 0);
+    }
+
+    function _forwardBatchCall(ISuperfluid.Operation[] memory ops, uint256 valueToForward) internal returns (bool) {
         bytes memory fwBatchCallData = abi.encodeCall(_host.forwardBatchCall, (ops));
 
         // https://eips.ethereum.org/EIPS/eip-2771
         // we encode the msg.sender as the last 20 bytes per EIP-2771 to extract the original txn signer later on
         // solhint-disable-next-line avoid-low-level-calls
-        (bool success, bytes memory returnedData) = address(_host).call(abi.encodePacked(fwBatchCallData, msg.sender));
+        (bool success, bytes memory returnedData) = address(_host)
+            .call{value: valueToForward}(abi.encodePacked(fwBatchCallData, msg.sender));
 
         if (!success) {
             CallUtils.revertFromReturnedData(returnedData);

--- a/packages/ethereum-contracts/contracts/utils/MacroForwarder.sol
+++ b/packages/ethereum-contracts/contracts/utils/MacroForwarder.sol
@@ -29,11 +29,12 @@ contract MacroForwarder is ForwarderBase {
      * @dev Run the macro defined by the provided macro contract and params.
      * @param  m      Target macro.
      * @param  params Parameters to run the macro.
+     * If value (native coins) is provided, it is forwarded.
      */
-    function runMacro(IUserDefinedMacro m, bytes calldata params) external returns (bool)
+    function runMacro(IUserDefinedMacro m, bytes calldata params) external payable returns (bool)
     {
         ISuperfluid.Operation[] memory operations = buildBatchOperations(m, params);
-        bool retVal = _forwardBatchCall(operations);
+        bool retVal = _forwardBatchCall(operations, msg.value);
         m.postCheck(_host, params, msg.sender);
         return retVal;
     }

--- a/packages/ethereum-contracts/contracts/utils/MacroForwarder.sol
+++ b/packages/ethereum-contracts/contracts/utils/MacroForwarder.sol
@@ -7,8 +7,8 @@ import { ForwarderBase } from "../utils/ForwarderBase.sol";
 
 
 /**
- * @dev This is a trusted forwarder with high degree of extensibility through permission-less and user-defined "macro
- * contracts". This is a vanilla version without EIP-712 support.
+ * @dev This is a minimal version of a trusted forwarder with high degree of extensibility
+ * through permissionless and user-defined "macro contracts".
  */
 contract MacroForwarder is ForwarderBase {
     constructor(ISuperfluid host) ForwarderBase(host) {}

--- a/packages/ethereum-contracts/contracts/utils/MacroForwarder.sol
+++ b/packages/ethereum-contracts/contracts/utils/MacroForwarder.sol
@@ -34,7 +34,7 @@ contract MacroForwarder is ForwarderBase {
     function runMacro(IUserDefinedMacro m, bytes calldata params) external payable returns (bool)
     {
         ISuperfluid.Operation[] memory operations = buildBatchOperations(m, params);
-        bool retVal = _forwardBatchCall(operations, msg.value);
+        bool retVal = _forwardBatchCallWithValue(operations, msg.value);
         m.postCheck(_host, params, msg.sender);
         return retVal;
     }

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@superfluid-finance/ethereum-contracts",
     "description": " Ethereum contracts implementation for the Superfluid Protocol",
-    "version": "1.11.0",
+    "version": "1.11.1",
     "dependencies": {
         "@decentral.ee/web3-helpers": "0.5.3",
         "@nomiclabs/hardhat-ethers": "2.2.3",
@@ -18,7 +18,7 @@
         "@safe-global/safe-service-client": "^2.0.3",
         "@safe-global/safe-web3-lib": "^1.9.4",
         "@superfluid-finance/js-sdk": "^0.6.3",
-        "@superfluid-finance/metadata": "^1.5.1",
+        "@superfluid-finance/metadata": "^1.5.2",
         "async": "^3.2.6",
         "csv-writer": "^1.6.0",
         "ethers": "^5.7.2",

--- a/packages/ethereum-contracts/test/foundry/utils/MacroForwarder.t.sol
+++ b/packages/ethereum-contracts/test/foundry/utils/MacroForwarder.t.sol
@@ -65,7 +65,7 @@ contract GoodMacro is IUserDefinedMacro {
     function postCheck(ISuperfluid host, bytes memory params, address msgSender) external view { }
 
     // recommended view function for parameter encoding
-    function getParams(ISuperToken token, int96 flowRate, address[] calldata recipients) external pure returns (bytes memory) {
+    function paramsCreateFlows(ISuperToken token, int96 flowRate, address[] calldata recipients) external pure returns (bytes memory) {
         return abi.encode(token, flowRate, recipients);
     }
 }
@@ -103,7 +103,7 @@ contract MultiFlowDeleteMacro is IUserDefinedMacro {
     }
 
     // recommended view function for parameter encoding
-    function getParams(ISuperToken superToken, address sender, address[] memory receivers, uint256 minBalanceAfter)
+    function paramsDeleteFlows(ISuperToken superToken, address sender, address[] memory receivers, uint256 minBalanceAfter)
         external pure
         returns (bytes memory)
     {
@@ -121,7 +121,7 @@ contract MultiFlowDeleteMacro is IUserDefinedMacro {
 }
 
 /*
- * Example for a macro which has all the state needed, thus needs no additional calldata
+ * Example for a macro which has auint8 state needed, thus needs no additionalata
  * in the context of batch calls.
  * Important: state changes do NOT take place in the context of macro calls.
  */
@@ -169,6 +169,129 @@ contract StatefulMacro is IUserDefinedMacro {
     function postCheck(ISuperfluid host, bytes memory params, address msgSender) external view { }
 }
 
+/// Example for a macro which takes a fee for CFA operations
+contract PaidCFAOpsMacro is IUserDefinedMacro {
+    uint8 constant OP_CREATE_FLOW = 0;
+    uint8 constant OP_UPDATE_FLOW = 1;
+    uint8 constant OP_DELETE_FLOW = 2;
+
+    address payable immutable FEE_RECEIVER;
+    uint256 immutable FEE_AMOUNT;
+
+    error UnknownOperation();
+    error FeeOverpaid();
+
+    constructor(address payable feeReceiver, uint256 feeAmount) {
+        FEE_RECEIVER = feeReceiver;
+        FEE_AMOUNT = feeAmount;
+    }
+
+    function buildBatchOperations(ISuperfluid host, bytes memory params, address /*msgSender*/) external override view
+        returns (ISuperfluid.Operation[] memory operations)
+    {
+        IConstantFlowAgreementV1 cfa = IConstantFlowAgreementV1(address(host.getAgreementClass(
+            keccak256("org.superfluid-finance.agreements.ConstantFlowAgreement.v1")
+        )));
+
+        // first operation: take fee
+        operations = new ISuperfluid.Operation[](2);
+
+        operations[0] = ISuperfluid.Operation({
+            operationType: BatchOperation.OPERATION_TYPE_SIMPLE_FORWARD_CALL,
+            target: address(this),
+            data: abi.encodeCall(this.takeFee, (FEE_AMOUNT))
+        });
+
+        // second operation: manage flow
+        // param parsing is now a 2-step process.
+        // first we parse the op code, then depending on its value the arguments
+        (uint8 op, bytes memory opArgs) = abi.decode(params, (uint8, bytes));
+        if (op == OP_CREATE_FLOW) {
+            (ISuperToken token, address receiver, int96 flowRate) =
+                abi.decode(opArgs, (ISuperToken, address, int96));
+            operations[1] = ISuperfluid.Operation({
+                operationType: BatchOperation.OPERATION_TYPE_SUPERFLUID_CALL_AGREEMENT,
+                target: address(cfa),
+                data: abi.encode(
+                    abi.encodeCall(
+                        cfa.createFlow,
+                        (token, receiver, flowRate, new bytes(0))
+                    ),
+                    new bytes(0) // userdata
+                )
+            });
+        } else if (op == OP_UPDATE_FLOW) {
+            (ISuperToken token, address receiver, int96 flowRate) =
+                abi.decode(opArgs, (ISuperToken, address, int96));
+            operations[1] = ISuperfluid.Operation({
+                operationType: BatchOperation.OPERATION_TYPE_SUPERFLUID_CALL_AGREEMENT,
+                target: address(cfa),
+                data: abi.encode(
+                    abi.encodeCall(
+                        cfa.updateFlow,
+                        (token, receiver, flowRate, new bytes(0))
+                    ),
+                    new bytes(0) // userdata
+                )
+            });
+        } else if (op == OP_DELETE_FLOW) {
+            (ISuperToken token, address sender, address receiver) =
+                abi.decode(opArgs, (ISuperToken, address, address));
+            operations[1] = ISuperfluid.Operation({
+                operationType: BatchOperation.OPERATION_TYPE_SUPERFLUID_CALL_AGREEMENT,
+                target: address(cfa),
+                data: abi.encode(
+                    abi.encodeCall(
+                        cfa.deleteFlow,
+                        (token, sender, receiver, new bytes(0))
+                    ),
+                    new bytes(0) // userdata
+                )
+            });
+        } else {
+            revert UnknownOperation();
+        }
+    }
+
+    // Forwards a fee in native tokens to the FEE_RECEIVER.
+    // Will fail if less than `amount` is provided.
+    function takeFee(uint256 amount) external payable {
+        FEE_RECEIVER.transfer(amount);
+    }
+
+    // Don't allow native tokens in excess of the required fee
+    function postCheck(ISuperfluid /*host*/, bytes memory /*params*/, address /*msgSender*/) external view {
+        if (address(this).balance != 0) revert FeeOverpaid();
+    }
+
+    // recommended view functions for parameter construction
+    // since this is a multi-method macro, a dispatch logic using op codes is applied.
+
+    // view function for getting params for createFlow
+    function paramsCreateFlow(ISuperToken token, address receiver, int96 flowRate) external pure returns (bytes memory) {
+        return abi.encode(
+            OP_CREATE_FLOW, // op
+            abi.encode(token, receiver, flowRate) // opArgs
+        );
+    }
+
+    // view function for getting params for updateFlow
+    function paramsUpdateFlow(ISuperToken token, address receiver, int96 flowRate) external pure returns (bytes memory) {
+        return abi.encode(
+            OP_UPDATE_FLOW, // op
+            abi.encode(token, receiver, flowRate) // opArgs
+        );
+    }
+
+    // view function for getting params for deleteFlow
+    function paramsDeleteFlow(ISuperToken token, address sender, address receiver) external pure returns (bytes memory) {
+        return abi.encode(
+            OP_DELETE_FLOW, // op
+            abi.encode(token, sender, receiver) // opArgs
+        );
+    }
+}
+
 // ============== Test Contract ==============
 
 contract MacroForwarderTest is FoundrySuperfluidTester {
@@ -195,21 +318,7 @@ contract MacroForwarderTest is FoundrySuperfluidTester {
         vm.startPrank(admin);
         // NOTE! This is different from abi.encode(superToken, int96(42), [bob, carol]),
         //       which is a fixed array: address[2].
-        sf.macroForwarder.runMacro(m, abi.encode(superToken, int96(42), recipients));
-        assertEq(sf.cfa.getNetFlow(superToken, bob), 42);
-        assertEq(sf.cfa.getNetFlow(superToken, carol), 42);
-        vm.stopPrank();
-    }
-
-    function testGoodMacroUsingGetParams() external {
-        GoodMacro m = new GoodMacro();
-        address[] memory recipients = new address[](2);
-        recipients[0] = bob;
-        recipients[1] = carol;
-        vm.startPrank(admin);
-        // NOTE! This is different from abi.encode(superToken, int96(42), [bob, carol]),
-        //       which is a fixed array: address[2].
-        sf.macroForwarder.runMacro(m, m.getParams(superToken, int96(42), recipients));
+        sf.macroForwarder.runMacro(m, m.paramsCreateFlows(superToken, int96(42), recipients));
         assertEq(sf.cfa.getNetFlow(superToken, bob), 42);
         assertEq(sf.cfa.getNetFlow(superToken, carol), 42);
         vm.stopPrank();
@@ -244,7 +353,7 @@ contract MacroForwarderTest is FoundrySuperfluidTester {
             superToken.createFlow(recipients[i], 42);
         }
         // now batch-delete them
-        sf.macroForwarder.runMacro(m, m.getParams(superToken, sender, recipients, 0));
+        sf.macroForwarder.runMacro(m, m.paramsDeleteFlows(superToken, sender, recipients, 0));
 
         for (uint i = 0; i < recipients.length; ++i) {
             assertEq(sf.cfa.getNetFlow(superToken, recipients[i]), 0);
@@ -278,5 +387,43 @@ contract MacroForwarderTest is FoundrySuperfluidTester {
 
         // reasonable reward expectation: post check passes
         sf.macroForwarder.runMacro(m, abi.encode(superToken, alice, recipients, danBalanceBefore + (uint256(uint96(flowRate)) * 600)));
+    }
+
+    function testPaidCFAOps() external {
+        address payable feeReceiver = payable(address(0x420));
+        uint256 feeAmount = 1e15;
+        int96 flowRate1 = 42;
+        int96 flowRate2 = 42;
+
+        // alice needs funds for fee payment
+        vm.deal(alice, 1 ether);
+
+        PaidCFAOpsMacro m = new PaidCFAOpsMacro(feeReceiver, feeAmount);
+
+        vm.startPrank(alice);
+
+        // alice creates a flow to bob
+        sf.macroForwarder.runMacro{value: feeAmount}(
+            m,
+            m.paramsCreateFlow(superToken, bob, flowRate1)
+        );
+        assertEq(feeReceiver.balance, feeAmount, "unexpected fee receiver balance");
+        assertEq(sf.cfa.getNetFlow(superToken, bob), flowRate1);
+
+        // ... then updates that flow
+        sf.macroForwarder.runMacro{value: feeAmount}(
+            m,
+            m.paramsUpdateFlow(superToken, bob, flowRate2)
+        );
+        assertEq(feeReceiver.balance, feeAmount * 2, "unexpected fee receiver balance");
+        assertEq(sf.cfa.getNetFlow(superToken, bob), flowRate2);
+
+        // ... and finally deletes it
+        sf.macroForwarder.runMacro{value: feeAmount}(
+            m,
+            m.paramsDeleteFlow(superToken, alice, bob)
+        );
+        assertEq(feeReceiver.balance, feeAmount * 3, "unexpected fee receiver balance");
+        assertEq(sf.cfa.getNetFlow(superToken, bob), 0);
     }
 }

--- a/packages/ethereum-contracts/test/foundry/utils/MacroForwarder.t.sol
+++ b/packages/ethereum-contracts/test/foundry/utils/MacroForwarder.t.sol
@@ -260,6 +260,8 @@ contract PaidCFAOpsMacro is IUserDefinedMacro {
     }
 
     // Don't allow native tokens in excess of the required fee
+    // Note: this is safe only as long as this contract can't receive native tokens through other means,
+    // e.g. by implementing a fallback or receive function.
     function postCheck(ISuperfluid /*host*/, bytes memory /*params*/, address /*msgSender*/) external view {
         if (address(this).balance != 0) revert FeeOverpaid();
     }

--- a/packages/hot-fuzz/package.json
+++ b/packages/hot-fuzz/package.json
@@ -10,7 +10,7 @@
         "@openzeppelin/contracts": "4.9.6"
     },
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "^1.11.0"
+        "@superfluid-finance/ethereum-contracts": "^1.11.1"
     },
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo#readme",
     "license": "AGPL-3.0",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -7,13 +7,13 @@
         "path": false
     },
     "dependencies": {
-        "@superfluid-finance/metadata": "^1.5.1",
+        "@superfluid-finance/metadata": "^1.5.2",
         "@truffle/contract": "4.6.31",
         "auto-bind": "4.0.0",
         "node-fetch": "2.7.0"
     },
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "^1.11.0",
+        "@superfluid-finance/ethereum-contracts": "^1.11.1",
         "chai-as-promised": "^8.0.0",
         "webpack": "^5.94.0",
         "webpack-bundle-analyzer": "^4.10.2",

--- a/packages/metadata/CHANGELOG.md
+++ b/packages/metadata/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the metadata will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.5.2]
+### Changed
+- New (payable) MacroForwarder for all networks
+
 ## [v1.5.1]
 ### Added
 - VestingSchedulerV2 address on Base

--- a/packages/metadata/main/networks/list.cjs
+++ b/packages/metadata/main/networks/list.cjs
@@ -243,7 +243,7 @@ module.exports =
                 "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
             },
             "existentialNFTCloneFactory": "0xCd67c5bC1dfA3FF7d86b5ABc62A65C912Cbd2DA7",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 14820000,
         "logsQueryRange": 20000,
@@ -303,7 +303,7 @@ module.exports =
                 "wrapStrategy": "0xb4afa36BAd8c76976Dc77a21c9Ad711EF720eE4b"
             },
             "existentialNFTCloneFactory": "0x497aa106Da00BFa8f8BC266EF0793131930Fa630",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 11650500,
         "logsQueryRange": 10000,
@@ -364,7 +364,7 @@ module.exports =
                 "wrapStrategy": "0x0Cf060a501c0040e9CCC708eFE94079F501c6Bb4"
             },
             "existentialNFTCloneFactory": "0xCb0Ff4D0cA186f0Fc0301258066Fe3fA258417a6",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 4300000,
         "logsQueryRange": 50000,
@@ -424,7 +424,7 @@ module.exports =
                 "wrapStrategy": "0x342076aA957B0ec8bC1d3893af719b288eA31e61"
             },
             "existentialNFTCloneFactory": "0xF353978890204756fc5fa6dfbD16a91eac9E6f4d",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 7600000,
         "logsQueryRange": 50000,
@@ -484,7 +484,7 @@ module.exports =
                 "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
             },
             "existentialNFTCloneFactory": "0x94aE5f52E401A5766b0877d2f030cFb9C3792BD7",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 14700000,
         "logsQueryRange": 50000,
@@ -544,7 +544,7 @@ module.exports =
                 "wrapStrategy": "0x9e308cb079ae130790F604b1030cDf386670f199"
             },
             "existentialNFTCloneFactory": "0xe9F27eb8cdAaA0B01a4034e109496C3026b01bd9",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 18800000,
         "logsQueryRange": 5000,
@@ -603,7 +603,7 @@ module.exports =
                 "manager": "0x30aE282CF477E2eF28B14d0125aCEAd57Fe1d7a1",
                 "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
             },
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 15870000,
         "logsQueryRange": 10000,
@@ -657,7 +657,7 @@ module.exports =
             "toga": "0x9bCa3a623e7b2e248510d88B2894F54898d88F91",
             "batchLiquidator": "0xCb0Ff4D0cA186f0Fc0301258066Fe3fA258417a6",
             "existentialNFTCloneFactory": "0x051e766e2d8dc65ae2bFCF084A50AD0447634227",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 16393000,
         "logsQueryRange": 20000,
@@ -702,7 +702,7 @@ module.exports =
                 "wrapStrategy": "0xB29005319B0caB24cF6D4d24e8420E54BB29Cb0d"
             },
             "existentialNFTCloneFactory": "0x642332562BC60a4Bd9681E7bb1588f7456A497aC",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 1000000,
         "logsQueryRange": 20000,
@@ -752,7 +752,7 @@ module.exports =
             "toga": "0x1bF9D75d50fD828a93f69ECB06f2B85767792CEB",
             "batchLiquidator": "0x2eaa49BeB4Aa4fcC709DC14c0FA0fF1B292077b5",
             "superTokenFactory": "0xacFBED2bC9344C158DD3dC229b84Bd7220e7c673",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 2575000,
         "logsQueryRange": 50000,
@@ -788,7 +788,7 @@ module.exports =
             "toga": "0x38ed5512Ac11926bB697F4CF4eE0DD04358E2E7e",
             "batchLiquidator": "0x7BCE8e8401dc98E3Da26F1D701c3C2168b8e466c",
             "superTokenFactory": "0x184D999ea60e9b16fE4cCC1f756422114E9B663f",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 6500000,
         "logsQueryRange": 50000,

--- a/packages/metadata/main/networks/list.cjs
+++ b/packages/metadata/main/networks/list.cjs
@@ -28,7 +28,7 @@ module.exports =
                 "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
             },
             "existentialNFTCloneFactory": "0xF76529ddEE7AA7890323eCa40C212758DD93B888",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 3220000,
         "logsQueryRange": 50000,
@@ -71,7 +71,7 @@ module.exports =
             "superfluidLoader": "0x862F59081FC7907F940bE4227b9f485d700E6cdD",
             "batchLiquidator": "0x79aE8BF8EE9238d8E848F7dbBF74Ddb3365f6c11",
             "existentialNFTCloneFactory": "0x0D1F0d4629B722b4dFabd195c14F12f2095418d9",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 3322400,
         "logsQueryRange": 10000,
@@ -115,7 +115,7 @@ module.exports =
             },
             "superfluidLoader": "0x109412E3C84f0539b43d39dB691B08c90f58dC7c",
             "batchLiquidator": "0x9539B21cC67844417E80aE168bc28c831E7Ed271",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 6886559,
         "logsQueryRange": 50000,
@@ -164,7 +164,7 @@ module.exports =
             "superfluidLoader": "0xe25603df330027d91A0BAcc3e80a7f9e84930FC6",
             "batchLiquidator": "0x70bbB7a057A13070dF11d533e8f299357D778637",
             "superTokenFactory": "0x87560833d59Be057aFc63cFFa3fc531589Ba428F",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 2823800,
         "logsQueryRange": 50000,
@@ -198,7 +198,7 @@ module.exports =
             "superTokenFactory": "0x7447E94Dfe3d804a9f46Bf12838d467c912C8F6C",
             "superfluidLoader": "0x777Be25F9fdcA87e8a0E06Ad4be93d65429FCb9f",
             "batchLiquidator": "0x95043eC349476B413eF5c369c4d2454a1a65eaB9",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 10604500,
         "logsQueryRange": 50000,

--- a/packages/metadata/module/networks/list.js
+++ b/packages/metadata/module/networks/list.js
@@ -243,7 +243,7 @@ export default
                 "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
             },
             "existentialNFTCloneFactory": "0xCd67c5bC1dfA3FF7d86b5ABc62A65C912Cbd2DA7",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 14820000,
         "logsQueryRange": 20000,
@@ -303,7 +303,7 @@ export default
                 "wrapStrategy": "0xb4afa36BAd8c76976Dc77a21c9Ad711EF720eE4b"
             },
             "existentialNFTCloneFactory": "0x497aa106Da00BFa8f8BC266EF0793131930Fa630",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 11650500,
         "logsQueryRange": 10000,
@@ -364,7 +364,7 @@ export default
                 "wrapStrategy": "0x0Cf060a501c0040e9CCC708eFE94079F501c6Bb4"
             },
             "existentialNFTCloneFactory": "0xCb0Ff4D0cA186f0Fc0301258066Fe3fA258417a6",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 4300000,
         "logsQueryRange": 50000,
@@ -424,7 +424,7 @@ export default
                 "wrapStrategy": "0x342076aA957B0ec8bC1d3893af719b288eA31e61"
             },
             "existentialNFTCloneFactory": "0xF353978890204756fc5fa6dfbD16a91eac9E6f4d",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 7600000,
         "logsQueryRange": 50000,
@@ -484,7 +484,7 @@ export default
                 "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
             },
             "existentialNFTCloneFactory": "0x94aE5f52E401A5766b0877d2f030cFb9C3792BD7",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 14700000,
         "logsQueryRange": 50000,
@@ -544,7 +544,7 @@ export default
                 "wrapStrategy": "0x9e308cb079ae130790F604b1030cDf386670f199"
             },
             "existentialNFTCloneFactory": "0xe9F27eb8cdAaA0B01a4034e109496C3026b01bd9",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 18800000,
         "logsQueryRange": 5000,
@@ -603,7 +603,7 @@ export default
                 "manager": "0x30aE282CF477E2eF28B14d0125aCEAd57Fe1d7a1",
                 "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
             },
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 15870000,
         "logsQueryRange": 10000,
@@ -657,7 +657,7 @@ export default
             "toga": "0x9bCa3a623e7b2e248510d88B2894F54898d88F91",
             "batchLiquidator": "0xCb0Ff4D0cA186f0Fc0301258066Fe3fA258417a6",
             "existentialNFTCloneFactory": "0x051e766e2d8dc65ae2bFCF084A50AD0447634227",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 16393000,
         "logsQueryRange": 20000,
@@ -702,7 +702,7 @@ export default
                 "wrapStrategy": "0xB29005319B0caB24cF6D4d24e8420E54BB29Cb0d"
             },
             "existentialNFTCloneFactory": "0x642332562BC60a4Bd9681E7bb1588f7456A497aC",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 1000000,
         "logsQueryRange": 20000,
@@ -752,7 +752,7 @@ export default
             "toga": "0x1bF9D75d50fD828a93f69ECB06f2B85767792CEB",
             "batchLiquidator": "0x2eaa49BeB4Aa4fcC709DC14c0FA0fF1B292077b5",
             "superTokenFactory": "0xacFBED2bC9344C158DD3dC229b84Bd7220e7c673",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 2575000,
         "logsQueryRange": 50000,
@@ -788,7 +788,7 @@ export default
             "toga": "0x38ed5512Ac11926bB697F4CF4eE0DD04358E2E7e",
             "batchLiquidator": "0x7BCE8e8401dc98E3Da26F1D701c3C2168b8e466c",
             "superTokenFactory": "0x184D999ea60e9b16fE4cCC1f756422114E9B663f",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 6500000,
         "logsQueryRange": 50000,

--- a/packages/metadata/module/networks/list.js
+++ b/packages/metadata/module/networks/list.js
@@ -28,7 +28,7 @@ export default
                 "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
             },
             "existentialNFTCloneFactory": "0xF76529ddEE7AA7890323eCa40C212758DD93B888",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 3220000,
         "logsQueryRange": 50000,
@@ -71,7 +71,7 @@ export default
             "superfluidLoader": "0x862F59081FC7907F940bE4227b9f485d700E6cdD",
             "batchLiquidator": "0x79aE8BF8EE9238d8E848F7dbBF74Ddb3365f6c11",
             "existentialNFTCloneFactory": "0x0D1F0d4629B722b4dFabd195c14F12f2095418d9",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 3322400,
         "logsQueryRange": 10000,
@@ -115,7 +115,7 @@ export default
             },
             "superfluidLoader": "0x109412E3C84f0539b43d39dB691B08c90f58dC7c",
             "batchLiquidator": "0x9539B21cC67844417E80aE168bc28c831E7Ed271",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 6886559,
         "logsQueryRange": 50000,
@@ -164,7 +164,7 @@ export default
             "superfluidLoader": "0xe25603df330027d91A0BAcc3e80a7f9e84930FC6",
             "batchLiquidator": "0x70bbB7a057A13070dF11d533e8f299357D778637",
             "superTokenFactory": "0x87560833d59Be057aFc63cFFa3fc531589Ba428F",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 2823800,
         "logsQueryRange": 50000,
@@ -198,7 +198,7 @@ export default
             "superTokenFactory": "0x7447E94Dfe3d804a9f46Bf12838d467c912C8F6C",
             "superfluidLoader": "0x777Be25F9fdcA87e8a0E06Ad4be93d65429FCb9f",
             "batchLiquidator": "0x95043eC349476B413eF5c369c4d2454a1a65eaB9",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 10604500,
         "logsQueryRange": 50000,

--- a/packages/metadata/networks.json
+++ b/packages/metadata/networks.json
@@ -26,7 +26,7 @@
                 "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
             },
             "existentialNFTCloneFactory": "0xF76529ddEE7AA7890323eCa40C212758DD93B888",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 3220000,
         "logsQueryRange": 50000,
@@ -69,7 +69,7 @@
             "superfluidLoader": "0x862F59081FC7907F940bE4227b9f485d700E6cdD",
             "batchLiquidator": "0x79aE8BF8EE9238d8E848F7dbBF74Ddb3365f6c11",
             "existentialNFTCloneFactory": "0x0D1F0d4629B722b4dFabd195c14F12f2095418d9",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 3322400,
         "logsQueryRange": 10000,
@@ -113,7 +113,7 @@
             },
             "superfluidLoader": "0x109412E3C84f0539b43d39dB691B08c90f58dC7c",
             "batchLiquidator": "0x9539B21cC67844417E80aE168bc28c831E7Ed271",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 6886559,
         "logsQueryRange": 50000,
@@ -162,7 +162,7 @@
             "superfluidLoader": "0xe25603df330027d91A0BAcc3e80a7f9e84930FC6",
             "batchLiquidator": "0x70bbB7a057A13070dF11d533e8f299357D778637",
             "superTokenFactory": "0x87560833d59Be057aFc63cFFa3fc531589Ba428F",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 2823800,
         "logsQueryRange": 50000,
@@ -196,7 +196,7 @@
             "superTokenFactory": "0x7447E94Dfe3d804a9f46Bf12838d467c912C8F6C",
             "superfluidLoader": "0x777Be25F9fdcA87e8a0E06Ad4be93d65429FCb9f",
             "batchLiquidator": "0x95043eC349476B413eF5c369c4d2454a1a65eaB9",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 10604500,
         "logsQueryRange": 50000,

--- a/packages/metadata/networks.json
+++ b/packages/metadata/networks.json
@@ -241,7 +241,7 @@
                 "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
             },
             "existentialNFTCloneFactory": "0xCd67c5bC1dfA3FF7d86b5ABc62A65C912Cbd2DA7",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 14820000,
         "logsQueryRange": 20000,
@@ -301,7 +301,7 @@
                 "wrapStrategy": "0xb4afa36BAd8c76976Dc77a21c9Ad711EF720eE4b"
             },
             "existentialNFTCloneFactory": "0x497aa106Da00BFa8f8BC266EF0793131930Fa630",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 11650500,
         "logsQueryRange": 10000,
@@ -362,7 +362,7 @@
                 "wrapStrategy": "0x0Cf060a501c0040e9CCC708eFE94079F501c6Bb4"
             },
             "existentialNFTCloneFactory": "0xCb0Ff4D0cA186f0Fc0301258066Fe3fA258417a6",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 4300000,
         "logsQueryRange": 50000,
@@ -422,7 +422,7 @@
                 "wrapStrategy": "0x342076aA957B0ec8bC1d3893af719b288eA31e61"
             },
             "existentialNFTCloneFactory": "0xF353978890204756fc5fa6dfbD16a91eac9E6f4d",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 7600000,
         "logsQueryRange": 50000,
@@ -482,7 +482,7 @@
                 "wrapStrategy": "0x51FBAbD31A615E14b1bC12E9d887f60997264a4E"
             },
             "existentialNFTCloneFactory": "0x94aE5f52E401A5766b0877d2f030cFb9C3792BD7",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 14700000,
         "logsQueryRange": 50000,
@@ -542,7 +542,7 @@
                 "wrapStrategy": "0x9e308cb079ae130790F604b1030cDf386670f199"
             },
             "existentialNFTCloneFactory": "0xe9F27eb8cdAaA0B01a4034e109496C3026b01bd9",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 18800000,
         "logsQueryRange": 5000,
@@ -601,7 +601,7 @@
                 "manager": "0x30aE282CF477E2eF28B14d0125aCEAd57Fe1d7a1",
                 "wrapStrategy": "0x1D65c6d3AD39d454Ea8F682c49aE7744706eA96d"
             },
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 15870000,
         "logsQueryRange": 10000,
@@ -655,7 +655,7 @@
             "toga": "0x9bCa3a623e7b2e248510d88B2894F54898d88F91",
             "batchLiquidator": "0xCb0Ff4D0cA186f0Fc0301258066Fe3fA258417a6",
             "existentialNFTCloneFactory": "0x051e766e2d8dc65ae2bFCF084A50AD0447634227",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 16393000,
         "logsQueryRange": 20000,
@@ -700,7 +700,7 @@
                 "wrapStrategy": "0xB29005319B0caB24cF6D4d24e8420E54BB29Cb0d"
             },
             "existentialNFTCloneFactory": "0x642332562BC60a4Bd9681E7bb1588f7456A497aC",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 1000000,
         "logsQueryRange": 20000,
@@ -750,7 +750,7 @@
             "toga": "0x1bF9D75d50fD828a93f69ECB06f2B85767792CEB",
             "batchLiquidator": "0x2eaa49BeB4Aa4fcC709DC14c0FA0fF1B292077b5",
             "superTokenFactory": "0xacFBED2bC9344C158DD3dC229b84Bd7220e7c673",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 2575000,
         "logsQueryRange": 50000,
@@ -786,7 +786,7 @@
             "toga": "0x38ed5512Ac11926bB697F4CF4eE0DD04358E2E7e",
             "batchLiquidator": "0x7BCE8e8401dc98E3Da26F1D701c3C2168b8e466c",
             "superTokenFactory": "0x184D999ea60e9b16fE4cCC1f756422114E9B663f",
-            "macroForwarder": "0xfD01285b9435bc45C243E5e7F978E288B2912de6"
+            "macroForwarder": "0xFD0268E33111565dE546af2675351A4b1587F89F"
         },
         "startBlockV1": 6500000,
         "logsQueryRange": 50000,

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@superfluid-finance/metadata",
     "description": "Superfluid Metadata",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "author": "Superfluid",
     "bugs": "https://github.com/superfluid-finance/protocol-monorepo/issues",
     "homepage": "https://github.com/superfluid-finance/protocol-monorepo/tree/dev/packages/metadata#readme",

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -4,8 +4,8 @@
     "version": "0.8.0",
     "bugs": "https://github.com/superfluid-finance/protocol-monorepo/issues",
     "dependencies": {
-        "@superfluid-finance/ethereum-contracts": "1.11.0",
-        "@superfluid-finance/metadata": "^1.5.1",
+        "@superfluid-finance/ethereum-contracts": "1.11.1",
+        "@superfluid-finance/metadata": "^1.5.2",
         "browserify": "17.0.0",
         "graphql-request": "6.1.0",
         "lodash": "4.17.21",

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -9,7 +9,7 @@
         "mustache": "4.2.0"
     },
     "devDependencies": {
-        "@superfluid-finance/metadata": "^1.5.1",
+        "@superfluid-finance/metadata": "^1.5.2",
         "coingecko-api": "^1.0.10",
         "graphql": "^16.9.0",
         "graphql-request": "^6.1.0",


### PR DESCRIPTION
Since batch calls are payable, making the MacroForwarder payable allows the building of macros forwarding ETH.

This PR includes a test case with a new example macro offering more than one operation (create/update/delete flow), using the convention of _paramsX_ view functions for convenient parameter encoding.