### PR TITLE
test(hot-fuzz): correct liquidity sum invariance formula in HotFuzzBase

### DIFF
--- a/packages/hot-fuzz/contracts/HotFuzzBase.sol
+++ b/packages/hot-fuzz/contracts/HotFuzzBase.sol
@@ -141,10 +141,9 @@ contract HotFuzzBase {
         address[] memory accounts = _listAccounts();
         for (uint i = 0; i < accounts.length; ++i) {
             (int256 avb, uint256 d, uint256 od, ) = superToken.realtimeBalanceOfNow(accounts[i]);
-            // FIXME: correct formula
-            // liquiditySum += avb + int256(d) - int256(od);
-            // current faulty one
-            liquiditySum += avb + (d > od ? int256(d) - int256(od) : int256(0));
+            // Sum of account availabilities adjusted by deposit (d) and owed deposit (od)
+            // Correct invariance: liquiditySum += avb + int256(d) - int256(od);
+            liquiditySum += avb + int256(d) - int256(od);
         }
         assert(int256(expectedTotalSupply) == liquiditySum);
         return int256(expectedTotalSupply) == liquiditySum;


### PR DESCRIPTION
Title: test(hot-fuzz): correct liquidity sum invariance formula in HotFuzzBase

Summary
- Fixes the liquidity sum invariance in `HotFuzzBase.sol` by using the correct formula:
  `liquiditySum += avb + int256(d) - int256(od);`
- Removes the prior clamped variant noted as faulty under a FIXME.

Rationale
- The comment already documents the intended formula; using a clamped delta hides real violations.
- This increases the signal of the fuzz harness without touching production contracts.

Scope
- File: `packages/hot-fuzz/contracts/HotFuzzBase.sol`
- Tests/tools only; no changes in protocol contracts or build flows.

Notes
- Open as draft to confirm maintainer preference; happy to adjust or close if there’s context for the clamped behavior.
