### PR TITLE
Add `MT_FLOWRATE` type family and `MoneyEvent`

### DIFF
--- a/packages/spec-haskell/pkgs/semantic-money/semantic-money.cabal
+++ b/packages/spec-haskell/pkgs/semantic-money/semantic-money.cabal
@@ -27,6 +27,7 @@ library
     -- other-extensions:
     build-depends:
         base >=4.16.0.0 && <5,
+        containers,
         data-default
 
 test-suite semantic-money-test-suite
@@ -40,6 +41,7 @@ test-suite semantic-money-test-suite
     main-is:          Main.hs
     build-depends:
         base >=4.16.0.0 && <5,
+        containers,
         QuickCheck >=2.13,
         hspec >=2.0,
         HUnit >=1.6.0.0,

--- a/packages/spec-haskell/pkgs/semantic-money/src/Money/Theory/SemanticMoney.hs
+++ b/packages/spec-haskell/pkgs/semantic-money/src/Money/Theory/SemanticMoney.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DerivingStrategies     #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Money.Theory.SemanticMoney where
 
 import           Data.Default (Default (..))
 import           Data.Kind    (Type)
+import           Data.List
 
 
 -- | Type system trite: types used in semantic money
@@ -238,3 +240,97 @@ instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt, f 
       (r', er') = if u' == 0 then (0, r `mt_fr_mul_u` u) else r `mt_fr_mul_u_qr_u` (u, u')
       b' = fst . flow1 r' $ b
       a' = fst . flow1 (er' + flowRate a) $ a
+
+-- Represents a single snapshot of change
+data MoneyEvent mt = MoneyEvent
+  { eventTime      :: MT_TIME mt
+  , eventValueDelta     :: MT_VALUE mt  -- Discrete value change
+  , eventFlowDelta :: MT_FLOWRATE mt  -- Rate change
+  , eventIndicator     :: Int          -- For conflict resolution
+  }
+
+-- Representation of an accuont
+data AccountState mt = AccountState
+  { asTime       :: MT_TIME mt
+  , asValue      :: MT_VALUE mt
+  , asFlowRate   :: MT_FLOWRATE mt
+  }
+
+-- Make the types be Eq compatible
+instance ( MonetaryTypes mt
+         , Eq (MT_TIME mt)
+         , Eq (MT_VALUE mt)
+         , Eq (MT_FLOWRATE mt)
+         ) => Eq (MoneyEvent mt) where
+  a == b = eventTime a == eventTime b
+        && eventValueDelta a == eventValueDelta b
+        && eventFlowDelta a == eventFlowDelta b
+        && eventIndicator a == eventIndicator b
+
+  (/=) a b = not (a == b)
+
+instance ( MonetaryTypes mt
+         , Eq (MT_TIME mt)
+         , Eq (MT_VALUE mt)
+         , Eq (MT_FLOWRATE mt)
+         ) => Eq (AccountState mt) where
+  a == b = asTime a == asTime b
+        && asValue a == asValue b
+        && asFlowRate a == asFlowRate b
+
+  (/=) a b = not (a == b)
+
+-- Takes two AccountState and provides their delta as a MoneyEvent
+deltaEvents :: MonetaryTypes mt
+               => AccountState mt  -- Previous state
+               -> AccountState mt  -- Current state
+               -> Maybe (MoneyEvent mt)
+deltaEvents prev current
+  | asTime prev >= asTime current = Nothing
+  | otherwise = Just $ MoneyEvent
+      { eventTime = asTime current
+      ,  eventValueDelta = asValue current - (asValue prev + valueGrowth)
+      , eventFlowDelta = asFlowRate current - asFlowRate prev
+      , eventIndicator = 0
+      }
+  where
+    deltaT = asTime current - asTime prev
+    valueGrowth = asFlowRate prev `mt_fr_mul_t` fromIntegral deltaT
+
+-- Ensure that the snapshots are conflict-free
+ensureSnapshots :: (MonetaryTypes mt, Ord (MT_TIME mt))
+                 => [MoneyEvent mt]
+                 -> Either String [MoneyEvent mt]
+ensureSnapshots snaps = do
+  let sorted = sortOn eventTime snaps
+  validated <- validateTimeline sorted
+  pure $ settleSnapshots validated
+
+-- These two functions below are not required as of now, but they are
+-- useful for any real usage of MoneyEvents, since the logic is to
+-- have an ordering and operate on the snapshots
+
+-- Ensure that the set of snapshots is strictly ordered by timeline
+validateTimeline :: (MonetaryTypes mt, Ord (MT_TIME mt))
+                 => [MoneyEvent mt]
+                 -> Either String [MoneyEvent mt]
+validateTimeline [] = Right []
+validateTimeline [x] = Right [x]
+validateTimeline (x:y:xs)
+  | eventTime x > eventTime y = Left "Snapshots out of temporal order"
+  | eventTime x == eventTime y && eventIndicator x >= eventIndicator y =
+      Left "Conflicting snapshots: same timestamp with non-decreasing nonce"
+  | otherwise = (x:) <$> validateTimeline (y:xs)
+
+-- Merge and settle changes of snapshots that are in the same timeline
+settleSnapshots :: MonetaryTypes mt => [MoneyEvent mt] -> [MoneyEvent mt]
+settleSnapshots = map mergeGroup . groupBy sameTime
+  where
+    sameTime a b = eventTime a == eventTime b
+    mergeGroup [] = error "Empty group"
+    mergeGroup grp@(x:_) = MoneyEvent
+      { eventTime = eventTime x
+      , eventValueDelta = sum (map eventValueDelta grp)
+      , eventFlowDelta = sum (map eventFlowDelta grp)
+      , eventIndicator = maximum (map eventIndicator grp)
+      }

