### PR TITLE
Switch to monthly foundry again

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     foundry = {
-      url = "github:shazow/foundry.nix/stable";
+      url = "github:shazow/foundry.nix/monthly";
       inputs.flake-utils.follows = "flake-utils";
       inputs.nixpkgs.follows = "nixpkgs";
     };


### PR DESCRIPTION
The stable release of foundry link used in foundry.nix project has a link permanancy issue. I will report back.