### PR TITLE
[SUBGRAPH] Avalanche Fuji CLI name

### DIFF
--- a/packages/subgraph/scripts/buildNetworkConfig.ts
+++ b/packages/subgraph/scripts/buildNetworkConfig.ts
@@ -21,6 +21,9 @@ const vendorCliNameExceptions: Record<string, Record<string, string>> = {
     "goldsky": {
         "xdai-mainnet": "xdai",
         "avalanche-fuji": "avalanche-testnet"
+    },
+    "superfluid": {
+        "avalanche-fuji": "avalanche-fuji"
     }
 }
 


### PR DESCRIPTION
This PR adds an exception for the generation of avalanche fuji subgraph manifests for hosted subgraphs.  The CLI name on Superfluid Metadata is `fuji`, the recognised name on graph protocol is `avalanche-fuji`.