--- a/packages/spec-haskell/pkgs/semantic-money/src/Money/Theory/SemanticMoney.hs
+++ b/packages/spec-haskell/pkgs/semantic-money/src/Money/Theory/SemanticMoney.hs
@@ -257,17 +257,22 @@ data MoneyEvent' mt acci {- account index -} -- pdpi {- proportional distributio
 --  | Distribute     (MT_TIME mt) acci pdpi (MT_VALUE mt)    -- ^ One-to-many distribution of value.
 --  | DistributeFlow (MT_TIME mt) acci pdpi (MT_FLOWRATE mt) -- ^ One-to-many flow distribution of value.
 
+--
+-- Naive System and Its Event Processing
+--
+
 data NaiveSystem mt = MkNaiveSystem
   -- ^ accounts indexed by Int
   (IntMap.IntMap (BasicParticle mt))
   -- ^ pools indexed by Int
   (IntMap.IntMap (PDPoolIndex mt (BasicParticle mt)))
 
-processEvents :: forall mt t v.
+stepProcessEvents :: forall mt t v.
   (MonetaryTypes mt, MT_TIME mt ~ t, MT_VALUE mt ~ v) =>
+  NaiveSystem mt ->
   [MoneyEvent' mt Int {- account index -}] ->
   NaiveSystem mt
-processEvents = go (MkNaiveSystem IntMap.empty IntMap.empty)
+stepProcessEvents = go
   where go s [] = s
         go (MkNaiveSystem accs pools) (Transfer t fromIx toIx amount:xs) = go s' xs
           where
@@ -288,10 +293,34 @@ processEvents = go (MkNaiveSystem IntMap.empty IntMap.empty)
                     $ accs
             s' = MkNaiveSystem accs' pools
 
+naiveProcessEvents :: forall mt t v.
+  (MonetaryTypes mt, MT_TIME mt ~ t, MT_VALUE mt ~ v) =>
+  [MoneyEvent' mt Int {- account index -}] ->
+  NaiveSystem mt
+naiveProcessEvents = stepProcessEvents (MkNaiveSystem IntMap.empty IntMap.empty)
+
 naiveSystemSnapshot :: forall mt t v.
   (MonetaryTypes mt, MT_TIME mt ~ t, MT_VALUE mt ~ v) =>
-  NaiveSystem mt -> IntMap.IntMap (t -> v)
+  NaiveSystem mt ->
+  IntMap.IntMap (t -> v)
 naiveSystemSnapshot (MkNaiveSystem accs _) = rtb <$> accs
+
+-- --
+-- -- Snapshot-Based System and Its Event Processing
+-- --
+
+-- data SystemSnapshot mt
+
+-- data SnapshotBasedSystem mt
+
+-- sbsProcessEvents:: forall mt t v.
+--   (MonetaryTypes mt, MT_TIME mt ~ t, MT_VALUE mt ~ v) =>
+--   [MoneyEvent' mt Int {- account index -}] ->
+--   SnapshotBasedSystem mt ->
+--   SnapshotBasedSystem mt
+-- xProcessEvents = undefined
+
+
 
 -- Represents a single snapshot of change
 data MoneyEvent mt = MoneyEvent

--- a/packages/spec-haskell/pkgs/semantic-money/src/Money/Theory/SemanticMoney.hs
+++ b/packages/spec-haskell/pkgs/semantic-money/src/Money/Theory/SemanticMoney.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE DerivingStrategies     #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 module Money.Theory.SemanticMoney where
-
 import           Data.Default (Default (..))
 import           Data.Kind    (Type)
 import           Data.List
+-- containers
+import qualified Data.IntMap  as IntMap
 
 
 -- | Type system trite: types used in semantic money
@@ -19,6 +18,9 @@ class ( Integral (MT_TIME  mt)
       , Integral (MT_VALUE mt)
       , Integral (MT_UNIT  mt)
       , Integral (MT_FLOWRATE mt)
+      , Eq (MT_TIME mt)
+      , Eq (MT_VALUE mt)
+      , Eq (MT_FLOWRATE mt)
       ) => MonetaryTypes mt where
     mt_v_mul_t :: MT_VALUE mt -> MT_TIME mt -> MT_VALUE mt
     mt_v_mul_t v t = v * (fromInteger . toInteger) t
@@ -241,39 +243,81 @@ instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt, f 
       b' = fst . flow1 r' $ b
       a' = fst . flow1 (er' + flowRate a) $ a
 
+
+
+
+
+
+
+
+
+data MoneyEvent' mt acci {- account index -} -- pdpi {- proportional distribution pool member index -}
+  = Transfer       (MT_TIME mt) acci acci (MT_VALUE mt)    -- ^ One-to-one transfer of value.
+  | UpdateFlow     (MT_TIME mt) acci acci (MT_FLOWRATE mt) -- ^ One-to-one flow of value.
+--  | Distribute     (MT_TIME mt) acci pdpi (MT_VALUE mt)    -- ^ One-to-many distribution of value.
+--  | DistributeFlow (MT_TIME mt) acci pdpi (MT_FLOWRATE mt) -- ^ One-to-many flow distribution of value.
+
+data NaiveSystem mt = MkNaiveSystem
+  -- ^ accounts indexed by Int
+  (IntMap.IntMap (BasicParticle mt))
+  -- ^ pools indexed by Int
+  (IntMap.IntMap (PDPoolIndex mt (BasicParticle mt)))
+
+processEvents :: forall mt t v.
+  (MonetaryTypes mt, MT_TIME mt ~ t, MT_VALUE mt ~ v) =>
+  [MoneyEvent' mt Int {- account index -}] ->
+  NaiveSystem mt
+processEvents = go (MkNaiveSystem IntMap.empty IntMap.empty)
+  where go s [] = s
+        go (MkNaiveSystem accs pools) (Transfer t fromIx toIx amount:xs) = go s' xs
+          where
+            sender = IntMap.findWithDefault mempty fromIx accs
+            receiver = IntMap.findWithDefault mempty fromIx accs
+            (sender', receiver') = shift2 amount t (sender, receiver)
+            accs' = IntMap.insert fromIx sender'
+                    $ IntMap.insert toIx receiver'
+                    $ accs
+            s' = MkNaiveSystem accs' pools
+        go (MkNaiveSystem accs pools) (UpdateFlow t fromIx toIx rate:xs) = go s' xs
+          where
+            sender = IntMap.findWithDefault mempty fromIx accs
+            receiver = IntMap.findWithDefault mempty fromIx accs
+            (sender', receiver') = flow2 rate t (sender, receiver)
+            accs' = IntMap.insert fromIx sender'
+                    $ IntMap.insert toIx receiver'
+                    $ accs
+            s' = MkNaiveSystem accs' pools
+
+naiveSystemSnapshot :: forall mt t v.
+  (MonetaryTypes mt, MT_TIME mt ~ t, MT_VALUE mt ~ v) =>
+  NaiveSystem mt -> IntMap.IntMap (t -> v)
+naiveSystemSnapshot (MkNaiveSystem accs _) = rtb <$> accs
+
 -- Represents a single snapshot of change
 data MoneyEvent mt = MoneyEvent
-  { eventTime      :: MT_TIME mt
-  , eventValueDelta     :: MT_VALUE mt  -- Discrete value change
-  , eventFlowDelta :: MT_FLOWRATE mt  -- Rate change
-  , eventIndicator     :: Int          -- For conflict resolution
+  { eventTime       :: MT_TIME mt
+  , eventValueDelta :: MT_VALUE mt     -- Discrete value change
+  , eventFlowDelta  :: MT_FLOWRATE mt  -- Rate change
+  , eventIndicator  :: Int             -- For conflict resolution
   }
 
 -- Representation of an accuont
 data AccountState mt = AccountState
-  { asTime       :: MT_TIME mt
-  , asValue      :: MT_VALUE mt
-  , asFlowRate   :: MT_FLOWRATE mt
+  { asTime     :: MT_TIME mt
+  , asValue    :: MT_VALUE mt
+  , asFlowRate :: MT_FLOWRATE mt
   }
 
 -- Make the types be Eq compatible
-instance ( MonetaryTypes mt
-         , Eq (MT_TIME mt)
-         , Eq (MT_VALUE mt)
-         , Eq (MT_FLOWRATE mt)
-         ) => Eq (MoneyEvent mt) where
-  a == b = eventTime a == eventTime b
-        && eventValueDelta a == eventValueDelta b
-        && eventFlowDelta a == eventFlowDelta b
-        && eventIndicator a == eventIndicator b
+-- instance MonetaryTypes mt => Eq (MoneyEvent mt) where
+--   a == b = eventTime a == eventTime b
+--         && eventValueDelta a == eventValueDelta b
+--         && eventFlowDelta a == eventFlowDelta b
+--         && eventIndicator a == eventIndicator b
 
-  (/=) a b = not (a == b)
+--   (/=) a b = not (a == b)
 
-instance ( MonetaryTypes mt
-         , Eq (MT_TIME mt)
-         , Eq (MT_VALUE mt)
-         , Eq (MT_FLOWRATE mt)
-         ) => Eq (AccountState mt) where
+instance MonetaryTypes mt => Eq (AccountState mt) where
   a == b = asTime a == asTime b
         && asValue a == asValue b
         && asFlowRate a == asFlowRate b
@@ -289,7 +333,7 @@ deltaEvents prev current
   | asTime prev >= asTime current = Nothing
   | otherwise = Just $ MoneyEvent
       { eventTime = asTime current
-      ,  eventValueDelta = asValue current - (asValue prev + valueGrowth)
+      , eventValueDelta = asValue current - (asValue prev + valueGrowth)
       , eventFlowDelta = asFlowRate current - asFlowRate prev
       , eventIndicator = 0
       }

--- a/packages/spec-haskell/pkgs/semantic-money/src/Money/Theory/SemanticMoney.hs
+++ b/packages/spec-haskell/pkgs/semantic-money/src/Money/Theory/SemanticMoney.hs
@@ -16,7 +16,7 @@ import           Data.Kind    (Type)
 class ( Integral (MT_TIME  mt)
       , Integral (MT_VALUE mt)
       , Integral (MT_UNIT  mt)
-      -- FIXME add FlowRate type
+      , Integral (MT_FLOWRATE mt)
       ) => MonetaryTypes mt where
     mt_v_mul_t :: MT_VALUE mt -> MT_TIME mt -> MT_VALUE mt
     mt_v_mul_t v t = v * (fromInteger . toInteger) t
@@ -27,19 +27,29 @@ class ( Integral (MT_TIME  mt)
     mt_v_mul_u_qr_u :: MT_VALUE mt -> (MT_UNIT mt, MT_UNIT mt) -> (MT_VALUE mt, MT_VALUE mt)
     mt_v_mul_u_qr_u v (u1, u2) = (v * (fromInteger . toInteger) u1) `quotRem` (fromInteger . toInteger) u2
 
+
+    mt_fr_mul_t :: MT_FLOWRATE mt -> MT_TIME mt -> MT_VALUE mt
+    mt_fr_mul_t r t = (fromInteger . toInteger) r * (fromInteger . toInteger) t
+    mt_fr_mul_u :: MT_FLOWRATE mt -> MT_UNIT mt -> MT_FLOWRATE mt
+    mt_fr_mul_u r u = r * (fromInteger . toInteger) u
+    mt_fr_div_u :: MT_FLOWRATE mt -> MT_UNIT mt -> MT_FLOWRATE mt
+    mt_fr_div_u r u = let u' = (fromInteger . toInteger) u in r `div` u'
+    mt_fr_mul_u_qr_u :: MT_FLOWRATE mt -> (MT_UNIT mt, MT_UNIT mt) -> (MT_FLOWRATE mt, MT_FLOWRATE mt)
+    mt_fr_mul_u_qr_u r (u1, u2) = (r * (fromInteger . toInteger) u1) `quotRem` (fromInteger . toInteger) u2
+
     type family MT_TIME  mt = (t :: Type) | t -> mt
     type family MT_VALUE mt = (v :: Type) | v -> mt
     type family MT_UNIT  mt = (u :: Type) | u -> mt
-
+    type family MT_FLOWRATE mt = (fr :: Type) | fr -> mt
 --
 -- General Payment Primitives
 --
 
 class ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt
-      ) => MonetaryUnit mt t v mu | mu -> mt where
+      , fr ~ MT_FLOWRATE mt) => MonetaryUnit mt t v fr mu | mu -> mt where
     settle    :: t -> mu -> mu
     settledAt :: mu -> t
-    flowRate  :: mu -> v
+    flowRate  :: mu -> fr
     rtb       :: mu -> t -> v
 
  -- * On right side biased operations:
@@ -47,27 +57,27 @@ class ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt
  --   2) The adjustment must not produce new error term, or otherwise it would require recursive adjustments.
 
 class ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt
-      , MonetaryUnit mt t v ix, Monoid ix
-      ) => Index mt t v u ix | ix -> mt where
+      , MonetaryUnit mt t v fr ix, Monoid ix
+      ) => Index mt t v u fr ix | ix -> mt where
     shift1 :: v -> ix -> (ix, v)
-    flow1  :: v -> ix -> (ix, v)
+    flow1  :: fr -> ix -> (ix, fr)
 
 class ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt
-      , MonetaryUnit mt t v mp, Index mt t v u mp
-      ) => MonetaryParticle mt t v u mp where
+      , fr ~ MT_FLOWRATE mt, MonetaryUnit mt t v fr mp, Index mt t v u fr mp
+      ) => MonetaryParticle mt t v u  fr mp where
     -- align 2-primitive, right side biased
