### PR TITLE
subgraph: add transfer spender and owed deposit fields

### DIFF
--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Stop indexing new `AccountTokenSnapshotLog` entries (schema retained; existing rows remain queryable)
 - Add `TransferEvent.operator`, populated from the paired ERC-777 `Sent` event; null for mint/burn/upgrade/downgrade paths that don't emit `Sent`
 - Add `FlowUpdatedEvent.receiverIsSuperApp` flag, sourced from the cached `Account.isSuperApp` on the receiver
+- Add `Stream.owedDeposit` and `FlowUpdatedEvent.owedDeposit`, sourced from the CFA's `getFlow` return tuple — exposes how much of the sender's deposit is credited to the receiving SuperApp
 
 ## [2.2.0]
 

--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fix AccountTokenSnapshotLog capturing intermediate state instead of final state after ATS updates
 - Skip deprecated TokenStatisticLog validation in integration tests
+- Stop indexing new `AccountTokenSnapshotLog` entries (schema retained; existing rows remain queryable)
+- Add `TransferEvent.operator`, populated from the paired ERC-777 `Sent` event; null for mint/burn/upgrade/downgrade paths that don't emit `Sent`
+- Add `FlowUpdatedEvent.receiverIsSuperApp` flag, sourced from the cached `Account.isSuperApp` on the receiver
 
 ## [2.2.0]
 

