### PR TITLE
[ETHEREUM-CONTRACTS] emit Transfer event in updateMemberUnits()

### DIFF
--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -14,7 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 - Fixed deployment of SimpleForwarder (solved an issue which caused batch operation `OPERATION_TYPE_SIMPLE_FORWARD_CALL` to always revert)
-- `SuperTokenV1Library.getFlowRate` and `SuperTokenV1Library.getFlowInfo` now also allow querying the flowrate between pools and pool members.
+- `SuperTokenV1Library.getFlowRate` and `SuperTokenV1Library.getFlowInfo` now also allow querying the flowrate between pools and pool members
+- Superfluid Pools now emit a Transfer event when changing units with `updateMemberUnits`.
 
 ### Breaking
 - `SuperTokenV1Library.distributeFlow`: return `actualFlowRate` instead of a bool

--- a/packages/ethereum-contracts/contracts/agreements/gdav1/SuperfluidPool.sol
+++ b/packages/ethereum-contracts/contracts/agreements/gdav1/SuperfluidPool.sol
@@ -389,7 +389,7 @@ contract SuperfluidPool is ISuperfluidPool, BeaconProxiable {
         uint128 oldUnits = _updateMemberUnits(memberAddr, newUnits);
 
         // Unit updates by admin are effectively mint/burn operations when viewed through the ERC20 lens.
-        // We thus emit a Transfer even from/to the zero address accordingly.
+        // We thus emit a Transfer event from/to the zero address accordingly.
         if (oldUnits < newUnits) {
             emit Transfer(address(0), memberAddr, newUnits - oldUnits);
         } else if (oldUnits > newUnits) {

--- a/packages/ethereum-contracts/contracts/agreements/gdav1/SuperfluidPool.sol
+++ b/packages/ethereum-contracts/contracts/agreements/gdav1/SuperfluidPool.sol
@@ -386,7 +386,15 @@ contract SuperfluidPool is ISuperfluidPool, BeaconProxiable {
     function updateMemberUnits(address memberAddr, uint128 newUnits) external returns (bool) {
         if (msg.sender != admin && msg.sender != address(GDA)) revert SUPERFLUID_POOL_NOT_POOL_ADMIN_OR_GDA();
 
-        _updateMemberUnits(memberAddr, newUnits);
+        uint128 oldUnits = _updateMemberUnits(memberAddr, newUnits);
+
+        // Unit updates by admin are effectively mint/burn operations when viewed through the ERC20 lens.
+        // We thus emit a Transfer even from/to the zero address accordingly.
+        if (oldUnits < newUnits) {
+            emit Transfer(address(0), memberAddr, newUnits - oldUnits);
+        } else if (oldUnits > newUnits) {
+            emit Transfer(memberAddr, address(0), oldUnits - newUnits);
+        }
 
         return true;
     }
@@ -433,7 +441,7 @@ contract SuperfluidPool is ISuperfluidPool, BeaconProxiable {
         }
     }
 
-    function _updateMemberUnits(address memberAddr, uint128 newUnits) internal returns (bool) {
+    function _updateMemberUnits(address memberAddr, uint128 newUnits) internal returns (uint128 oldUnits) {
         // @note normally we keep the sanitization in the external functions, but here
         // this is used in both updateMemberUnits and transfer
         if (GDA.isPool(superToken, memberAddr)) revert SUPERFLUID_POOL_NO_POOL_MEMBERS();
@@ -447,7 +455,7 @@ contract SuperfluidPool is ISuperfluidPool, BeaconProxiable {
         MemberData memory memberData = _membersData[memberAddr];
         PDPoolMember memory pdPoolMember = _memberDataToPDPoolMember(memberData);
 
-        uint128 oldUnits = memberData.ownedUnits;
+        oldUnits = memberData.ownedUnits;
 
         PDPoolMemberMU memory mu = PDPoolMemberMU(pdPoolIndex, pdPoolMember);
 
@@ -468,8 +476,6 @@ contract SuperfluidPool is ISuperfluidPool, BeaconProxiable {
         emit MemberUnitsUpdated(superToken, memberAddr, oldUnits, newUnits);
 
         _handlePoolMemberNFT(memberAddr, newUnits);
-
-        return true;
     }
 
     function _claimAll(address memberAddr, uint32 time) internal returns (int256 amount) {


### PR DESCRIPTION
Problem: now that the pools have proper ERC20 metadata, we also want tooling like explorers to properly render the token state.
Since explorers heavily rely on the Transfer event as trigger for balance updates, it becomes a problem that `updateMemberUnits` doesn't emit them. This PR changes that.

`updateMemberUnits` to a higher than previous amount is effectively a mint, thus a transfer from zero to the member.
`updateMemberUnits` to a lower than previous amount is effectively a burn, thus a transfer from the member to zero.

Already deployed to base-sepolia for test purposes.