-    align2 :: forall a. Index mt t v u a => u -> u -> (mp, a) -> (mp, a)
+    align2 :: forall a. Index mt t v u fr a => u -> u -> (mp, a) -> (mp, a)
 
 -- polymorphic 2-primitives
 --
 
 -- 2-primitive higher order function
-prim2 :: (Index mt t v u a, Index mt t v u b)
+prim2 :: (Index mt t v u fr a, Index mt t v u  fr b)
       => ((a, b) -> (a, b)) -> t -> (a, b) -> (a, b)
 prim2 op t' (a, b) = op (settle t' a, settle t' b)
 
 -- shift2, right side biased error term adjustment
-shift2 :: (Index mt t v u a, Index mt t v u b)
+shift2 :: (Index mt t v u fr a, Index mt t v u fr b)
        => v -> t -> (a, b) -> (a, b)
 shift2 amount = prim2 op
     where op (a, b) = let (b', amount') = shift1 amount b
@@ -75,23 +85,23 @@ shift2 amount = prim2 op
                       in  (a', b')
 
 -- flow2, right side biased error term adjustment
-flow2 :: (Index mt t v u a, Index mt t v u b)
-      => v -> t -> (a, b) -> (a, b)
+flow2 :: (Index mt t v u fr a, Index mt t v u fr b)
+      => fr -> t -> (a, b) -> (a, b)
 flow2 r = prim2 op
     where op (a, b) = let (b', r') = flow1 r b
                           (a', _) = flow1 (-r') a
                       in  (a', b')
 
 -- shiftFlow2 for the left side (a), right side biased error term adjustment
