### PR TITLE
[WORKFLOW] Codecov@v7.0.0 for lost gpg key

### DIFF
--- a/.github/workflows/call.upload-coverage-reports.yml
+++ b/.github/workflows/call.upload-coverage-reports.yml
@@ -22,7 +22,7 @@ jobs:
           name: ethereum-contracts-coverage
           path: packages/ethereum-contracts/coverage
       - name: Upload ethereum-contracts-coverage to codecov
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/ethereum-contracts/coverage/lcov.info
@@ -36,7 +36,7 @@ jobs:
           name: sdk-core-coverage
           path: packages/sdk-core/coverage
       - name: Upload sdk-core-coverage to codecov
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/sdk-core/coverage/lcov.info


### PR DESCRIPTION
https://github.com/codecov/codecov-action/releases/tag/v7.0.0
```Due to migration issues with keybase, we are unable to update our keys under the codecovsecurity account. We have deleted the account and are using codecovsecops with the original gpg key```