### PR TITLE
[SUBGRAPH] Networks map update

### DIFF
--- a/packages/subgraph/tasks/vendorNetworkMap.json
+++ b/packages/subgraph/tasks/vendorNetworkMap.json
@@ -1,5 +1,5 @@
 {
-  "superfluid": ["polygon-mainnet", "xdai-mainnet", "base-mainnet", "optimism-mainnet", "arbitrum-one", "celo-mainnet", "bsc-mainnet", "avalanche-c", "optimism-sepolia", "scroll-sepolia", "scroll-mainnet", "degenchain", "base-sepolia"],
+  "superfluid": ["polygon-mainnet", "xdai-mainnet", "base-mainnet", "optimism-mainnet", "arbitrum-one", "celo-mainnet", "bsc-mainnet", "avalanche-c", "optimism-sepolia", "scroll-sepolia", "scroll-mainnet", "degenchain", "base-sepolia", "eth-sepolia", "avalanche-fuji"],
   "goldsky": ["polygon-mainnet", "xdai-mainnet", "eth-mainnet", "base-mainnet", "optimism-mainnet", "arbitrum-one", "bsc-mainnet", "avalanche-c", "optimism-sepolia", "scroll-sepolia", "scroll-mainnet", "eth-sepolia", "avalanche-fuji", "base-sepolia", "degenchain"],
   "graph": ["polygon-mainnet", "eth-mainnet", "celo-mainnet"]
 }

--- a/packages/subgraph/tasks/vendorNetworkMap.json
+++ b/packages/subgraph/tasks/vendorNetworkMap.json
@@ -1,6 +1,6 @@
 {
   "superfluid": ["polygon-mainnet", "xdai-mainnet", "base-mainnet", "optimism-mainnet", "arbitrum-one", "celo-mainnet", "bsc-mainnet", "avalanche-c", "optimism-sepolia", "scroll-sepolia", "scroll-mainnet", "degenchain", "base-sepolia", "eth-sepolia", "avalanche-fuji"],
   "goldsky": ["polygon-mainnet", "xdai-mainnet", "eth-mainnet", "base-mainnet", "optimism-mainnet", "arbitrum-one", "bsc-mainnet", "avalanche-c", "optimism-sepolia", "scroll-sepolia", "scroll-mainnet", "eth-sepolia", "avalanche-fuji", "base-sepolia", "degenchain"],
-  "graph": ["polygon-mainnet", "eth-mainnet", "celo-mainnet"]
+  "graph": ["polygon-mainnet", "xdai-mainnet", "base-mainnet", "optimism-mainnet", "arbitrum-one", "celo-mainnet", "bsc-mainnet", "avalanche-c", "scroll-mainnet", "degenchain"]
 }
 


### PR DESCRIPTION
- Adds `eth-sepolia` and `avalanche-fuji` to the list of networks supported by Superfluid hosted subgraphs
- Updates the mainnet networks supported on the Graph Network.