-shiftFlow2a :: (Index mt t v u a, Index mt t v u b)
-            => v -> t -> (a, b) -> (a, b)
+shiftFlow2a :: (Index mt t v u fr a, Index mt t v u fr b)
+            => fr -> t -> (a, b) -> (a, b)
 shiftFlow2a dr t (a, b) = let ( _, b1) = flow2 (flowRate a) t (a, mempty)
                               (a', b2) = flow2 (-flowRate a + dr) t (a, mempty)
                           in  (a', b <> b1 <> b2)
 
 -- shiftFlow2 for the right side (b), right side biased error term adjustment
-shiftFlow2b :: (Index mt t v u a, Index mt t v u b)
-            => v -> t -> (a, b) -> (a, b)
+shiftFlow2b :: (Index mt t v u fr a, Index mt t v u fr b)
+            => fr -> t -> (a, b) -> (a, b)
 shiftFlow2b dr t (a, b) = let (a1,  _) = flow2 (-flowRate b) t (mempty, b)
                               (a2, b') = flow2 (flowRate b + dr) t (mempty, b)
                           in  (a <> a1 <> a2, b')
@@ -107,11 +117,11 @@ deriving newtype instance ( MonetaryTypes mt
                           , Semigroup wp ) => Semigroup (UniversalIndex mt wp)
 deriving newtype instance ( MonetaryTypes mt
                           , Monoid wp ) => Monoid (UniversalIndex mt wp)
-deriving newtype instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt
-                          , MonetaryUnit mt t v wp ) => MonetaryUnit mt t v (UniversalIndex mt wp)
-deriving newtype instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt
+deriving newtype instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, fr ~ MT_FLOWRATE mt
+                          , MonetaryUnit mt t v fr wp ) => MonetaryUnit mt t v fr (UniversalIndex mt wp)
+deriving newtype instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt, fr ~ MT_FLOWRATE mt
                           , Monoid wp
-                          , Index mt t v u wp ) => Index mt t v u (UniversalIndex mt wp)
+                          , Index mt t v u fr wp ) => Index mt t v u fr (UniversalIndex mt wp)
 
 --
 -- Proportional Distribution Pool
