### PR TITLE
[CI] Replace actions/create-release@v1

### DIFF
--- a/.github/workflows/cd.packages-stable.create-release-drafts.yml
+++ b/.github/workflows/cd.packages-stable.create-release-drafts.yml
@@ -36,12 +36,12 @@ jobs:
 
       - name: Create ethereum-contracts stable release draft
         if: env.SHOULD_PUBLISH_ETHEREUM_CONTRACTS == 1
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ethereum-contracts@v${{ env.ETHEREUM_CONTRACTS_NEW_VERSION }}
-          release_name: ethereum-contracts@v${{ env.ETHEREUM_CONTRACTS_NEW_VERSION }}
+          name: ethereum-contracts@v${{ env.ETHEREUM_CONTRACTS_NEW_VERSION }}
           body_path: .github/RELEASE_TEMPLATE/release-notes.md
           draft: true
 
@@ -78,12 +78,12 @@ jobs:
 
       - name: Create subgraph stable release draft
         if: env.SHOULD_PUBLISH_SUBGRAPH == 1
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: subgraph@v${{ env.SUBGRAPH_NEW_VERSION }}
-          release_name: subgraph@v${{ env.SUBGRAPH_NEW_VERSION }}
+          name: subgraph@v${{ env.SUBGRAPH_NEW_VERSION }}
           body_path: .github/RELEASE_TEMPLATE/release-notes.md
           draft: true
 
@@ -111,12 +111,12 @@ jobs:
 
       - name: Create metadata stable release draft
         if: env.SHOULD_PUBLISH_METADATA == 1
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: metadata@v${{ env.METADATA_NEW_VERSION }}
-          release_name: metadata@v${{ env.METADATA_NEW_VERSION }}
+          name: metadata@v${{ env.METADATA_NEW_VERSION }}
           body: |
             Please refer to the CHANGELOG.md file in metadata package for more details on the changeset.
           draft: false
@@ -185,12 +185,12 @@ jobs:
 
       - name: Create sdk-core stable release draft
         if: needs.check-sdk-core-version.outputs.publish_sdk_core == 1
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: sdk-core@v${{ needs.check-sdk-core-version.outputs.sdk_core_new_version }}
-          release_name: sdk-core@v${{ needs.check-sdk-core-version.outputs.sdk_core_new_version }}
+          name: sdk-core@v${{ needs.check-sdk-core-version.outputs.sdk_core_new_version }}
           body_path: .github/RELEASE_TEMPLATE/release-notes.md
           draft: true
 
@@ -216,11 +216,11 @@ jobs:
 
       - name: Create sdk-redux stable release draft
         if: env.SHOULD_PUBLISH_SDK_REDUX == 1
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: sdk-redux@v${{ env.SDK_REDUX_NEW_VERSION }}
-          release_name: sdk-redux@v${{ env.SDK_REDUX_NEW_VERSION }}
+          name: sdk-redux@v${{ env.SDK_REDUX_NEW_VERSION }}
           body_path: .github/RELEASE_TEMPLATE/release-notes.md
           draft: true

--- a/.github/workflows/cd.packages-stable.create-release-drafts.yml
+++ b/.github/workflows/cd.packages-stable.create-release-drafts.yml
@@ -134,14 +134,18 @@ jobs:
     runs-on: ubuntu-22.04
 
     outputs:
-      publish_sdk_core: ${{ env.SHOULD_PUBLISH_SDK_CORE }}
-      sdk_core_new_version: ${{ env.SDK_CORE_NEW_VERSION }}
+      publish_sdk_core: ${{ steps.check-version.outputs.SHOULD_PUBLISH_SDK_CORE }}
+      sdk_core_new_version: ${{ steps.check-version.outputs.SDK_CORE_NEW_VERSION }}
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Check package versions
-        run: ./tasks/check-package-version.sh sdk-core SHOULD_PUBLISH_SDK_CORE SDK_CORE_NEW_VERSION >> "$GITHUB_ENV"
+        id: check-version
+        run: |
+          OUTPUT=$(./tasks/check-package-version.sh sdk-core SHOULD_PUBLISH_SDK_CORE SDK_CORE_NEW_VERSION)
+          echo "$OUTPUT" >> "$GITHUB_ENV"
+          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
 
   test-sdk-core-query-schema-against-deployed-v1-subgraphs:
     uses: ./.github/workflows/call.check-query-schema-against-subgraph.yml

--- a/.github/workflows/handler.publish-dev-release-packages.yml
+++ b/.github/workflows/handler.publish-dev-release-packages.yml
@@ -347,6 +347,11 @@ jobs:
           repository: superfluid-finance/build-scripts
           path: build-scripts
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
       - uses: DeterminateSystems/nix-installer-action@v13
 
       - name: Parse Tag


### PR DESCRIPTION
This PR:
-  Replaces `actions/create-release@v1` with the maintained `softprops/action-gh-release@v2`. There are no much changes, except the `release_name` that has been changed to `name`.
- Introduces $GITHUB_OUTPUT to pass outputs across jobs for SDK-core draft creation
- Add npm registry url to setup .npmrc for OIDC authentication for publishing `release`