### PR TITLE
[ETHEREUM-CONTRACTS] Add SparkYieldBackend - ERC4626 + deposit setting a referral

### DIFF
--- a/packages/ethereum-contracts/contracts/superfluid/ERC4626YieldBackend.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/ERC4626YieldBackend.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import { IERC4626 } from "@openzeppelin-v5/contracts/interfaces/IERC4626.sol";
 import { IYieldBackend } from "../interfaces/superfluid/IYieldBackend.sol";
 import { IERC20, ISuperToken } from "../interfaces/superfluid/ISuperfluid.sol";
-import { IERC4626 } from "@openzeppelin-v5/contracts/interfaces/IERC4626.sol";
 
 
 /**
@@ -31,7 +31,7 @@ contract ERC4626YieldBackend is IYieldBackend {
         ASSET_TOKEN.approve(address(VAULT), 0);
     }
 
-    function deposit(uint256 amount) external {
+    function deposit(uint256 amount) external virtual {
         require(amount > 0, "amount must be greater than 0");
         VAULT.deposit(amount, address(this));
     }

--- a/packages/ethereum-contracts/contracts/superfluid/SparkYieldBackend.sol
+++ b/packages/ethereum-contracts/contracts/superfluid/SparkYieldBackend.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { ERC4626YieldBackend } from "./ERC4626YieldBackend.sol";
+import { IERC4626 } from "@openzeppelin-v5/contracts/interfaces/IERC4626.sol";
+
+
+/**
+ * @title Minimal interface for Spark Protocol vaults with referral-tracked deposits.
+ * @dev Subset of the full Spark vault interface. Adds only the deposit(assets, receiver, referral)
+ *      overload and Referral event required by SparkYieldBackend.
+ */
+interface ISparkVault is IERC4626 {
+    event Referral(uint16 indexed referral, address indexed owner, uint256 assets, uint256 shares);
+
+    function deposit(uint256 assets, address receiver, uint256 minShares, uint16 referral)
+        external
+        returns (uint256 shares);
+}
+
+/**
+ * @title A SuperToken yield backend for Spark Protocol vaults (SparkVault).
+ * Extends ERC4626YieldBackend with a slight modification: provide a referral when calling deposit().
+ */
+contract SparkYieldBackend is ERC4626YieldBackend {
+    uint16 public immutable REFERRAL_ID;
+
+    /**
+     * @param vault The Spark vault (ERC4626 with referral deposit)
+     * @param surplusReceiver The address to receive surplus yield
+     * @param referralId The referral ID passed to deposit() for tracking
+     */
+    constructor(ISparkVault vault, address surplusReceiver, uint16 referralId)
+        ERC4626YieldBackend(IERC4626(address(vault)), surplusReceiver)
+    {
+        REFERRAL_ID = referralId;
+    }
+
+    function deposit(uint256 amount) external override {
+        require(amount > 0, "amount must be greater than 0");
+        // since the non-overloaded deposit() sets minShares to 0, we do that too
+        ISparkVault(address(VAULT)).deposit(amount, address(this), 0, REFERRAL_ID);
+    }
+}

