### PR TITLE
ci(security): add minimal Gitleaks scan on PRs and pushes to dev/main

### DIFF
--- a/.github/workflows/ci.gitleaks.yml
+++ b/.github/workflows/ci.gitleaks.yml
@@ -1,0 +1,30 @@
+name: CI • Gitleaks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: Scan for secrets
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          config-path: .gitleaks.toml
+          args: --no-banner --redact
+

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+title = "Superfluid protocol-monorepo gitleaks configuration"
+
+[allowlist]
+description = "Global allowlist to reduce noise"
+paths = [
+  "''(^|/)yarn\\.lock$''",
+  "''(^|/)package-lock\\.json$''",
+  "''(^|/)\\.pnp\\..*$''",
+  "''(^|/)\\.yarn/.*$''",
+  "''(^|/).*\\.png$''",
+  "''(^|/).*\\.jpg$''",
+  "''(^|/).*\\.jpeg$''",
+  "''(^|/).*\\.gif$''",
+  "''(^|/).*\\.svg$''",
+  "''(^|/).*\\.ico$''",
+  "''(^|/).*\\.drawio$''",
+  "''(^|/).*\\.md$''"
+]
+
+# Using built-in gitleaks rules. Add repo-specific allowlists as needed.
+


### PR DESCRIPTION
Title: ci(security): add minimal Gitleaks scan on PRs and pushes to dev/main

Summary
- Adds a lightweight Gitleaks scan to catch secrets before merge.
- No SARIF/Code Scanning integration; keeps permissions minimal and aligns with current CI style.
- Includes a small `.gitleaks.toml` allowlist for common noise (lockfiles, images, markdown).

Rationale (Right-Sized, 2025 Best Practice)
- Secret scanning is standard across crypto repos and adds near-zero maintenance cost.
- This repo doesn’t currently run Gitleaks; this complements existing tests/fuzz workflows without adding heavy dashboards.

Scope
- Files: `.github/workflows/ci.gitleaks.yml`, `.gitleaks.toml`.
- No product code changes; workflow runs on PR and on pushes to `dev`/`main`.

Notes
- If maintainers later want GitHub Code Scanning UI, we can add a SARIF upload step in a follow-up.