--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [2.3.1]
+
+- Rename `TransferEvent.operator` → `TransferEvent.spender`. The field is now populated only when the paired ERC-777 `Sent.operator` differs from `Sent.from` (i.e. `transferFrom` / `operatorSend`), matching ERC-20 allowance terminology. Self-transfers and mint/burn/upgrade/downgrade paths leave it null.
+- Fix the field (formerly `operator`) always being null on the 2.3.0 deployment. `handleSent` tried to load a `TransferEvent` that did not exist yet — `SuperToken._move` emits `Sent` before `Transfer`, and graph-node runs handlers in log order. `handleSent` now fully creates the `TransferEvent` itself (using `initializeEventEntity` with the Sent event and patching `logIndex` / `order` to the paired Transfer's log slot); `_createTransferEventEntity` (called by `handleTransfer`) skips creation when the entity already exists. `TransferEvent` stays `@entity(immutable: true)`.
+- Clarify `Stream.owedDeposit` docstring: the value reflects the most recent `FlowUpdatedEvent` for the stream and may lag the on-chain `getFlow` value if a downstream SuperApp flow changes without re-emitting `FlowUpdated` on the upstream slot.
+
+## [2.3.0]
+
 - Fix AccountTokenSnapshotLog capturing intermediate state instead of final state after ATS updates
 - Skip deprecated TokenStatisticLog validation in integration tests
 - Stop indexing new `AccountTokenSnapshotLog` entries (schema retained; existing rows remain queryable)

--- a/packages/subgraph/CHANGELOG.md
+++ b/packages/subgraph/CHANGELOG.md
@@ -10,7 +10,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Skip deprecated TokenStatisticLog validation in integration tests
 - Stop indexing new `AccountTokenSnapshotLog` entries (schema retained; existing rows remain queryable)
 - Add `TransferEvent.operator`, populated from the paired ERC-777 `Sent` event; null for mint/burn/upgrade/downgrade paths that don't emit `Sent`
-- Add `FlowUpdatedEvent.receiverIsSuperApp` flag, sourced from the cached `Account.isSuperApp` on the receiver
 - Add `Stream.owedDeposit` and `FlowUpdatedEvent.owedDeposit`, sourced from the CFA's `getFlow` return tuple — exposes how much of the sender's deposit is credited to the receiving SuperApp
 
 ## [2.2.0]

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@superfluid-finance/subgraph",
     "description": "Subgraph for the Superfluid Ethereum contracts.",
-    "version": "2.2.4",
+    "version": "2.3.1",
     "dependencies": {
         "@graphprotocol/graph-cli": "0.98.1",
         "@graphprotocol/graph-ts": "0.38.2",

--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -13,7 +13,7 @@
         "coingecko-api": "^1.0.10",
         "graphql": "^16.12.0",
         "graphql-request": "^6.1.0",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.1",
         "matchstick-as": "^0.6.0"
     },
     "homepage": "https://github.com/superfluid-org/protocol-monorepo/tree/dev/packages/subgraph",

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -1435,7 +1435,7 @@ type TransferEvent implements Event @entity(immutable: true) {
     addresses[0] = `token`
     addresses[1] = `from`
     addresses[2] = `to`
-    addresses[3] = `operator` (when present; sourced from the paired ERC-777 Sent event)
+    addresses[3] = `spender` (only included for allowance-based transfers where the spender differs from `from`, sourced from the paired ERC-777 Sent event)
     """
     addresses: [Bytes!]!
     blockNumber: BigInt!
@@ -1449,11 +1449,9 @@ type TransferEvent implements Event @entity(immutable: true) {
     token: Bytes!
 
     """
-    msg.sender to the SuperToken contract for this transfer, sourced from the paired ERC-777 Sent event.
-    Null for mint/burn paths, which don't emit Sent.
-    When `operator != from` and non-null, the transfer was a `transferFrom`/`operatorSend` (allowance-based).
+    The authorized spender that initiated this allowance-based transfer, sourced from the paired ERC-777 `Sent` event when `Sent.operator != Sent.from`. Indicates the transfer went through `transferFrom` / `operatorSend`. Null for self-transfers (`Sent.operator == Sent.from`) and for paths that emit no `Sent` (mint, burn, upgrade, downgrade).
     """
-    operator: Bytes
+    spender: Bytes
 }
 
 type TokenDowngradedEvent implements Event @entity(immutable: true) {
@@ -2012,8 +2010,7 @@ type Stream @entity(immutable: false) {
     deposit: BigInt!
 
     """
-    The owedDeposit on the active flow — the portion of `deposit` credited to
-    the receiving SuperApp. Zero for non-SuperApp receivers.
+    The owedDeposit reported by the CFA for this (sender, receiver, token) flow at the time of the most recent `FlowUpdatedEvent` for this stream. May lag the on-chain value if the receiving SuperApp's downstream changes without re-emitting `FlowUpdated` on this upstream. Zero for non-SuperApp receivers.
     """
     owedDeposit: BigInt!
 

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -150,6 +150,12 @@ type FlowUpdatedEvent implements Event @entity(immutable: true) {
     """
     totalAmountStreamedUntilTimestamp: BigInt!
 
+    """
+    Whether the stream receiver was flagged as a SuperApp at the time this event was processed.
+    Sourced from `Account.isSuperApp`, which is resolved once via `host.getAppManifest` during first account init; not refreshed thereafter.
+    """
+    receiverIsSuperApp: Boolean!
+
     # ---------------------------------- links ----------------------------------
     """
     The stream entity which is being modified.
@@ -1429,6 +1435,7 @@ type TransferEvent implements Event @entity(immutable: true) {
     addresses[0] = `token`
     addresses[1] = `from`
     addresses[2] = `to`
+    addresses[3] = `operator` (when present; sourced from the paired ERC-777 Sent event)
     """
     addresses: [Bytes!]!
     blockNumber: BigInt!
@@ -1440,6 +1447,13 @@ type TransferEvent implements Event @entity(immutable: true) {
     value: BigInt!
 
     token: Bytes!
+
+    """
+    msg.sender to the SuperToken contract for this transfer, sourced from the paired ERC-777 Sent event.
+    Null for mint/burn paths, which don't emit Sent.
+    When `operator != from` and non-null, the transfer was a `transferFrom`/`operatorSend` (allowance-based).
+    """
+    operator: Bytes
 }
 
 type TokenDowngradedEvent implements Event @entity(immutable: true) {

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -156,12 +156,6 @@ type FlowUpdatedEvent implements Event @entity(immutable: true) {
     """
     totalAmountStreamedUntilTimestamp: BigInt!
 
-    """
-    Whether the stream receiver was flagged as a SuperApp at the time this event was processed.
-    Sourced from `Account.isSuperApp`, which is resolved once via `host.getAppManifest` during first account init; not refreshed thereafter.
-    """
-    receiverIsSuperApp: Boolean!
-
     # ---------------------------------- links ----------------------------------
     """
     The stream entity which is being modified.

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -125,6 +125,12 @@ type FlowUpdatedEvent implements Event @entity(immutable: true) {
     deposit: BigInt!
 
     """
+    The owedDeposit on the flow at the time of this event — the portion of the
+    sender's `deposit` credited to the receiving SuperApp. Zero for non-SuperApp receivers.
+    """
+    owedDeposit: BigInt!
+
+    """
     Arbitrary bytes (additional data) passed upon flow creation.
     """
     userData: Bytes!
@@ -2010,6 +2016,12 @@ type Stream @entity(immutable: false) {
     # ---------------------------------- state ----------------------------------
     currentFlowRate: BigInt!
     deposit: BigInt!
+
+    """
+    The owedDeposit on the active flow — the portion of `deposit` credited to
+    the receiving SuperApp. Zero for non-SuperApp receivers.
+    """
+    owedDeposit: BigInt!
 
     """
     The amount streamed until `updatedAtTimestamp`/`updatedAtBlock`.

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -692,6 +692,7 @@ export function _createAccountTokenSnapshotLogEntity(
     tokenAddress: Address,
     eventName: string
 ): void {
+    return;
     if (accountAddress.equals(ZERO_ADDRESS)) {
         return;
     }

--- a/packages/subgraph/src/mappingHelpers.ts
+++ b/packages/subgraph/src/mappingHelpers.ts
@@ -304,6 +304,7 @@ export function getOrInitStream(event: FlowUpdated): Stream {
         stream.receiver = event.params.receiver.toHex();
         stream.currentFlowRate = BigInt.fromI32(0);
         stream.deposit = BigInt.fromI32(0);
+        stream.owedDeposit = BigInt.fromI32(0);
         stream.streamedUntilUpdatedAt = BigInt.fromI32(0);
         stream.updatedAtTimestamp = currentTimestamp;
         stream.updatedAtBlockNumber = event.block.number;

--- a/packages/subgraph/src/mappings/cfav1.ts
+++ b/packages/subgraph/src/mappings/cfav1.ts
@@ -6,7 +6,6 @@ import {
     IConstantFlowAgreementV1,
 } from "../../generated/ConstantFlowAgreementV1/IConstantFlowAgreementV1";
 import {
-    Account,
     FlowOperatorUpdatedEvent,
     FlowUpdatedEvent,
     StreamPeriod,
@@ -25,7 +24,6 @@ import {
     createEventID,
 } from "../utils";
 import {
-    getOrInitAccount,
     getOrInitFlowOperator,
     getOrInitStream,
     getOrInitStreamRevision,
@@ -118,8 +116,6 @@ export function handleFlowUpdated(event: FlowUpdated): void {
         streamRevision.save();
     }
 
-    const receiverAccount = getOrInitAccount(receiverAddress, event.block);
-
     // create event entity
     const flowUpdateEvent = _createFlowUpdatedEntity(
         event,
@@ -128,7 +124,6 @@ export function handleFlowUpdated(event: FlowUpdated): void {
         newStreamedUntilLastUpdate,
         newDeposit,
         newOwedDeposit,
-        receiverAccount
     );
     handleStreamPeriodUpdate(
         event,
@@ -416,7 +411,6 @@ function _createFlowUpdatedEntity(
     totalAmountStreamedUntilTimestamp: BigInt,
     deposit: BigInt,
     owedDeposit: BigInt,
-    receiverAccount: Account
 ): FlowUpdatedEvent {
     const ev = new FlowUpdatedEvent(createEventID("FlowUpdated", event));
     initializeEventEntity(ev, event, [
@@ -438,7 +432,6 @@ function _createFlowUpdatedEntity(
     ev.flowOperator = ZERO_ADDRESS;
     ev.deposit = deposit;
     ev.owedDeposit = owedDeposit;
-    ev.receiverIsSuperApp = receiverAccount.isSuperApp;
 
     const type = getFlowActionType(oldFlowRate, event.params.flowRate);
     ev.type = type;

--- a/packages/subgraph/src/mappings/cfav1.ts
+++ b/packages/subgraph/src/mappings/cfav1.ts
@@ -6,6 +6,7 @@ import {
     IConstantFlowAgreementV1,
 } from "../../generated/ConstantFlowAgreementV1/IConstantFlowAgreementV1";
 import {
+    Account,
     FlowOperatorUpdatedEvent,
     FlowUpdatedEvent,
     StreamPeriod,
@@ -24,6 +25,7 @@ import {
     createEventID,
 } from "../utils";
 import {
+    getOrInitAccount,
     getOrInitFlowOperator,
     getOrInitStream,
     getOrInitStreamRevision,
@@ -112,13 +114,16 @@ export function handleFlowUpdated(event: FlowUpdated): void {
         streamRevision.save();
     }
 
+    const receiverAccount = getOrInitAccount(receiverAddress, event.block);
+
     // create event entity
     const flowUpdateEvent = _createFlowUpdatedEntity(
         event,
         oldFlowRate,
         stream.id,
         newStreamedUntilLastUpdate,
-        newDeposit
+        newDeposit,
+        receiverAccount
     );
     handleStreamPeriodUpdate(
         event,
@@ -404,7 +409,8 @@ function _createFlowUpdatedEntity(
     oldFlowRate: BigInt,
     streamId: string,
     totalAmountStreamedUntilTimestamp: BigInt,
-    deposit: BigInt
+    deposit: BigInt,
+    receiverAccount: Account
 ): FlowUpdatedEvent {
     const ev = new FlowUpdatedEvent(createEventID("FlowUpdated", event));
     initializeEventEntity(ev, event, [
@@ -425,6 +431,7 @@ function _createFlowUpdatedEntity(
     ev.totalAmountStreamedUntilTimestamp = totalAmountStreamedUntilTimestamp;
     ev.flowOperator = ZERO_ADDRESS;
     ev.deposit = deposit;
+    ev.receiverIsSuperApp = receiverAccount.isSuperApp;
 
     const type = getFlowActionType(oldFlowRate, event.params.flowRate);
     ev.type = type;

--- a/packages/subgraph/src/mappings/cfav1.ts
+++ b/packages/subgraph/src/mappings/cfav1.ts
@@ -77,6 +77,9 @@ export function handleFlowUpdated(event: FlowUpdated): void {
     const newDeposit = depositResult.reverted
         ? BigInt.fromI32(0)
         : depositResult.value.value2; // deposit
+    const newOwedDeposit = depositResult.reverted
+        ? BigInt.fromI32(0)
+        : depositResult.value.value3; // owedDeposit
 
     const stream = getOrInitStream(event);
     const oldDeposit = stream.deposit;
@@ -96,6 +99,7 @@ export function handleFlowUpdated(event: FlowUpdated): void {
     stream.updatedAtTimestamp = currentTimestamp;
     stream.updatedAtBlockNumber = event.block.number;
     stream.deposit = newDeposit;
+    stream.owedDeposit = newOwedDeposit;
     stream.userData = event.params.userData;
     stream.save();
 
@@ -123,6 +127,7 @@ export function handleFlowUpdated(event: FlowUpdated): void {
         stream.id,
         newStreamedUntilLastUpdate,
         newDeposit,
+        newOwedDeposit,
         receiverAccount
     );
     handleStreamPeriodUpdate(
@@ -410,6 +415,7 @@ function _createFlowUpdatedEntity(
     streamId: string,
     totalAmountStreamedUntilTimestamp: BigInt,
     deposit: BigInt,
+    owedDeposit: BigInt,
     receiverAccount: Account
 ): FlowUpdatedEvent {
     const ev = new FlowUpdatedEvent(createEventID("FlowUpdated", event));
@@ -431,6 +437,7 @@ function _createFlowUpdatedEntity(
     ev.totalAmountStreamedUntilTimestamp = totalAmountStreamedUntilTimestamp;
     ev.flowOperator = ZERO_ADDRESS;
     ev.deposit = deposit;
+    ev.owedDeposit = owedDeposit;
     ev.receiverIsSuperApp = receiverAccount.isSuperApp;
 
     const type = getFlowActionType(oldFlowRate, event.params.flowRate);

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -15,7 +15,6 @@ import {
     ApprovalEvent,
     BurnedEvent,
     MintedEvent,
-    SentEvent,
     Stream,
     StreamRevision,
     TokenDowngradedEvent,
@@ -23,6 +22,7 @@ import {
     TransferEvent,
 } from "../../generated/schema";
 import {
+    BIG_INT_ONE,
     BIG_INT_ZERO,
     createEventID,
     initializeEventEntity,
@@ -185,7 +185,21 @@ export function handleSent(event: Sent): void {
         return;
     }
 
-    _createSentEventEntity(event);
+    const transferLogIndex = event.logIndex.plus(BIG_INT_ONE);
+    const transferEventId =
+        "Transfer-" +
+        event.transaction.hash.toHexString() +
+        "-" +
+        transferLogIndex.toString();
+    const transferEvent = TransferEvent.load(transferEventId);
+    if (transferEvent == null) {
+        return;
+    }
+    transferEvent.operator = event.params.operator;
+    transferEvent.addresses = transferEvent.addresses.concat([
+        event.params.operator,
+    ]);
+    transferEvent.save();
 }
 
 /**
@@ -362,24 +376,6 @@ function _createMintedEventEntity(event: Minted): void {
     ev.amount = event.params.amount;
     ev.data = event.params.data;
     ev.operatorData = event.params.operatorData;
-    ev.save();
-}
-
-function _createSentEventEntity(event: Sent): void {
-    const eventId = createEventID("Sent", event);
-    const ev = new SentEvent(eventId);
-    initializeEventEntity(ev, event, [
-        event.address,
-        event.params.operator,
-        event.params.to,
-    ]);
-    ev.amount = event.params.amount;
-    ev.data = event.params.data;
-    ev.token = event.address;
-    ev.operator = event.params.operator;
-    ev.operatorData = event.params.operatorData;
-    ev.from = event.params.from;
-    ev.to = event.params.to;
     ev.save();
 }
 

--- a/packages/subgraph/src/mappings/superToken.ts
+++ b/packages/subgraph/src/mappings/superToken.ts
@@ -25,6 +25,7 @@ import {
     BIG_INT_ONE,
     BIG_INT_ZERO,
     createEventID,
+    getOrder,
     initializeEventEntity,
     tokenHasValidHost,
     ZERO_ADDRESS,
@@ -179,27 +180,42 @@ export function handleTransfer(event: Transfer): void {
 }
 
 export function handleSent(event: Sent): void {
-    let hostAddress = getHostAddress();
-    let hasValidHost = tokenHasValidHost(hostAddress, event.address);
-    if (!hasValidHost) {
-        return;
-    }
+    const hostAddress = getHostAddress();
+    if (!tokenHasValidHost(hostAddress, event.address)) return;
 
+    // Only record the spender when it differs from the token owner. Self-transfers
+    // (transfer / send by the owner) carry no extra info.
+    if (event.params.operator.equals(event.params.from)) return;
+
+    // Sent is emitted at logIndex N immediately before the paired Transfer at N+1
+    // (see SuperToken._move). graph-node runs handlers in log order — the paired
+    // TransferEvent doesn't exist yet at this point. Fully create it here using
+    // the (identical) tx/block context from the Sent event; handleTransfer's
+    // _createTransferEventEntity then skips creation when the entity already
+    // exists. Same-block mutations are permitted on `@entity(immutable: true)`.
     const transferLogIndex = event.logIndex.plus(BIG_INT_ONE);
     const transferEventId =
         "Transfer-" +
         event.transaction.hash.toHexString() +
         "-" +
         transferLogIndex.toString();
-    const transferEvent = TransferEvent.load(transferEventId);
-    if (transferEvent == null) {
-        return;
-    }
-    transferEvent.operator = event.params.operator;
-    transferEvent.addresses = transferEvent.addresses.concat([
+    const ev = new TransferEvent(transferEventId);
+    initializeEventEntity(ev, event, [
+        event.address,
+        event.params.from,
+        event.params.to,
         event.params.operator,
     ]);
-    transferEvent.save();
+    // initializeEventEntity used the Sent event's logIndex (N); fix to the
+    // upcoming Transfer's logIndex (N+1).
+    ev.logIndex = transferLogIndex;
+    ev.order = getOrder(event.block.number, transferLogIndex);
+    ev.from = event.params.from.toHex();
+    ev.to = event.params.to.toHex();
+    ev.value = event.params.amount;
+    ev.token = event.address;
+    ev.spender = event.params.operator;
+    ev.save();
 }
 
 /**
@@ -402,6 +418,11 @@ function _createTokenDowngradedEventEntity(event: TokenDowngraded): void {
 
 function _createTransferEventEntity(event: Transfer): void {
     const eventId = createEventID("Transfer", event);
+    // If the paired `handleSent` already created this entity (spender stamped),
+    // skip creation here. handleSent emits with the same tx/block context, so
+    // the fields it set are already correct.
+    if (TransferEvent.load(eventId) != null) return;
+
     const ev = new TransferEvent(eventId);
     initializeEventEntity(ev, event, [
         event.address,

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -344,10 +344,8 @@ templates:
           handler: handleBurned
         - event: Minted(indexed address,indexed address,uint256,bytes,bytes)
           handler: handleMinted
-        # Not indexing Sent event anymore. Use Transfer instead.
-        # - event: Sent(indexed address,indexed address,indexed address,uint256,bytes,bytes)
-        #   handler: handleSent
-        #   receipt: true
+        - event: Sent(indexed address,indexed address,indexed address,uint256,bytes,bytes)
+          handler: handleSent
         - event: TokenUpgraded(indexed address,uint256)
           handler: handleTokenUpgraded
           # Decided not to do calls here as the RPC call might not always happen.

--- a/packages/subgraph/test/helpers/initializers.ts
+++ b/packages/subgraph/test/helpers/initializers.ts
@@ -187,7 +187,6 @@ export const getOrInitAccountTokenSnapshot = (
             account: { id: accountId },
             token: { id: tokenId },
             flowOperators: [],
-            accountTokenSnapshotLogs: [],
         };
     }
     return existingATS;

--- a/packages/subgraph/test/interfaces.ts
+++ b/packages/subgraph/test/interfaces.ts
@@ -316,30 +316,6 @@ export interface IAccountTokenSnapshot extends IBaseAggregateEntity {
     readonly account: ILightEntity;
     readonly token: ILightEntity;
     readonly flowOperators: ILightEntity[];
-    readonly accountTokenSnapshotLogs: IAccountTokenSnapshotLog[];
-}
-
-export interface IAccountTokenSnapshotLog {
-    readonly transactionHash: string;
-    readonly blockNumber: string;
-    readonly logIndex: string;
-    readonly timestamp: string;
-    readonly order: string;
-    readonly triggeredByEventName: string;
-    readonly balance: string;
-    readonly totalApprovedSubscriptions: number;
-    readonly totalNumberOfActiveStreams: number;
-    readonly totalNumberOfClosedStreams: number;
-    readonly totalSubscriptionsWithUnits: number;
-    readonly totalAmountStreamed: string;
-    readonly totalAmountStreamedIn: string;
-    readonly totalAmountStreamedOut: string;
-    readonly totalAmountTransferred: string;
-    readonly totalDeposit: string;
-    readonly totalInflowRate: string;
-    readonly totalNetFlowRate: string;
-    readonly totalOutflowRate: string;
-    readonly maybeCriticalAtTimestamp: string;
 }
 
 export interface ITokenStatistic extends IBaseAggregateEntity {

--- a/packages/subgraph/test/queries/aggregateQueries.ts
+++ b/packages/subgraph/test/queries/aggregateQueries.ts
@@ -28,32 +28,6 @@ export const getAccountTokenSnapshot = gql`
             token {
                 id
             }
-            accountTokenSnapshotLogs(
-                first: 1
-                orderBy: order
-                orderDirection: desc
-            ) {
-                blockNumber
-                transactionHash
-                balance
-                logIndex
-                order
-                timestamp
-                totalAmountStreamed
-                totalAmountStreamedIn
-                totalAmountStreamedOut
-                totalAmountTransferred
-                maybeCriticalAtTimestamp
-                totalApprovedSubscriptions
-                totalDeposit
-                totalInflowRate
-                totalNetFlowRate
-                totalNumberOfActiveStreams
-                totalNumberOfClosedStreams
-                totalOutflowRate
-                totalSubscriptionsWithUnits
-                triggeredByEventName
-            }
         }
     }
 `;

--- a/packages/subgraph/test/validation/aggregateValidators.ts
+++ b/packages/subgraph/test/validation/aggregateValidators.ts
@@ -5,7 +5,6 @@ import {
 } from "../helpers/helpers";
 import {
     IAccountTokenSnapshot,
-    IAccountTokenSnapshotLog,
     ITokenStatistic,
     ITokenStatisticLog,
 } from "../interfaces";
@@ -16,7 +15,7 @@ import {
 
 export const fetchATSAndValidate = async (
     expectedATSData: IAccountTokenSnapshot,
-    skipLogEntryValidation: boolean // Boolean flag to decide, whether to check log entries or not. Ignore IDA claim/distribute case
+    _skipLogEntryValidation: boolean // retained for signature compatibility; ATSLog indexing is deprecated
 ) => {
     const graphATS = await fetchEntityAndEnsureExistence<IAccountTokenSnapshot>(
         getAccountTokenSnapshot,
@@ -24,7 +23,6 @@ export const fetchATSAndValidate = async (
         "AccountTokenSnapshot"
     );
     validateATSEntity(graphATS, expectedATSData);
-    if (!skipLogEntryValidation) validateATSLogEntry(graphATS);
 };
 
 export const fetchTokenStatsAndValidate = async (
@@ -130,76 +128,6 @@ export const validateATSEntity = (
         graphATSData.totalAmountTransferredUntilUpdatedAt,
         "ATS: totalAmountTransferredUntilUpdatedAt error"
     ).to.equal(expectedTotalAmountTransferredUntilUpdatedAt);
-};
-
-export const validateATSLogEntry = (graphATSData: IAccountTokenSnapshot) => {
-    const accountTokenSnapshotLog: IAccountTokenSnapshotLog =
-        graphATSData.accountTokenSnapshotLogs[0];
-    expect(
-        graphATSData.maybeCriticalAtTimestamp,
-        "ATSLog: maybeCriticalAtTimestamp error"
-    ).to.equal(accountTokenSnapshotLog.maybeCriticalAtTimestamp);
-    expect(
-        graphATSData.totalNumberOfActiveStreams,
-        "ATSLog: totalNumberOfActiveStreams error"
-    ).to.equal(accountTokenSnapshotLog.totalNumberOfActiveStreams);
-    expect(
-        graphATSData.totalNumberOfClosedStreams,
-        "ATSLog: totalNumberOfClosedStreams error"
-    ).to.equal(accountTokenSnapshotLog.totalNumberOfClosedStreams);
-    expect(
-        graphATSData.totalSubscriptionsWithUnits,
-        "ATSLog: totalSubscriptionWithUnits error"
-    ).to.equal(accountTokenSnapshotLog.totalSubscriptionsWithUnits);
-    expect(
-        graphATSData.totalApprovedSubscriptions,
-        "ATSLog: totalApprovedSubscriptions error"
-    ).to.equal(accountTokenSnapshotLog.totalApprovedSubscriptions);
-    expect(
-        graphATSData.balanceUntilUpdatedAt,
-        "ATSLog: balanceUntilUpdatedAt error"
-    ).to.equal(accountTokenSnapshotLog.balance);
-    expect(
-        graphATSData.totalNetFlowRate,
-        "ATSLog: totalNetFlowRate error"
-    ).to.equal(accountTokenSnapshotLog.totalNetFlowRate);
-
-    expect(
-        graphATSData.totalInflowRate,
-        "ATSLog: totalInflowRate error"
-    ).to.equal(accountTokenSnapshotLog.totalInflowRate);
-    expect(graphATSData.totalDeposit, "ATSLog: totalDeposit error").to.equal(
-        accountTokenSnapshotLog.totalDeposit
-    );
-    expect(
-        graphATSData.totalOutflowRate,
-        "ATSLog: totalOutflowRate error"
-    ).to.equal(accountTokenSnapshotLog.totalOutflowRate);
-    expect(
-        graphATSData.totalAmountStreamedUntilUpdatedAt,
-        "ATSLog: totalAmountStreamedUntilUpdatedAt error"
-    ).to.equal(accountTokenSnapshotLog.totalAmountStreamed);
-    expect(
-        graphATSData.totalAmountStreamedInUntilUpdatedAt,
-        "ATSLog: totalAmountStreamedInUntilUpdatedAt error"
-    ).to.equal(accountTokenSnapshotLog.totalAmountStreamedIn);
-    expect(
-        graphATSData.totalAmountStreamedOutUntilUpdatedAt,
-        "ATSLog: totalAmountStreamedOutUntilUpdatedAt error"
-    ).to.equal(accountTokenSnapshotLog.totalAmountStreamedOut);
-    expect(
-        graphATSData.totalAmountTransferredUntilUpdatedAt,
-        "ATSLog: totalAmountTransferredUntilUpdatedAt error"
-    ).to.equal(accountTokenSnapshotLog.totalAmountTransferred);
-    expect(
-        graphATSData.updatedAtTimestamp,
-        "ATSLog: updatedAtTimestamp error"
-    ).to.equal(accountTokenSnapshotLog.timestamp);
-
-    expect(
-        graphATSData.updatedAtBlockNumber,
-        "ATSLog: updatedAtBlockNumber error"
-    ).to.equal(accountTokenSnapshotLog.blockNumber);
 };
 
 /**

--- a/packages/subgraph/tests/cfav1/cfav1.helper.ts
+++ b/packages/subgraph/tests/cfav1/cfav1.helper.ts
@@ -214,10 +214,14 @@ export function createFlowUpdatedEventWithMocks(
     assert.fieldEquals("FlowUpdatedEvent", id, "totalSenderFlowRate", totalSenderFlowRate.toString());
     assert.fieldEquals("FlowUpdatedEvent", id, "totalReceiverFlowRate", totalReceiverFlowRate.toString());
     assert.fieldEquals("FlowUpdatedEvent", id, "deposit", deposit.toString());
+    assert.fieldEquals("FlowUpdatedEvent", id, "owedDeposit", expectedOwedDeposit.toString());
     assert.fieldEquals("FlowUpdatedEvent", id, "userData", userData.toHexString());
     assert.fieldEquals("FlowUpdatedEvent", id, "oldFlowRate", oldFlowRate.toString());
     assert.fieldEquals("FlowUpdatedEvent", id, "type", expectedType);
     assert.fieldEquals("FlowUpdatedEvent", id, "stream", streamId);
+
+    assert.fieldEquals("Stream", streamId, "deposit", deposit.toString());
+    assert.fieldEquals("Stream", streamId, "owedDeposit", expectedOwedDeposit.toString());
 
     // Assert account token snapshots were created for sender and receiver
     const senderAtsId = getAccountTokenSnapshotID(Address.fromString(sender), Address.fromString(superToken));

--- a/packages/subgraph/tests/cfav1/event/cfav1.event.test.ts
+++ b/packages/subgraph/tests/cfav1/event/cfav1.event.test.ts
@@ -61,6 +61,23 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
         );
     });
 
+    test("handleFlowUpdated() - Should persist non-zero owedDeposit on Stream and FlowUpdatedEvent", () => {
+        modifyFlowAndAssertFlowUpdatedEventProperties(
+            maticXAddress,              // superToken
+            maticXName,                 // tokenName
+            maticXSymbol,               // tokenSymbol
+            alice,                      // sender
+            bob,                        // receiver
+            ZERO_ADDRESS,               // underlyingToken
+            "0",                        // expectedType
+            BigInt.fromI32(123456),     // expectedOwedDeposit (non-zero: receiver is a SuperApp)
+            initialFlowRate,            // flowRate
+            BIG_INT_ZERO,               // previousSenderFlowRate
+            BIG_INT_ZERO,               // previousReceiverFlowRate
+            ""                          // userData
+        );
+    });
+
     test("handleFlowUpdated() - Should create new FlowUpdatedEvent entities (create => update)", () => {
         // create flow
         modifyFlowAndAssertFlowUpdatedEventProperties(

--- a/packages/subgraph/tests/cfav1/event/cfav1.event.test.ts
+++ b/packages/subgraph/tests/cfav1/event/cfav1.event.test.ts
@@ -6,9 +6,11 @@ import {
     describe,
     test,
 } from "matchstick-as/assembly/index";
-import { handleFlowOperatorUpdated } from "../../../src/mappings/cfav1";
+import { Account } from "../../../generated/schema";
+import { handleFlowOperatorUpdated, handleFlowUpdated } from "../../../src/mappings/cfav1";
 import {
     BIG_INT_ZERO,
+    createEventID,
     getFlowOperatorID,
     ZERO_ADDRESS,
 } from "../../../src/utils";
@@ -16,15 +18,23 @@ import { assertEventBaseProperties } from "../../assertionHelpers";
 import {
     alice,
     bob,
+    DEFAULT_DECIMALS,
     maticXAddress,
     maticXName,
     maticXSymbol,
 } from "../../constants";
 import {
     createFlowOperatorUpdatedEvent,
+    createFlowUpdatedEvent,
+    getDeposit,
     modifyFlowAndAssertFlowUpdatedEventProperties,
 } from "../cfav1.helper";
-import { mockedApprove } from "../../mockedFunctions";
+import { createSuperToken } from "../../mockedEntities";
+import { stringToBytes } from "../../converters";
+import {
+    mockedApprove,
+    mockedHandleFlowUpdatedRPCCalls,
+} from "../../mockedFunctions";
 
 const initialFlowRate = BigInt.fromI32(100);
 
@@ -186,5 +196,124 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
         assert.fieldEquals("FlowOperatorUpdatedEvent", id, "flowOperator", flowOperatorId);
         assert.fieldEquals("FlowOperatorUpdatedEvent", id, "permissions", permissions.toString());
         assert.fieldEquals("FlowOperatorUpdatedEvent", id, "flowRateAllowance", flowRateAllowance.toString());
+    });
+
+    test("handleFlowUpdated() - Should set receiverIsSuperApp=true when receiver Account is a SuperApp", () => {
+        const sender = alice;
+        const receiver = bob;
+        const flowRate = BigInt.fromI32(100);
+
+        // Pre-seed both Accounts so getOrInitAccount returns cached values without host-RPC.
+        const senderAccount = new Account(sender);
+        senderAccount.createdAtTimestamp = BIG_INT_ZERO;
+        senderAccount.createdAtBlockNumber = BIG_INT_ZERO;
+        senderAccount.updatedAtTimestamp = BIG_INT_ZERO;
+        senderAccount.updatedAtBlockNumber = BIG_INT_ZERO;
+        senderAccount.isSuperApp = false;
+        senderAccount.save();
+
+        const receiverAccount = new Account(receiver);
+        receiverAccount.createdAtTimestamp = BIG_INT_ZERO;
+        receiverAccount.createdAtBlockNumber = BIG_INT_ZERO;
+        receiverAccount.updatedAtTimestamp = BIG_INT_ZERO;
+        receiverAccount.updatedAtBlockNumber = BIG_INT_ZERO;
+        receiverAccount.isSuperApp = true;
+        receiverAccount.save();
+
+        const flowUpdatedEvent = createFlowUpdatedEvent(
+            maticXAddress,
+            sender,
+            receiver,
+            flowRate,
+            flowRate.neg(),
+            flowRate,
+            stringToBytes("")
+        );
+
+        // Pre-seed Token so tokenHasValidHost() returns true without host-RPC.
+        createSuperToken(
+            Address.fromString(maticXAddress),
+            flowUpdatedEvent.block,
+            DEFAULT_DECIMALS,
+            maticXName,
+            maticXSymbol,
+            false,
+            ZERO_ADDRESS
+        );
+
+        mockedHandleFlowUpdatedRPCCalls(
+            flowUpdatedEvent,
+            maticXAddress,
+            DEFAULT_DECIMALS,
+            maticXName,
+            maticXSymbol,
+            ZERO_ADDRESS,
+            getDeposit(flowRate),
+            BIG_INT_ZERO
+        );
+
+        handleFlowUpdated(flowUpdatedEvent);
+
+        const eventId = createEventID("FlowUpdated", flowUpdatedEvent);
+        assert.fieldEquals("FlowUpdatedEvent", eventId, "receiverIsSuperApp", "true");
+    });
+
+    test("handleFlowUpdated() - Should set receiverIsSuperApp=false when receiver is not a SuperApp", () => {
+        const sender = alice;
+        const receiver = bob;
+        const flowRate = BigInt.fromI32(100);
+
+        // Pre-seed non-SuperApp Accounts for both.
+        const senderAccount = new Account(sender);
+        senderAccount.createdAtTimestamp = BIG_INT_ZERO;
+        senderAccount.createdAtBlockNumber = BIG_INT_ZERO;
+        senderAccount.updatedAtTimestamp = BIG_INT_ZERO;
+        senderAccount.updatedAtBlockNumber = BIG_INT_ZERO;
+        senderAccount.isSuperApp = false;
+        senderAccount.save();
+
+        const receiverAccount = new Account(receiver);
+        receiverAccount.createdAtTimestamp = BIG_INT_ZERO;
+        receiverAccount.createdAtBlockNumber = BIG_INT_ZERO;
+        receiverAccount.updatedAtTimestamp = BIG_INT_ZERO;
+        receiverAccount.updatedAtBlockNumber = BIG_INT_ZERO;
+        receiverAccount.isSuperApp = false;
+        receiverAccount.save();
+
+        const flowUpdatedEvent = createFlowUpdatedEvent(
+            maticXAddress,
+            sender,
+            receiver,
+            flowRate,
+            flowRate.neg(),
+            flowRate,
+            stringToBytes("")
+        );
+
+        createSuperToken(
+            Address.fromString(maticXAddress),
+            flowUpdatedEvent.block,
+            DEFAULT_DECIMALS,
+            maticXName,
+            maticXSymbol,
+            false,
+            ZERO_ADDRESS
+        );
+
+        mockedHandleFlowUpdatedRPCCalls(
+            flowUpdatedEvent,
+            maticXAddress,
+            DEFAULT_DECIMALS,
+            maticXName,
+            maticXSymbol,
+            ZERO_ADDRESS,
+            getDeposit(flowRate),
+            BIG_INT_ZERO
+        );
+
+        handleFlowUpdated(flowUpdatedEvent);
+
+        const eventId = createEventID("FlowUpdated", flowUpdatedEvent);
+        assert.fieldEquals("FlowUpdatedEvent", eventId, "receiverIsSuperApp", "false");
     });
 });

--- a/packages/subgraph/tests/cfav1/event/cfav1.event.test.ts
+++ b/packages/subgraph/tests/cfav1/event/cfav1.event.test.ts
@@ -6,11 +6,9 @@ import {
     describe,
     test,
 } from "matchstick-as/assembly/index";
-import { Account } from "../../../generated/schema";
-import { handleFlowOperatorUpdated, handleFlowUpdated } from "../../../src/mappings/cfav1";
+import { handleFlowOperatorUpdated } from "../../../src/mappings/cfav1";
 import {
     BIG_INT_ZERO,
-    createEventID,
     getFlowOperatorID,
     ZERO_ADDRESS,
 } from "../../../src/utils";
@@ -18,23 +16,15 @@ import { assertEventBaseProperties } from "../../assertionHelpers";
 import {
     alice,
     bob,
-    DEFAULT_DECIMALS,
     maticXAddress,
     maticXName,
     maticXSymbol,
 } from "../../constants";
 import {
     createFlowOperatorUpdatedEvent,
-    createFlowUpdatedEvent,
-    getDeposit,
     modifyFlowAndAssertFlowUpdatedEventProperties,
 } from "../cfav1.helper";
-import { createSuperToken } from "../../mockedEntities";
-import { stringToBytes } from "../../converters";
-import {
-    mockedApprove,
-    mockedHandleFlowUpdatedRPCCalls,
-} from "../../mockedFunctions";
+import { mockedApprove } from "../../mockedFunctions";
 
 const initialFlowRate = BigInt.fromI32(100);
 
@@ -213,124 +203,5 @@ describe("ConstantFlowAgreementV1 Event Entity Unit Tests", () => {
         assert.fieldEquals("FlowOperatorUpdatedEvent", id, "flowOperator", flowOperatorId);
         assert.fieldEquals("FlowOperatorUpdatedEvent", id, "permissions", permissions.toString());
         assert.fieldEquals("FlowOperatorUpdatedEvent", id, "flowRateAllowance", flowRateAllowance.toString());
-    });
-
-    test("handleFlowUpdated() - Should set receiverIsSuperApp=true when receiver Account is a SuperApp", () => {
-        const sender = alice;
-        const receiver = bob;
-        const flowRate = BigInt.fromI32(100);
-
-        // Pre-seed both Accounts so getOrInitAccount returns cached values without host-RPC.
-        const senderAccount = new Account(sender);
-        senderAccount.createdAtTimestamp = BIG_INT_ZERO;
-        senderAccount.createdAtBlockNumber = BIG_INT_ZERO;
-        senderAccount.updatedAtTimestamp = BIG_INT_ZERO;
-        senderAccount.updatedAtBlockNumber = BIG_INT_ZERO;
-        senderAccount.isSuperApp = false;
-        senderAccount.save();
-
-        const receiverAccount = new Account(receiver);
-        receiverAccount.createdAtTimestamp = BIG_INT_ZERO;
-        receiverAccount.createdAtBlockNumber = BIG_INT_ZERO;
-        receiverAccount.updatedAtTimestamp = BIG_INT_ZERO;
-        receiverAccount.updatedAtBlockNumber = BIG_INT_ZERO;
-        receiverAccount.isSuperApp = true;
-        receiverAccount.save();
-
-        const flowUpdatedEvent = createFlowUpdatedEvent(
-            maticXAddress,
-            sender,
-            receiver,
-            flowRate,
-            flowRate.neg(),
-            flowRate,
-            stringToBytes("")
-        );
-
-        // Pre-seed Token so tokenHasValidHost() returns true without host-RPC.
-        createSuperToken(
-            Address.fromString(maticXAddress),
-            flowUpdatedEvent.block,
-            DEFAULT_DECIMALS,
-            maticXName,
-            maticXSymbol,
-            false,
-            ZERO_ADDRESS
-        );
-
-        mockedHandleFlowUpdatedRPCCalls(
-            flowUpdatedEvent,
-            maticXAddress,
-            DEFAULT_DECIMALS,
-            maticXName,
-            maticXSymbol,
-            ZERO_ADDRESS,
-            getDeposit(flowRate),
-            BIG_INT_ZERO
-        );
-
-        handleFlowUpdated(flowUpdatedEvent);
-
-        const eventId = createEventID("FlowUpdated", flowUpdatedEvent);
-        assert.fieldEquals("FlowUpdatedEvent", eventId, "receiverIsSuperApp", "true");
-    });
-
-    test("handleFlowUpdated() - Should set receiverIsSuperApp=false when receiver is not a SuperApp", () => {
-        const sender = alice;
-        const receiver = bob;
-        const flowRate = BigInt.fromI32(100);
-
-        // Pre-seed non-SuperApp Accounts for both.
-        const senderAccount = new Account(sender);
-        senderAccount.createdAtTimestamp = BIG_INT_ZERO;
-        senderAccount.createdAtBlockNumber = BIG_INT_ZERO;
-        senderAccount.updatedAtTimestamp = BIG_INT_ZERO;
-        senderAccount.updatedAtBlockNumber = BIG_INT_ZERO;
-        senderAccount.isSuperApp = false;
-        senderAccount.save();
-
-        const receiverAccount = new Account(receiver);
-        receiverAccount.createdAtTimestamp = BIG_INT_ZERO;
-        receiverAccount.createdAtBlockNumber = BIG_INT_ZERO;
-        receiverAccount.updatedAtTimestamp = BIG_INT_ZERO;
-        receiverAccount.updatedAtBlockNumber = BIG_INT_ZERO;
-        receiverAccount.isSuperApp = false;
-        receiverAccount.save();
-
-        const flowUpdatedEvent = createFlowUpdatedEvent(
-            maticXAddress,
-            sender,
-            receiver,
-            flowRate,
-            flowRate.neg(),
-            flowRate,
-            stringToBytes("")
-        );
-
-        createSuperToken(
-            Address.fromString(maticXAddress),
-            flowUpdatedEvent.block,
-            DEFAULT_DECIMALS,
-            maticXName,
-            maticXSymbol,
-            false,
-            ZERO_ADDRESS
-        );
-
-        mockedHandleFlowUpdatedRPCCalls(
-            flowUpdatedEvent,
-            maticXAddress,
-            DEFAULT_DECIMALS,
-            maticXName,
-            maticXSymbol,
-            ZERO_ADDRESS,
-            getDeposit(flowRate),
-            BIG_INT_ZERO
-        );
-
-        handleFlowUpdated(flowUpdatedEvent);
-
-        const eventId = createEventID("FlowUpdated", flowUpdatedEvent);
-        assert.fieldEquals("FlowUpdatedEvent", eventId, "receiverIsSuperApp", "false");
     });
 });

--- a/packages/subgraph/tests/mockedEntities.ts
+++ b/packages/subgraph/tests/mockedEntities.ts
@@ -91,6 +91,7 @@ export function createStream(
     stream.updatedAtBlockNumber = blockNumber;
     stream.currentFlowRate = currentFlowRate;
     stream.deposit = deposit;
+    stream.owedDeposit = BigInt.fromI32(0);
     stream.streamedUntilUpdatedAt = streamedUntilUpdatedAt;
     stream.token = tokenAddress.toHex();
     stream.sender = senderAddress.toHex();

--- a/packages/subgraph/tests/superToken/event/superToken.event.test.ts
+++ b/packages/subgraph/tests/superToken/event/superToken.event.test.ts
@@ -17,11 +17,13 @@ import {
     handleTokenUpgraded,
     handleTransfer,
 } from "../../../src/mappings/superToken";
+import { TransferEvent } from "../../../generated/schema";
+import { _createAccountTokenSnapshotLogEntity } from "../../../src/mappingHelpers";
 import { BIG_INT_ONE, BIG_INT_ZERO, encode, ZERO_ADDRESS } from "../../../src/utils";
 import { assertEmptyTokenStatisticProperties, assertEventBaseProperties, assertTokenStatisticProperties } from "../../assertionHelpers";
 import { alice, bob, cfaV1Address, charlie, DEFAULT_DECIMALS, delta, FAKE_INITIAL_BALANCE, FALSE, maticXName, maticXSymbol, TRUE } from "../../constants";
 import { getETHAddress, getETHUnsignedBigInt, stringToBytes } from "../../converters";
-import { createStream, createStreamRevision } from "../../mockedEntities";
+import { createStream, createStreamRevision, createSuperToken } from "../../mockedEntities";
 import { mockedGetAppManifest, mockedGetHost, mockedHandleSuperTokenInitRPCCalls, mockedRealtimeBalanceOf } from "../../mockedFunctions";
 import {
     createAgreementLiquidatedByEvent,
@@ -413,7 +415,83 @@ describe("SuperToken Mapper Unit Tests", () => {
             );
         });
 
-        test("handleSent() - Should create a new SentEvent entity", () => {
+        test("handleSent() - Should stamp operator onto paired TransferEvent (transferFrom path)", () => {
+            const operator = charlie; // spender, != from
+            const from = alice;
+            const to = bob;
+            const amount = BigInt.fromI32(100);
+            const data = stringToBytes("");
+            const operatorData = stringToBytes("");
+
+            // Emission order in SuperToken._move: Sent first, then Transfer.
+            // So the paired TransferEvent has logIndex == sent.logIndex + 1.
+            const sentEvent = createSentEvent(
+                operator,
+                from,
+                to,
+                amount,
+                data,
+                operatorData
+            );
+            sentEvent.logIndex = BigInt.fromI32(0);
+
+            // Pre-create the paired TransferEvent directly (bypassing handleTransfer,
+            // which has heavier RPC-mock requirements covered in existing tests).
+            const transferEventId =
+                "Transfer-" +
+                sentEvent.transaction.hash.toHexString() +
+                "-1";
+            const transferEventEntity = new TransferEvent(transferEventId);
+            transferEventEntity.blockNumber = sentEvent.block.number;
+            transferEventEntity.logIndex = BigInt.fromI32(1);
+            transferEventEntity.order = BigInt.fromI32(0);
+            transferEventEntity.timestamp = sentEvent.block.timestamp;
+            transferEventEntity.name = "Transfer";
+            transferEventEntity.transactionHash = sentEvent.transaction.hash;
+            transferEventEntity.gasPrice = sentEvent.transaction.gasPrice;
+            transferEventEntity.addresses = [
+                sentEvent.address,
+                Address.fromString(from),
+                Address.fromString(to),
+            ];
+            transferEventEntity.from = from;
+            transferEventEntity.to = to;
+            transferEventEntity.value = amount;
+            transferEventEntity.token = sentEvent.address;
+            transferEventEntity.save();
+
+            // Pre-seed Token so tokenHasValidHost() returns true without RPC.
+            createSuperToken(
+                sentEvent.address,
+                sentEvent.block,
+                DEFAULT_DECIMALS,
+                maticXName,
+                maticXSymbol,
+                false,
+                ZERO_ADDRESS
+            );
+
+            handleSent(sentEvent);
+
+            assert.fieldEquals("TransferEvent", transferEventId, "operator", operator);
+            // operator appended to addresses array
+            assert.fieldEquals(
+                "TransferEvent",
+                transferEventId,
+                "addresses",
+                "[" +
+                    sentEvent.address.toHexString() +
+                    ", " +
+                    Address.fromString(from).toHexString() +
+                    ", " +
+                    Address.fromString(to).toHexString() +
+                    ", " +
+                    Address.fromString(operator).toHexString() +
+                    "]"
+            );
+        });
+
+        test("handleSent() - Should no-op when no paired TransferEvent exists (mint/burn path)", () => {
             const operator = alice;
             const from = alice;
             const to = bob;
@@ -430,20 +508,23 @@ describe("SuperToken Mapper Unit Tests", () => {
                 operatorData
             );
 
-            mockedGetHost(sentEvent.address.toHex());
+            // Pre-seed Token so tokenHasValidHost() returns true without RPC.
+            createSuperToken(
+                sentEvent.address,
+                sentEvent.block,
+                DEFAULT_DECIMALS,
+                maticXName,
+                maticXSymbol,
+                false,
+                ZERO_ADDRESS
+            );
 
+            // No TransferEvent was pre-seeded — handleSent must not crash
+            // and must not materialize any entity.
             handleSent(sentEvent);
 
-            const id = assertEventBaseProperties(
-                sentEvent,
-                "Sent"
-            );
-            assert.fieldEquals("SentEvent", id, "operator", operator);
-            assert.fieldEquals("SentEvent", id, "from", from);
-            assert.fieldEquals("SentEvent", id, "to", to);
-            assert.fieldEquals("SentEvent", id, "amount", amount.toString());
-            assert.fieldEquals("SentEvent", id, "data", data.toHexString());
-            assert.fieldEquals("SentEvent", id, "operatorData", operatorData.toHexString());
+            assert.entityCount("TransferEvent", 0);
+            assert.entityCount("SentEvent", 0);
         });
 
         test("handleBurned() - Should create a new BurnedEvent entity", () => {
@@ -695,6 +776,30 @@ describe("SuperToken Mapper Unit Tests", () => {
                 mintedEvent.block.number,
                 amount // totalSupply = 100
             );
+        });
+
+        test("_createAccountTokenSnapshotLogEntity() - Should be a no-op (ATSLog indexing deprecated)", () => {
+            const from = alice;
+            const to = bob;
+            const amount = BigInt.fromI32(100);
+
+            const burnedEvent = createBurnedEvent(
+                from,
+                to,
+                amount,
+                stringToBytes(""),
+                stringToBytes("")
+            );
+
+            _createAccountTokenSnapshotLogEntity(
+                burnedEvent,
+                Address.fromString(to),
+                burnedEvent.address,
+                "Burned"
+            );
+
+            // Helper is a no-op: no AccountTokenSnapshotLog rows are written.
+            assert.entityCount("AccountTokenSnapshotLog", 0);
         });
     });
 });

--- a/packages/subgraph/tests/superToken/event/superToken.event.test.ts
+++ b/packages/subgraph/tests/superToken/event/superToken.event.test.ts
@@ -415,7 +415,7 @@ describe("SuperToken Mapper Unit Tests", () => {
             );
         });
 
-        test("handleSent() - Should stamp operator onto paired TransferEvent (transferFrom path)", () => {
+        test("handleSent() + handleTransfer() - Should stamp spender on paired TransferEvent when operator != from", () => {
             const operator = charlie; // spender, != from
             const from = alice;
             const to = bob;
@@ -423,8 +423,10 @@ describe("SuperToken Mapper Unit Tests", () => {
             const data = stringToBytes("");
             const operatorData = stringToBytes("");
 
-            // Emission order in SuperToken._move: Sent first, then Transfer.
-            // So the paired TransferEvent has logIndex == sent.logIndex + 1.
+            // Emission order in SuperToken._move: Sent first (logIndex N), then
+            // Transfer (logIndex N+1). graph-node runs handlers in log order.
+            // matchstick's newMockEvent() uses identical defaults for tx.hash and
+            // block across calls, so the two events naturally share them.
             const sentEvent = createSentEvent(
                 operator,
                 from,
@@ -435,32 +437,9 @@ describe("SuperToken Mapper Unit Tests", () => {
             );
             sentEvent.logIndex = BigInt.fromI32(0);
 
-            // Pre-create the paired TransferEvent directly (bypassing handleTransfer,
-            // which has heavier RPC-mock requirements covered in existing tests).
-            const transferEventId =
-                "Transfer-" +
-                sentEvent.transaction.hash.toHexString() +
-                "-1";
-            const transferEventEntity = new TransferEvent(transferEventId);
-            transferEventEntity.blockNumber = sentEvent.block.number;
-            transferEventEntity.logIndex = BigInt.fromI32(1);
-            transferEventEntity.order = BigInt.fromI32(0);
-            transferEventEntity.timestamp = sentEvent.block.timestamp;
-            transferEventEntity.name = "Transfer";
-            transferEventEntity.transactionHash = sentEvent.transaction.hash;
-            transferEventEntity.gasPrice = sentEvent.transaction.gasPrice;
-            transferEventEntity.addresses = [
-                sentEvent.address,
-                Address.fromString(from),
-                Address.fromString(to),
-            ];
-            transferEventEntity.from = from;
-            transferEventEntity.to = to;
-            transferEventEntity.value = amount;
-            transferEventEntity.token = sentEvent.address;
-            transferEventEntity.save();
+            const transferEvent = createTransferEvent(from, to, amount);
+            transferEvent.logIndex = BigInt.fromI32(1);
 
-            // Pre-seed Token so tokenHasValidHost() returns true without RPC.
             createSuperToken(
                 sentEvent.address,
                 sentEvent.block,
@@ -472,15 +451,19 @@ describe("SuperToken Mapper Unit Tests", () => {
             );
 
             handleSent(sentEvent);
+            handleTransfer(transferEvent);
 
-            assert.fieldEquals("TransferEvent", transferEventId, "operator", operator);
-            // operator appended to addresses array
+            const transferEventId =
+                "Transfer-" +
+                transferEvent.transaction.hash.toHexString() +
+                "-1";
+            assert.fieldEquals("TransferEvent", transferEventId, "spender", operator);
             assert.fieldEquals(
                 "TransferEvent",
                 transferEventId,
                 "addresses",
                 "[" +
-                    sentEvent.address.toHexString() +
+                    transferEvent.address.toHexString() +
                     ", " +
                     Address.fromString(from).toHexString() +
                     ", " +
@@ -489,10 +472,11 @@ describe("SuperToken Mapper Unit Tests", () => {
                     Address.fromString(operator).toHexString() +
                     "]"
             );
+            assert.entityCount("TransferEvent", 1);
         });
 
-        test("handleSent() - Should no-op when no paired TransferEvent exists (mint/burn path)", () => {
-            const operator = alice;
+        test("handleSent() + handleTransfer() - Should leave spender null on self-transfer (operator == from)", () => {
+            const operator = alice; // == from
             const from = alice;
             const to = bob;
             const amount = BigInt.fromI32(100);
@@ -507,8 +491,11 @@ describe("SuperToken Mapper Unit Tests", () => {
                 data,
                 operatorData
             );
+            sentEvent.logIndex = BigInt.fromI32(0);
 
-            // Pre-seed Token so tokenHasValidHost() returns true without RPC.
+            const transferEvent = createTransferEvent(from, to, amount);
+            transferEvent.logIndex = BigInt.fromI32(1);
+
             createSuperToken(
                 sentEvent.address,
                 sentEvent.block,
@@ -519,12 +506,63 @@ describe("SuperToken Mapper Unit Tests", () => {
                 ZERO_ADDRESS
             );
 
-            // No TransferEvent was pre-seeded — handleSent must not crash
-            // and must not materialize any entity.
             handleSent(sentEvent);
+            handleTransfer(transferEvent);
 
-            assert.entityCount("TransferEvent", 0);
-            assert.entityCount("SentEvent", 0);
+            const transferEventId =
+                "Transfer-" +
+                transferEvent.transaction.hash.toHexString() +
+                "-1";
+            // No `spender` set: addresses[] is length 3, no _SentSpenderCache row was written.
+            assert.fieldEquals(
+                "TransferEvent",
+                transferEventId,
+                "addresses",
+                "[" +
+                    transferEvent.address.toHexString() +
+                    ", " +
+                    Address.fromString(from).toHexString() +
+                    ", " +
+                    Address.fromString(to).toHexString() +
+                    "]"
+            );
+            assert.entityCount("TransferEvent", 1);
+        });
+
+        test("handleTransfer() alone - Should leave spender null when no paired Sent (mint/burn/upgrade/downgrade path)", () => {
+            const from = alice;
+            const to = bob;
+            const value = BigInt.fromI32(100);
+
+            const transferEvent = createTransferEvent(from, to, value);
+
+            createSuperToken(
+                transferEvent.address,
+                transferEvent.block,
+                DEFAULT_DECIMALS,
+                maticXName,
+                maticXSymbol,
+                false,
+                ZERO_ADDRESS
+            );
+
+            handleTransfer(transferEvent);
+
+            const transferEventId = assertEventBaseProperties(transferEvent, "Transfer");
+            // No `spender` set: addresses[] is length 3, no cache row exists.
+            assert.fieldEquals(
+                "TransferEvent",
+                transferEventId,
+                "addresses",
+                "[" +
+                    transferEvent.address.toHexString() +
+                    ", " +
+                    Address.fromString(from).toHexString() +
+                    ", " +
+                    Address.fromString(to).toHexString() +
+                    "]"
+            );
+            assert.entityCount("TransferEvent", 1);
         });
 
         test("handleBurned() - Should create a new BurnedEvent entity", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13182,7 +13182,12 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@4.17.23, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.2.1, lodash@~4.17.0:
+lodash@4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.2.1, lodash@~4.17.0:
   version "4.17.23"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
   integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==


### PR DESCRIPTION
## Summary
- add `TransferEvent.operator`, sourced from the paired ERC-777 `Sent` event, and re-enable `Sent` handling only to enrich the paired `TransferEvent`
- add `Stream.owedDeposit` and `FlowUpdatedEvent.owedDeposit` from the CFA `getFlow` tuple (can be used to detect whether the stream is to a SuperApp)
- stop writing new `AccountTokenSnapshotLog` rows while keeping the schema shape intact and updating tests/validation accordingly
- keep the changelog entry for the `BufferAdjusted` GDA deposit fix that is now present on this branch

## Testing
- `cd packages/subgraph && yarn lint`
- `cd packages/subgraph && yarn matchstick`