### PR TITLE
github workflow: update codecov and its secret

### DIFF
--- a/.github/workflows/call.upload-coverage-reports.yml
+++ b/.github/workflows/call.upload-coverage-reports.yml
@@ -21,7 +21,7 @@ jobs:
           name: ethereum-contracts-coverage
           path: packages/ethereum-contracts/coverage
       - name: Upload ethereum-contracts-coverage to codecov
-        uses: codecov/codecov-action@v5.4.2
+        uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.codecov_token }}
           files: packages/ethereum-contracts/coverage/lcov.info
@@ -35,7 +35,7 @@ jobs:
           name: sdk-core-coverage
           path: packages/sdk-core/coverage
       - name: Upload sdk-core-coverage to codecov
-        uses: codecov/codecov-action@v5.4.2
+        uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.codecov_token }}
           files: packages/sdk-core/coverage/lcov.info

--- a/.github/workflows/call.upload-coverage-reports.yml
+++ b/.github/workflows/call.upload-coverage-reports.yml
@@ -2,9 +2,6 @@ name: Reusable Workflow | Upload Coverage Reports
 
 on:
   workflow_call:
-    secrets:
-      codecov_token:
-        required: true
 
 jobs:
   upload-coverage-reports:

--- a/.github/workflows/call.upload-coverage-reports.yml
+++ b/.github/workflows/call.upload-coverage-reports.yml
@@ -2,6 +2,10 @@ name: Reusable Workflow | Upload Coverage Reports
 
 on:
   workflow_call:
+    secrets:
+      codecov_token:
+        required: true
+
 
 jobs:
   upload-coverage-reports:

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -138,6 +138,7 @@ jobs:
     name: Upload Coverage Reports (Feature Branch)
     uses: ./.github/workflows/call.upload-coverage-reports.yml
     needs: [coverage-ethereum-contracts, coverage-sdk-core]
+    secrets: inherit
 
   # Note:
   #

--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -138,8 +138,6 @@ jobs:
     name: Upload Coverage Reports (Feature Branch)
     uses: ./.github/workflows/call.upload-coverage-reports.yml
     needs: [coverage-ethereum-contracts, coverage-sdk-core]
-    secrets:
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   # Note:
   #

--- a/.github/workflows/handler.publish-dev-release-packages.yml
+++ b/.github/workflows/handler.publish-dev-release-packages.yml
@@ -135,8 +135,6 @@ jobs:
     name: Upload Coverage Reports (Feature Branch)
     uses: ./.github/workflows/call.upload-coverage-reports.yml
     needs: [coverage-ethereum-contracts, coverage-sdk-core]
-    secrets:
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   all-packages-tested:
     name: All packages tested (Dev Branch)
@@ -377,7 +375,7 @@ jobs:
           yarn --cwd packages/ethereum-contracts build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Publish ethereum-contracts package
         if: env.PUBLISH_ETHEREUM_CONTRACTS == 1
         shell: bash

--- a/.github/workflows/handler.publish-dev-release-packages.yml
+++ b/.github/workflows/handler.publish-dev-release-packages.yml
@@ -135,6 +135,7 @@ jobs:
     name: Upload Coverage Reports (Feature Branch)
     uses: ./.github/workflows/call.upload-coverage-reports.yml
     needs: [coverage-ethereum-contracts, coverage-sdk-core]
+    secrets: inherit
 
   all-packages-tested:
     name: All packages tested (Dev Branch)


### PR DESCRIPTION
- Per https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token, no secrets is required for public repos.
- Update github action of codecov to 6.0.0