@@ -120,8 +130,8 @@ deriving newtype instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u
 data PDPoolIndex mt wp = PDPoolIndex { pdidx_total_units :: MT_UNIT mt
                                      , pdidx_wp          :: wp -- wrapped particle
                                      }
-instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt
-         , MonetaryUnit mt t v wp) => MonetaryUnit mt t v (PDPoolIndex mt wp) where
+instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, fr ~ MT_FLOWRATE mt
+         , MonetaryUnit mt t v fr wp) => MonetaryUnit mt t v fr (PDPoolIndex mt wp) where
     settle t' a@(PDPoolIndex _ mpi) = a { pdidx_wp = settle t' mpi }
     settledAt (PDPoolIndex _ mpi) = settledAt mpi
     flowRate (PDPoolIndex _ mpi) = flowRate mpi
@@ -136,25 +146,25 @@ instance (MonetaryTypes mt, Semigroup wp) => Semigroup (PDPoolIndex mt wp) where
 instance (MonetaryTypes mt, Monoid wp) => Monoid (PDPoolIndex mt wp) where
     mempty = PDPoolIndex 0 mempty
 
-instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt
-         , MonetaryParticle mt t v u wp) => Index mt t v u (PDPoolIndex mt wp) where
+instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt, fr ~ MT_FLOWRATE mt
+         , MonetaryParticle mt t v u fr wp) => Index mt t v u fr (PDPoolIndex mt wp) where
     shift1 x a@(PDPoolIndex tu mpi) = (a { pdidx_wp = mpi' }, x' `mt_v_mul_u` tu)
         where (mpi', x') = if tu == 0 then (mpi, 0) else shift1 (x `mt_v_div_u` tu) mpi
 
-    flow1 r' a@(PDPoolIndex tu mpi) = (a { pdidx_wp = mpi' }, r'' `mt_v_mul_u` tu)
-        where (mpi', r'') = if tu == 0 then flow1 0 mpi else flow1 (r' `mt_v_div_u` tu) mpi
+    flow1 r' a@(PDPoolIndex tu mpi) = (a { pdidx_wp = mpi' }, r'' `mt_fr_mul_u` tu)
+        where (mpi', r'') = if tu == 0 then flow1 0 mpi else flow1 (r' `mt_fr_div_u` tu) mpi
 
 data PDPoolMember mt wp = PDPoolMember { pdpm_owned_unit    :: MT_UNIT mt
                                        , pdpm_settled_value :: MT_VALUE mt
                                        , pdpm_synced_wp     :: wp
                                        }
-instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt
+instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt, fr ~ MT_FLOWRATE mt
          , Monoid wp ) => Default (PDPoolMember mt wp) where def = PDPoolMember 0 0 mempty
 type PDPoolMemberMU mt wp = (PDPoolIndex mt wp, PDPoolMember mt wp)
 
-pdpUpdateMember2 :: ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt
-                    , Index mt t v u a
-                    , MonetaryParticle mt t v u wp
+pdpUpdateMember2 :: ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt, fr ~ MT_FLOWRATE mt
+                    , Index mt t v u fr a
+                    , MonetaryParticle mt t v u fr wp
                     , mu ~ PDPoolMemberMU mt wp
                     ) => u -> t -> (a, mu) -> (a, mu)
 pdpUpdateMember2 u' t' (a, (b, pm))  = (a'', (b'', pm''))
@@ -164,8 +174,8 @@ pdpUpdateMember2 u' t' (a, (b, pm))  = (a'', (b'', pm''))
           b''  = PDPoolIndex tu' mpi'
           pm'' = pm' { pdpm_owned_unit = u', pdpm_synced_wp = mpi' }
 
-instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt
-         , MonetaryUnit mt t v wp) => MonetaryUnit mt t v (PDPoolMemberMU mt wp) where
+instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, fr ~ MT_FLOWRATE mt
+         , MonetaryUnit mt t v fr wp) => MonetaryUnit mt t v fr (PDPoolMemberMU mt wp) where
     settle t' (pix, pm) = (pix', pm')
         where sv' = rtb (pix, pm) t'
               pix'@(PDPoolIndex _ mpi') = settle t' pix
@@ -173,7 +183,7 @@ instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt
 
     settledAt (_, PDPoolMember _ _ mps) = settledAt mps
 
-    flowRate (PDPoolIndex _ mpi, PDPoolMember u _ _) = flowRate mpi `mt_v_mul_u` u
+    flowRate (PDPoolIndex _ mpi, PDPoolMember u _ _) = flowRate mpi `mt_fr_mul_u` u
 
     rtb (PDPoolIndex _ mpi, PDPoolMember u sv mps) t' = sv +
         -- let ti = bp_settled_at mpi
@@ -189,7 +199,7 @@ instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt
 
 data BasicParticle mt = BasicParticle { bp_settled_at    :: MT_TIME  mt
                                       , bp_settled_value :: MT_VALUE mt
-                                      , bp_flow_rate     :: MT_VALUE mt
+                                      , bp_flow_rate     :: MT_FLOWRATE mt
                                       }
 
 deriving stock instance MonetaryTypes mt => Eq (BasicParticle mt)
@@ -205,25 +215,26 @@ instance MonetaryTypes mt => Semigroup (BasicParticle mt) where
 instance MonetaryTypes mt => Monoid (BasicParticle mt) where
     mempty = BasicParticle 0 0 0
 
-instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt
-         ) => MonetaryUnit mt t v (BasicParticle mt) where
+instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, fr ~ MT_FLOWRATE mt
+         ) => MonetaryUnit mt t v fr (BasicParticle mt) where
     settle t' a = a { bp_settled_at = t'
                     , bp_settled_value = rtb a t'
                     }
     settledAt = bp_settled_at
     flowRate = bp_flow_rate
-    rtb (BasicParticle t s r) t' = r `mt_v_mul_t` (t' - t) + s
+    rtb (BasicParticle t s r) t' = r `mt_fr_mul_t` (t' - t) + s
 
-instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt
-         ) => Index mt t v u (BasicParticle mt) where
+instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt, fr ~ MT_FLOWRATE mt
+         ) => Index mt t v u fr (BasicParticle mt) where
 
     shift1 x a = (a { bp_settled_value = bp_settled_value a + x }, x)
     flow1 r' a = (a { bp_flow_rate = r' }, r')
 
-instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt
-         ) => MonetaryParticle mt t v u (BasicParticle mt) where
-    align2 u u' (b, a) = (b', a')
-        where r = flowRate b
-              (r', er') = if u' == 0 then (0, r `mt_v_mul_u` u) else r `mt_v_mul_u_qr_u` (u, u')
-              b' = fst . flow1 r' $ b
-              a' = fst . flow1 (er' + flowRate a) $ a
+instance ( MonetaryTypes mt, t ~ MT_TIME mt, v ~ MT_VALUE mt, u ~ MT_UNIT mt, f ~ MT_FLOWRATE mt ) =>
+  MonetaryParticle mt t v u f (BasicParticle mt) where
+  align2 u u' (b, a) = (b', a')
+    where
+      r = flowRate b
+      (r', er') = if u' == 0 then (0, r `mt_fr_mul_u` u) else r `mt_fr_mul_u_qr_u` (u, u')
+      b' = fst . flow1 r' $ b
+      a' = fst . flow1 (er' + flowRate a) $ a