--- a/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/AaveETHYieldBackendIntegration.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/AaveETHYieldBackendIntegration.t.sol
@@ -20,7 +20,6 @@ contract AaveETHYieldBackendIntegrationTest is Test {
 
     // Base network constants
     uint256 internal constant CHAIN_ID = 8453;
-    string internal constant RPC_URL = "https://mainnet.base.org";
 
     // Aave V3 Pool on Base (verified address)
     address internal constant AAVE_POOL = 0xA238Dd80C259a72e81d7e4664a9801593F98d1c5;
@@ -44,7 +43,7 @@ contract AaveETHYieldBackendIntegrationTest is Test {
 
     /// @notice Set up the test environment by forking the chain and deploying AaveETHYieldBackend
     function setUp() public {
-        vm.createSelectFork(RPC_URL);
+        vm.createSelectFork(vm.envOr("BASE_MAINNET_ARCHIVE_RPC_URL", string("https://mainnet.base.org")));
 
         // Verify chain id
         assertEq(block.chainid, CHAIN_ID, "Chainid mismatch");

--- a/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/AaveYieldBackendIntegration.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/AaveYieldBackendIntegration.t.sol
@@ -25,8 +25,8 @@ contract AaveYieldBackendIntegrationTest is YieldBackendIntegrationTestBase {
         return 8453;
     }
 
-    function _rpcUrl() internal pure override returns (string memory) {
-        return "https://mainnet.base.org";
+    function _rpcUrl() internal view override returns (string memory) {
+        return vm.envOr("BASE_MAINNET_ARCHIVE_RPC_URL", string("https://mainnet.base.org"));
     }
 
     function _superToken() internal pure override returns (address) {

--- a/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/ERC4626YieldBackendIntegration.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/ERC4626YieldBackendIntegration.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPLv3
 pragma solidity ^0.8.23;
 
-import { YieldBackendIntegrationTestBase } from "./YieldBackendIntegrationTestBase.sol";
-import { ERC4626YieldBackend } from "../../../../contracts/superfluid/ERC4626YieldBackend.sol";
-import { IYieldBackend } from "../../../../contracts/interfaces/superfluid/IYieldBackend.sol";
 import { IERC4626 } from "@openzeppelin-v5/contracts/interfaces/IERC4626.sol";
 import { IERC20Metadata } from "@openzeppelin-v5/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { ERC4626YieldBackend } from "../../../../contracts/superfluid/ERC4626YieldBackend.sol";
+import { IYieldBackend } from "../../../../contracts/interfaces/superfluid/IYieldBackend.sol";
+import { YieldBackendIntegrationTestBase } from "./YieldBackendIntegrationTestBase.sol";
 
 /**
  * @title ERC4626YieldBackendIntegrationTestBase
@@ -16,7 +16,7 @@ import { IERC20Metadata } from "@openzeppelin-v5/contracts/token/ERC20/extension
 abstract contract ERC4626YieldBackendIntegrationTestBase is YieldBackendIntegrationTestBase {
     function _vault() internal pure virtual returns (address);
 
-    function _createBackend() internal override returns (IYieldBackend) {
+    function _createBackend() internal virtual override returns (IYieldBackend) {
         return IYieldBackend(address(new ERC4626YieldBackend(IERC4626(_vault()), SURPLUS_RECEIVER)));
     }
 
@@ -48,7 +48,9 @@ abstract contract ERC4626YieldBackendIntegrationTestBase is YieldBackendIntegrat
 /// @notice ERC4626 yield backend integration tests with sUSDC vault on Base
 contract ERC4626YieldBackendIntegrationTestBaseSUSDC is ERC4626YieldBackendIntegrationTestBase {
     function _chainId() internal pure override returns (uint256) { return 8453; }
-    function _rpcUrl() internal pure override returns (string memory) { return "https://mainnet.base.org"; }
+    function _rpcUrl() internal view override returns (string memory) {
+        return vm.envOr("BASE_MAINNET_ARCHIVE_RPC_URL", string("https://mainnet.base.org"));
+    }
     function _vault() internal pure override returns (address) { return 0x3128a0F7f0ea68E7B7c9B00AFa7E41045828e858; }
     function _superToken() internal pure override returns (address) { return 0xD04383398dD2426297da660F9CCA3d439AF9ce1b; }
     function _underlyingToken() internal pure override returns (address) { return 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913; }
@@ -57,7 +59,9 @@ contract ERC4626YieldBackendIntegrationTestBaseSUSDC is ERC4626YieldBackendInteg
 /// @notice ERC4626 yield backend integration tests with sUSDC on Ethereum
 contract ERC4626YieldBackendIntegrationTestEthereumSUSDC is ERC4626YieldBackendIntegrationTestBase {
     function _chainId() internal pure override returns (uint256) { return 1; }
-    function _rpcUrl() internal pure override returns (string memory) { return "https://eth.drpc.org"; }
+    function _rpcUrl() internal view override returns (string memory) {
+        return vm.envOr("ETH_MAINNET_ARCHIVE_RPC_URL", string("https://eth.drpc.org"));
+    }
     function _vault() internal pure override returns (address) { return 0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE; }
     function _superToken() internal pure override returns (address) { return 0x1BA8603DA702602A8657980e825A6DAa03Dee93a; }
     function _underlyingToken() internal pure override returns (address) { return 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48; }

--- a/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/SparkYieldBackend.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/SparkYieldBackend.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity ^0.8.23;
+
+import { SparkYieldBackend, ISparkVault } from "../../../../contracts/superfluid/SparkYieldBackend.sol";
+import { IYieldBackend } from "../../../../contracts/interfaces/superfluid/IYieldBackend.sol";
+import { ERC4626YieldBackendIntegrationTestEthereumSUSDC } from "./ERC4626YieldBackendIntegration.t.sol";
+
+contract SparkYieldBackendUnitTestEthereumSUSDC is ERC4626YieldBackendIntegrationTestEthereumSUSDC {
+    uint16 internal constant REFERRAL_ID = 42;
+
+    event Referral(uint16 indexed referral, address indexed owner, uint256 assets, uint256 shares);
+
+    function _createBackend() internal override returns (IYieldBackend) {
+        return IYieldBackend(
+            address(new SparkYieldBackend(ISparkVault(_vault()), SURPLUS_RECEIVER, REFERRAL_ID))
+        );
+    }
+
+    function testDepositEmitsReferral() public {
+        vm.expectEmit(true, true, false, false, _vault());
+        emit Referral(REFERRAL_ID, address(superToken), 0, 0);
+        _enableYieldBackend();
+    }
+}

--- a/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/YieldBackendIntegrationTestBase.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/YieldBackendIntegrationTestBase.sol
@@ -30,7 +30,7 @@ abstract contract YieldBackendIntegrationTestBase is Test {
     // ============ Abstract hooks ============
 
     function _chainId() internal pure virtual returns (uint256);
-    function _rpcUrl() internal pure virtual returns (string memory);
+    function _rpcUrl() internal view virtual returns (string memory);
     function _superToken() internal pure virtual returns (address);
     function _underlyingToken() internal pure virtual returns (address);
     function _createBackend() internal virtual returns (IYieldBackend);


### PR DESCRIPTION
The Spark Vault implementation has an overloaded `deposit` method which also takes a referral code, see https://github.com/sparkdotfi/spark-vaults/blob/master/src/UsdcVault.sol#L386.
We want to use that, thus added a contract `SparkYieldBackend`.