### PR TITLE
[ETHEREUM-CONTRACTS] Release 1.15.1

### DIFF
--- a/packages/automation-contracts/autowrap/package.json
+++ b/packages/automation-contracts/autowrap/package.json
@@ -3,7 +3,7 @@
     "description": "Open contracts that allow upgrading underlying token to supertokens based on running stream",
     "version": "0.3.0",
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "^1.15.0",
+        "@superfluid-finance/ethereum-contracts": "^1.15.1",
         "@superfluid-finance/metadata": "^1.6.3"
     },
     "license": "MIT",

--- a/packages/automation-contracts/scheduler/package.json
+++ b/packages/automation-contracts/scheduler/package.json
@@ -3,7 +3,7 @@
     "description": "Open contracts that allow scheduling streams and vestings onchain",
     "version": "1.3.0",
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "^1.15.0",
+        "@superfluid-finance/ethereum-contracts": "^1.15.1",
         "@superfluid-finance/metadata": "^1.6.3"
     },
     "license": "MIT",

--- a/packages/ethereum-contracts/CHANGELOG.md
+++ b/packages/ethereum-contracts/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to the ethereum-contracts will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [v1.15.1]
 
 ### Added
 

--- a/packages/ethereum-contracts/package.json
+++ b/packages/ethereum-contracts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@superfluid-finance/ethereum-contracts",
     "description": " Ethereum contracts implementation for the Superfluid Protocol",
