### PR TITLE
[METADATA] metadata release is manual

### DIFF
--- a/.github/workflows/cd.packages-stable.create-release-drafts.yml
+++ b/.github/workflows/cd.packages-stable.create-release-drafts.yml
@@ -87,14 +87,13 @@ jobs:
           body_path: .github/RELEASE_TEMPLATE/release-notes.md
           draft: true
 
-  create-and-publish-metadata-package:
-    name: Create Metadata Release Draft and Publish to NPM
+  create-metadata-release-draft:
+    name: Create Metadata Release Draft
 
     runs-on: ubuntu-22.04
 
     permissions:
       contents: write
-      id-token: write
 
 
     steps:
@@ -119,14 +118,7 @@ jobs:
           name: metadata@v${{ env.METADATA_NEW_VERSION }}
           body: |
             Please refer to the CHANGELOG.md file in metadata package for more details on the changeset.
-          draft: false
-      - name: Publish metadata package
-        if: env.SHOULD_PUBLISH_METADATA == 1
-        run: |
-          yarn --cwd packages/metadata build
-          tasks/npm-publish.sh packages/metadata/ latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
 
   check-sdk-core-version:
     name: Checking if SDK-Core should be published

--- a/.github/workflows/handler.publish-dev-release-packages.yml
+++ b/.github/workflows/handler.publish-dev-release-packages.yml
@@ -366,6 +366,9 @@ jobs:
           if echo -n "$GITHUB_REF" | grep -qE "refs/tags/sdk-redux@";then
             echo "PUBLISH_SDK_REDUX=1" >> "$GITHUB_ENV"
           fi
+          if echo -n "$GITHUB_REF" | grep -qE "refs/tags/metadata@";then
+            echo "PUBLISH_METADATA=1" >> "$GITHUB_ENV"
+          fi
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -485,3 +488,18 @@ jobs:
           aws_secret_access_key: ${{ secrets.SITE_DEPLOYER_AWS_SECRET_ACCESS_KEY }}
           s3_uri: ${{ format('{0}sdk-redux', secrets.SITE_DEPLOYER_AWS_S3_DOCS_URI) }}
           cloudfront_distribution_id: E3JEO5R14CT8IH
+
+      - name: Build metadata package
+        if: env.PUBLISH_METADATA == 1
+        run: |
+          yarn --cwd packages/metadata build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish metadata package
+        if: env.PUBLISH_METADATA == 1
+        shell: bash
+        run: |
+          tasks/npm-publish.sh packages/metadata/ latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/handler.publish-dev-release-packages.yml
+++ b/.github/workflows/handler.publish-dev-release-packages.yml
@@ -493,13 +493,9 @@ jobs:
         if: env.PUBLISH_METADATA == 1
         run: |
           yarn --cwd packages/metadata build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish metadata package
         if: env.PUBLISH_METADATA == 1
         shell: bash
         run: |
           tasks/npm-publish.sh packages/metadata/ latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
OIDC trusted publishing requires a package (Stable and Dev) to publish from one workflow file only.
-   `cd.packages-stable.create-release-drafts.yml` no longer publishes metadata to npm — it only creates the release draft. 
- Stable/latest publish (`handler.publish-dev-release-packages.yml`) now includes metadata package. 