--- a/packages/spec-haskell/pkgs/semantic-money/test/Money/Theory/SemanticMoney_prop.hs
+++ b/packages/spec-haskell/pkgs/semantic-money/test/Money/Theory/SemanticMoney_prop.hs
@@ -180,7 +180,7 @@ flow2_tests = describe "flow2 tests" $ do
 
 process_one_transfer_event :: Bool
 process_one_transfer_event = (s IntMap.! 0) 0 == -100 && (s IntMap.! 1) 0 == 100
-  where s = naiveSystemSnapshot . processEvents $
+  where s = naiveSystemSnapshot . naiveProcessEvents $
             ([ Transfer 0 {- t -} 0 1 100
              ] :: [MoneyEvent' TestMonetaryTypes Int])
 

--- a/packages/spec-haskell/pkgs/semantic-money/test/Money/Theory/SemanticMoney_prop.hs
+++ b/packages/spec-haskell/pkgs/semantic-money/test/Money/Theory/SemanticMoney_prop.hs
@@ -3,11 +3,13 @@
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 
 module Money.Theory.SemanticMoney_prop (tests) where
-
+--
 import           Data.Default
 import           Test.Hspec
 import           Test.QuickCheck
-
+-- containers
+import qualified Data.IntMap                    as IntMap
+--
 import           Money.Theory.SemanticMoney
 import           Money.Theory.TestMonetaryTypes
 
@@ -176,9 +178,19 @@ flow2_tests = describe "flow2 tests" $ do
     it "uidx:uidx shiftFlow2b" $ property uu_shiftFlow2b
     it "uidx:pdidx shiftFlow2b" $ property updp_shiftFlow2b
 
+process_one_transfer_event :: Bool
+process_one_transfer_event = (s IntMap.! 0) 0 == -100 && (s IntMap.! 1) 0 == 100
+  where s = naiveSystemSnapshot . processEvents $
+            ([ Transfer 0 {- t -} 0 1 100
+             ] :: [MoneyEvent' TestMonetaryTypes Int])
+
+navive_event_processing = describe "naive event processing" $ do
+  it "simple demonstrative case" process_one_transfer_event
+
 tests = describe "Semantic money properties" $ do
     mu_laws
     mp_monoid_laws
     one2one_tests
     one2n_pd_tests
     flow2_tests
+    navive_event_processing

--- a/packages/spec-haskell/pkgs/semantic-money/test/Money/Theory/SemanticMoney_prop.hs
+++ b/packages/spec-haskell/pkgs/semantic-money/test/Money/Theory/SemanticMoney_prop.hs
@@ -16,13 +16,13 @@ import           Money.Theory.TestMonetaryTypes
 -- Monetary Units Laws: settle-idempotency, constant-rtb
 --------------------------------------------------------------------------------
 
-mu_settle_idempotency :: ( MonetaryUnit TestMonetaryTypes TestTime TestMValue mu
+mu_settle_idempotency :: ( MonetaryUnit TestMonetaryTypes TestTime TestMValue TestMFlowRate mu
                       , Eq mu
                       ) => mu -> TestTime -> Bool
 mu_settle_idempotency a t =
     settledAt (settle t a) == t &&
     settle t a == settle t (settle t a)
-mu_constant_rtb :: ( MonetaryUnit TestMonetaryTypes TestTime TestMValue mu
+mu_constant_rtb :: ( MonetaryUnit TestMonetaryTypes TestTime TestMValue TestMFlowRate mu
                    ) => mu -> TestTime -> TestTime -> TestTime -> Bool
 mu_constant_rtb a t1 t2 t3 =
     rtb (settle t1 a) t3 == rtb a t3 &&
@@ -134,13 +134,13 @@ one2n_pd_tests = describe "1toN proportional distribution 2-primitives" $ do
 
 uu_flow2 (a :: TestUniversalIndex) (b :: TestUniversalIndex) t1 r1 t2 r2 t3 =
     flowRate b' == r2 && flowRate a' == -r2 &&
-    r1 `mt_v_mul_t` (t2 - t1) + r2 `mt_v_mul_t` (t3 - t2) == rtb b' t3 - rtb b t1
+    r1 `mt_fr_mul_t` (t2 - t1) + r2 `mt_fr_mul_t` (t3 - t2) == rtb b' t3 - rtb b t1
     where (a', b') = flow2 r2 t2 (flow2 r1 t1 (a, b))
 
 updp_flow2 (a :: TestUniversalIndex) t1 r1 t2 r2 t3 =
     flowRate b'' == r2 && flowRate a'' == -r2 &&
     flowRate (b'', b1') == r2 &&
-    r1 `mt_v_mul_t` (t2 - t1) + r2 `mt_v_mul_t` (t3 - t2) == rtb (b'', b1') t3 - rtb (b', b1') t1
+    r1 `mt_fr_mul_t` (t2 - t1) + r2 `mt_fr_mul_t` (t3 - t2) == rtb (b'', b1') t3 - rtb (b', b1') t1
     where (a', (b', b1')) = pdpUpdateMember2 1 t1 (a, (mempty :: TestPDPoolIndex, def))
           (a'', b'') = flow2 r2 t2 (flow2 r1 t1 (a', b'))
 
@@ -148,14 +148,14 @@ uu_shiftFlow2a (a :: TestUniversalIndex) (b :: TestUniversalIndex) t1 r1 t2 r2 t
     flowRate b' - flowRate b == r1 + r2 && flowRate a' - flowRate a == -r1 -r2 &&
     rtb b' t3 - rtb b t3 == rtb a t3 - rtb a' t3 &&
     -- for shift flow semantics: rtb b' t3 - (rtb b t3 - rtb b t1) - rtb b t1 == rtb b' t3 - rtb b t3
-    r1 `mt_v_mul_t` (t2 - t1) + (r1 + r2) `mt_v_mul_t` (t3 - t2) == rtb b' t3 - rtb b t3
+    r1 `mt_fr_mul_t` (t2 - t1) + (r1 + r2) `mt_fr_mul_t` (t3 - t2) == rtb b' t3 - rtb b t3
     where (a', b') = shiftFlow2a r2 t2 (shiftFlow2a r1 t1 (a, b))
 
 uu_shiftFlow2b (a :: TestUniversalIndex) (b :: TestUniversalIndex) t1 r1 t2 r2 t3 =
     flowRate b' - flowRate b == r1 + r2 && flowRate a' - flowRate a == -r1 -r2 &&
     rtb b' t3 - rtb b t3 == rtb a t3 - rtb a' t3 &&
     -- ditto
-    r1 `mt_v_mul_t` (t2 - t1) + (r1 + r2) `mt_v_mul_t` (t3 - t2) == rtb b' t3 - rtb b t3
+    r1 `mt_fr_mul_t` (t2 - t1) + (r1 + r2) `mt_fr_mul_t` (t3 - t2) == rtb b' t3 - rtb b t3
     where (a', b') = shiftFlow2b r2 t2 (shiftFlow2b r1 t1 (a, b))
 
 -- NOTE: updp_shiftFlow2a is an invalid property due to right side biansed error term adjustment.
@@ -165,7 +165,7 @@ updp_shiftFlow2b (a :: TestUniversalIndex) t1 r1 t2 r2 t3 =
     flowRate (b'', b1') == r1 + r2 &&
     rtb (b'', b1') t3 - rtb (b', b1') t3 == rtb a' t3 - rtb a'' t3 &&
     -- ditto
-    r1 `mt_v_mul_t` (t2 - t1) + (r1 + r2) `mt_v_mul_t` (t3 - t2) == rtb (b'', b1') t3 - rtb (b', b1') t3
+    r1 `mt_fr_mul_t` (t2 - t1) + (r1 + r2) `mt_fr_mul_t` (t3 - t2) == rtb (b'', b1') t3 - rtb (b', b1') t3
     where (a', (b', b1')) = pdpUpdateMember2 1 t1 (a, (mempty :: TestPDPoolIndex, def))
           (a'', b'') = shiftFlow2b r2 t2 (shiftFlow2b r1 t1 (a', b'))
 

--- a/packages/spec-haskell/pkgs/semantic-money/test/Money/Theory/TestMonetaryTypes.hs
+++ b/packages/spec-haskell/pkgs/semantic-money/test/Money/Theory/TestMonetaryTypes.hs
@@ -22,10 +22,15 @@ newtype TestMUnit = TestMUnit Integer deriving (Enum, Eq, Ord, Num, Real, Integr
 instance Arbitrary TestMUnit where
     arbitrary = TestMUnit <$> arbitrary
 
+newtype TestMFlowRate = TestMFlowRate Integer deriving (Enum, Eq, Ord, Num, Real, Integral, Show)
+instance Arbitrary TestMFlowRate where
+    arbitrary = TestMFlowRate <$> arbitrary
+
 data TestMonetaryTypes
 instance MonetaryTypes TestMonetaryTypes where
     type MT_TIME  TestMonetaryTypes = TestTime
     type MT_VALUE TestMonetaryTypes = TestMValue
+    type MT_FLOWRATE TestMonetaryTypes = TestMFlowRate
     type MT_UNIT  TestMonetaryTypes = TestMUnit
 deriving instance Show (BasicParticle TestMonetaryTypes)
 


### PR DESCRIPTION
This PR adds a FlowRate type family to `MonetaryTypes`, which had been mentioned as a FIXME previously.

Moreover, this PR also adds a new type of `MoneyEvent` that is able to take a snapshot of change whenever a change occurs. There's also a new representation of an account with `AccountState`. This one might be unnecessary, but it's mostly for exemplification purposes.

`deltaEvents` is the crucial function that provides the delta of two `AccountState` as a `MoneyEvent` but I've also added two other functions: `validateTimeline` and `settleSnapshots` which would be useful later on as we do more operations with `MoneyEvent`. 