-    "version": "1.15.0",
+    "version": "1.15.1",
     "dependencies": {
         "@decentral.ee/web3-helpers": "0.5.3",
         "@nomiclabs/hardhat-ethers": "2.2.3",

--- a/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/AaveETHYieldBackend.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/AaveETHYieldBackend.t.sol
@@ -13,15 +13,14 @@ import { IPool } from "aave-v3/src/contracts/interfaces/IPool.sol";
  */
 contract AaveETHYieldBackendUnitTest is YieldBackendUnitTestBase {
     uint256 internal constant CHAIN_ID = 8453;
-    string internal constant RPC_URL = "https://mainnet.base.org";
 
     address internal constant AAVE_POOL = 0xA238Dd80C259a72e81d7e4664a9801593F98d1c5;
     address internal constant WETH = 0x4200000000000000000000000000000000000006;
 
     AaveETHYieldBackend internal aaveETHBackend;
 
-    function getRpcUrl() internal pure override returns (string memory) {
-        return RPC_URL;
+    function getRpcUrl() internal view override returns (string memory) {
+        return vm.envOr("BASE_MAINNET_ARCHIVE_RPC_URL", string("https://mainnet.base.org"));
     }
 
     function getChainId() internal pure override returns (uint256) {

--- a/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/AaveYieldBackend.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/AaveYieldBackend.t.sol
@@ -13,15 +13,14 @@ import { IPool } from "aave-v3/src/contracts/interfaces/IPool.sol";
  */
 contract AaveYieldBackendUnitTest is YieldBackendUnitTestBase {
     uint256 internal constant CHAIN_ID = 8453;
-    string internal constant RPC_URL = "https://mainnet.base.org";
 
     address internal constant AAVE_POOL = 0xA238Dd80C259a72e81d7e4664a9801593F98d1c5;
     address internal constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
 
     AaveYieldBackend internal aaveBackend;
 
-    function getRpcUrl() internal pure override returns (string memory) {
-        return RPC_URL;
+    function getRpcUrl() internal view override returns (string memory) {
+        return vm.envOr("BASE_MAINNET_ARCHIVE_RPC_URL", string("https://mainnet.base.org"));
     }
 
     function getChainId() internal pure override returns (uint256) {

--- a/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/ERC4626YieldBackend.t.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/ERC4626YieldBackend.t.sol
@@ -13,13 +13,12 @@ import { IERC4626 } from "@openzeppelin-v5/contracts/interfaces/IERC4626.sol";
  */
 contract ERC4626YieldBackendUnitTestEthereumSUSDS is YieldBackendUnitTestBase {
     uint256 internal constant CHAIN_ID = 1;
-    string internal constant RPC_URL = "https://eth.drpc.org";
     address internal constant VAULT = 0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD; // sUSDS on Ethereum
 
     ERC4626YieldBackend internal erc4626Backend;
 
-    function getRpcUrl() internal pure override returns (string memory) {
-        return RPC_URL;
+    function getRpcUrl() internal view override returns (string memory) {
+        return vm.envOr("ETH_MAINNET_ARCHIVE_RPC_URL", string("https://eth.drpc.org"));
     }
 
     function getChainId() internal pure override returns (uint256) {
@@ -61,13 +60,12 @@ contract ERC4626YieldBackendUnitTestEthereumSUSDS is YieldBackendUnitTestBase {
  */
 contract ERC4626YieldBackendUnitTestBaseSUSDC is YieldBackendUnitTestBase {
     uint256 internal constant CHAIN_ID = 8453;
-    string internal constant RPC_URL = "https://mainnet.base.org";
     address internal constant VAULT = 0x3128a0F7f0ea68E7B7c9B00AFa7E41045828e858; // sUSDC Vault on Base
 
     ERC4626YieldBackend internal erc4626Backend;
 
-    function getRpcUrl() internal pure override returns (string memory) {
-        return RPC_URL;
+    function getRpcUrl() internal view override returns (string memory) {
+        return vm.envOr("BASE_MAINNET_ARCHIVE_RPC_URL", string("https://mainnet.base.org"));
     }
 
     function getChainId() internal pure override returns (uint256) {

--- a/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/YieldBackendUnitTestBase.sol
+++ b/packages/ethereum-contracts/test/foundry/superfluid/yieldbackend/YieldBackendUnitTestBase.sol
@@ -23,7 +23,7 @@ abstract contract YieldBackendUnitTestBase is Test {
     // ============ Abstract functions for network configuration ============
 
     /// @notice Get the RPC URL for forking
-    function getRpcUrl() internal pure virtual returns (string memory);
+    function getRpcUrl() internal view virtual returns (string memory);
 
     /// @notice Get the expected chain ID
     function getChainId() internal pure virtual returns (uint256);

--- a/packages/hot-fuzz/package.json
+++ b/packages/hot-fuzz/package.json
@@ -7,13 +7,13 @@
     },
     "bugs": "https://github.com/superfluid-org/protocol-monorepo/issues",
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "^1.15.0"
+        "@superfluid-finance/ethereum-contracts": "^1.15.1"
     },
     "homepage": "https://github.com/superfluid-org/protocol-monorepo#readme",
     "license": "AGPL-3.0",
     "main": "index.js",
     "peerDependencies": {
-        "@superfluid-finance/ethereum-contracts": "1.15.0"
+        "@superfluid-finance/ethereum-contracts": "1.15.1"
     },
     "repository": {
         "type": "git",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -13,7 +13,7 @@
         "node-fetch": "2.7.0"
     },
     "devDependencies": {
-        "@superfluid-finance/ethereum-contracts": "^1.15.0",
+        "@superfluid-finance/ethereum-contracts": "^1.15.1",
         "chai-as-promised": "^8.0.2",
         "webpack": "^5.104.1",
         "webpack-bundle-analyzer": "^4.10.2",

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -4,7 +4,7 @@
     "version": "0.9.0",
     "bugs": "https://github.com/superfluid-org/protocol-monorepo/issues",
     "dependencies": {
-        "@superfluid-finance/ethereum-contracts": "1.15.0",
+        "@superfluid-finance/ethereum-contracts": "1.15.1",
         "@superfluid-finance/metadata": "^1.6.3",
         "graphql-request": "6.1.0",
         "lodash": "4.18.1",

--- a/packages/subgraph/tasks/setup-graph-node.sh
+++ b/packages/subgraph/tasks/setup-graph-node.sh
@@ -25,5 +25,14 @@ DOCKER_HOST_IP=$(docker network inspect subgraph_default | jq -r '.[0].IPAM.Conf
 # docker compose with required variables
 DOCKER_HOST_IP=$DOCKER_HOST_IP docker compose up --detach
 
-# extra sleep to let things setup
-sleep 5
+# Wait for admin JSON-RPC (same URL as package.json create-local)
+GRAPH_NODE_URL="${GRAPH_NODE_URL:-http://localhost:8020/}"
+for _ in $(seq 1 30); do
+    if curl -s --connect-timeout 2 -o /dev/null "$GRAPH_NODE_URL"; then
+        echo "Graph node ready at $GRAPH_NODE_URL"
+        exit 0
+    fi
+    sleep 2
+done
+echo "Graph node did not become ready at $GRAPH_NODE_URL" >&2
+exit 1


### PR DESCRIPTION
see changelog

Also addressed flaky CI:
- poll-based waiting for subgraph node instead of fixed sleep interval
- use configurable (non-public) archive RPC for all fork tests