### PR TITLE
[WORKFLOW] No codecov reports for dependabot  forks

### DIFF
--- a/.github/workflows/ci.feature.yml
+++ b/.github/workflows/ci.feature.yml
@@ -138,6 +138,9 @@ jobs:
     name: Upload Coverage Reports (Feature Branch)
     uses: ./.github/workflows/call.upload-coverage-reports.yml
     needs: [coverage-ethereum-contracts, coverage-sdk-core]
+    # Dependabot PRs have no access to repository secrets, also coverage uploads aren't
+    # needed for dependabot checks.
+    if: github.actor != 'dependabot[bot]'
     secrets: inherit
 
   # Note:


### PR DESCRIPTION
Dependabots were stripped of access to secrets because of security risks. Since the changes are strictly related to dependencies and not code change,  these changes disables coverage report for related PRs.
