### PR TITLE
chore: fix typo in BatchLiquidator comment

### DIFF
--- a/packages/ethereum-contracts/contracts/utils/BatchLiquidator.sol
+++ b/packages/ethereum-contracts/contracts/utils/BatchLiquidator.sol
@@ -49,7 +49,7 @@ contract BatchLiquidator {
      */
     function deleteFlows(address superToken, FlowLiquidationData[] memory data) external {
         for (uint256 i; i < data.length;) {
-            // We tolerate any errors occured during liquidations.
+            // We tolerate any errors occurred during liquidations.
             // It could be due to flow had been liquidated by others.
             _deleteFlow(superToken, data[i]);
 


### PR DESCRIPTION
## Summary

Correct `occured` to `occurred` in the BatchLiquidator liquidation error-handling comment.

This is a comment-only change and does not affect contract behavior or bytecode.

